### PR TITLE
Add JWT Authentication Support

### DIFF
--- a/ereadingtool/settings.py
+++ b/ereadingtool/settings.py
@@ -157,6 +157,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'jwt_auth.middleware.JWTAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'csp.middleware.CSPMiddleware',

--- a/ereadingtool/urls.py
+++ b/ereadingtool/urls.py
@@ -17,6 +17,8 @@ from django.contrib import admin
 from django.urls import path, include, reverse_lazy
 from django.views.generic import RedirectView, TemplateView
 
+from jwt_auth import views as jwt_auth_views
+
 from mixins.view import (ElmLoadJsView, NoAuthElmLoadJsView)
 
 from ereadingtool.views import AcknowledgementView, AboutView
@@ -26,6 +28,9 @@ from user.views.username import username
 urlpatterns = [
     path('load_elm.js', ElmLoadJsView.as_view(), name='load-elm'),
     path('load_elm_unauth.js', NoAuthElmLoadJsView.as_view(), name='load-elm-unauth'),
+
+    path("token-auth/", jwt_auth_views.jwt_token),
+    path("token-refresh/", jwt_auth_views.refresh_jwt_token),
 
     path('acknowledgements/', AcknowledgementView.as_view(), name='acknowledgements'),
     path('about/', AboutView.as_view(), name='about'),

--- a/ereadingtool/urls.py
+++ b/ereadingtool/urls.py
@@ -29,8 +29,8 @@ urlpatterns = [
     path('load_elm.js', ElmLoadJsView.as_view(), name='load-elm'),
     path('load_elm_unauth.js', NoAuthElmLoadJsView.as_view(), name='load-elm-unauth'),
 
-    path("token-auth/", jwt_auth_views.jwt_token),
-    path("token-refresh/", jwt_auth_views.refresh_jwt_token),
+    path("token-auth/", jwt_auth_views.jwt_token, name='jwt-token-auth'),
+    path("token-refresh/", jwt_auth_views.refresh_jwt_token, name='jwt-token-refresh'),
 
     path('acknowledgements/', AcknowledgementView.as_view(), name='acknowledgements'),
     path('about/', AboutView.as_view(), name='about'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django
+Django==2.2
 django-taggit
 ipython
 rjsmin
@@ -18,3 +18,4 @@ pdfkit
 asynctest
 Twisted[tls,http2]
 pytz
+webstack-django-jwt-auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ ipython
 rjsmin
 django-csp
 hypothesis[django]
+faker
 jsonschema
 channels
 python-statemachine

--- a/text/views/api/text_sections.py
+++ b/text/views/api/text_sections.py
@@ -2,9 +2,6 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 from django.views.generic import View
 
-from django.http import JsonResponse
-from jwt_auth.mixins import JSONWebTokenAuthMixin
-
 
 class TextSectionDefinitionAPIView(LoginRequiredMixin, View):
     login_url = reverse_lazy('instructor-login')

--- a/text/views/api/text_sections.py
+++ b/text/views/api/text_sections.py
@@ -2,8 +2,10 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 from django.views.generic import View
 
+from django.http import JsonResponse
+from jwt_auth.mixins import JSONWebTokenAuthMixin
+
 
 class TextSectionDefinitionAPIView(LoginRequiredMixin, View):
     login_url = reverse_lazy('instructor-login')
     allowed_methods = ['get', 'put', 'post', 'delete']
-

--- a/user/test/instructor.py
+++ b/user/test/instructor.py
@@ -6,7 +6,6 @@ from typing import AnyStr, Optional
 
 from django.test import TestCase
 from django.test.client import Client
-from hypothesis.strategies import just
 
 from django.utils import timezone
 
@@ -56,7 +55,7 @@ class TestInstructorUser(TestUserBase, TestCase):
             password='test-p4ssw0rd!'
         )
 
-        admin_instructor = self.new_instructor_with_user(self.instructor_admin_user, admin=just(True))
+        admin_instructor = self.new_instructor_with_user(self.instructor_admin_user, admin=True)
 
         self.assertTrue(admin_instructor.is_admin)
 
@@ -79,7 +78,7 @@ class TestInstructorUser(TestUserBase, TestCase):
         self.assertEquals(resp.status_code, 403)
 
     def test_instructor_invite_can_expire(self):
-        admin_client = self.login(Client(), (self.instructor_admin_user, self.instructor_admin_password))
+        admin_client = self.login(Client(), user=self.instructor_admin_user, password=self.instructor_admin_password)
 
         invitee_email = 'test-invite@test.com'
 
@@ -109,7 +108,7 @@ class TestInstructorUser(TestUserBase, TestCase):
         self.assertIn('invite_code', resp_content)
 
     def test_instructor_invite(self):
-        admin_client = self.login(Client(), (self.instructor_admin_user, self.instructor_admin_password))
+        admin_client = self.login(Client(), user=self.instructor_admin_user, password=self.instructor_admin_password)
 
         invitee_email = 'test-invite@test.com'
 

--- a/user/test/student.py
+++ b/user/test/student.py
@@ -204,12 +204,12 @@ class TestStudentUser(TestData, TestUser, TestCase):
             'difficulty': TextDifficulty.objects.get(pk=1).slug
         }
 
-        student_client = self.test_student_signup(student_signup_params)
+        student_anonymous_client = self.test_student_signup(student_signup_params)
 
-        student_login_resp = student_client.post(self.student_login_api_endpoint,
-                                                 data=json.dumps({'username': student_signup_params['email'],
-                                                                  'password': student_signup_params['password']}),
-                                                 content_type='application/json')
+        student_client = self.login(
+            student_anonymous_client,
+            username=student_signup_params['email'], password=student_signup_params['password']
+        )
 
         # welcome flag should be present on the first loading of the profile page, but not on subsequent loads
         def match_welcome_flag(resp: HttpResponse) -> bool:


### PR DESCRIPTION
JWT Support  
- Adds a JWT auth middleware
- Adds a test for logging in with a username/password and hitting an endpoint with the proper authorization token
- Removes unused imports in text sections
- Adds URI routing for two new auth endpoints:
- /token-auth/
- /token-refresh/

JWT Auth Testing
- Removes some improper use of .example() with hypothesis strategies
- Refactors TestUser login method to use JWT
- Removes TestUserLogin class
- Fixes broken 'welcome message' test that wasn't logging in with the TestUser login