### PR TITLE
Ignore VSCode config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ elm-stuff
 /.psc*
 /.purs*
 /.psa*
+
+# vscode
+.vscode/


### PR DESCRIPTION
Adds VSCode config directory to `.gitignore`.