### PR TITLE
Add protected pages

### DIFF
--- a/web/src/Pages/ProtectedApplicationTemplate.elm
+++ b/web/src/Pages/ProtectedApplicationTemplate.elm
@@ -1,0 +1,89 @@
+module Pages.ProtectedApplicationTemplate exposing (Model, Msg, Params, page)
+
+import Html exposing (..)
+import Shared
+import Spa.Document exposing (Document)
+import Spa.Page as Page exposing (Page)
+import Spa.Url as Url exposing (Url)
+
+
+page : Page Params Model Msg
+page =
+    Page.protectedApplication
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        , save = save
+        , load = load
+        }
+
+
+
+-- INIT
+
+
+type alias Params =
+    ()
+
+
+type alias Model =
+    Maybe SafeModel
+
+
+type SafeModel
+    = SafeModel { protectedInfo : String }
+
+
+init : Shared.Model -> Url Params -> ( SafeModel, Cmd Msg )
+init shared { params } =
+    ( SafeModel { protectedInfo = "For authenticated eyes only" }
+    , Cmd.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = ReplaceMe
+
+
+update : Msg -> SafeModel -> ( SafeModel, Cmd Msg )
+update msg (SafeModel model) =
+    -- let
+    --     model =
+    --         unwrap safeModel
+    -- in
+    case msg of
+        ReplaceMe ->
+            ( SafeModel model, Cmd.none )
+
+
+save : SafeModel -> Shared.Model -> Shared.Model
+save model shared =
+    shared
+
+
+load : Shared.Model -> SafeModel -> ( SafeModel, Cmd Msg )
+load shared safeModel =
+    ( safeModel, Cmd.none )
+
+
+subscriptions : SafeModel -> Sub Msg
+subscriptions (SafeModel model) =
+    Sub.none
+
+
+
+-- VIEW
+
+
+view : SafeModel -> Document Msg
+view (SafeModel model) =
+    { title = "ProtectedApplicationTemplate"
+    , body =
+        [ div [] [ text model.protectedInfo ]
+        ]
+    }

--- a/web/src/Pages/ProtectedApplicationTemplate.elm
+++ b/web/src/Pages/ProtectedApplicationTemplate.elm
@@ -32,12 +32,16 @@ type alias Model =
 
 
 type SafeModel
-    = SafeModel { protectedInfo : String }
+    = SafeModel
+        { protectedInfo : String
+        }
 
 
 init : Shared.Model -> Url Params -> ( SafeModel, Cmd Msg )
 init shared { params } =
-    ( SafeModel { protectedInfo = "For authenticated eyes only" }
+    ( SafeModel
+        { protectedInfo = "For authenticated eyes only"
+        }
     , Cmd.none
     )
 
@@ -52,10 +56,6 @@ type Msg
 
 update : Msg -> SafeModel -> ( SafeModel, Cmd Msg )
 update msg (SafeModel model) =
-    -- let
-    --     model =
-    --         unwrap safeModel
-    -- in
     case msg of
         ReplaceMe ->
             ( SafeModel model, Cmd.none )

--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -8,11 +8,13 @@ module Shared exposing
     , view
     )
 
-import Api
+import Api exposing (AuthError, AuthSuccess)
 import Api.Config as Config exposing (Config)
 import Browser.Navigation exposing (Key)
 import Html exposing (..)
 import Html.Attributes exposing (class, href)
+import Html.Events exposing (onClick)
+import Json.Encode as Encode
 import Session exposing (Session)
 import Spa.Document exposing (Document)
 import Spa.Generated.Route as Route
@@ -24,17 +26,18 @@ import Viewer exposing (Viewer)
 -- INIT
 
 
-type alias Flags =
-    { maybeConfig : Maybe Config
-    , maybeViewer : Maybe Viewer
-    }
-
-
 type alias Model =
     { url : Url
     , key : Key
     , session : Session
     , config : Config
+    , authMessage : String
+    }
+
+
+type alias Flags =
+    { maybeConfig : Maybe Config
+    , maybeViewer : Maybe Viewer
     }
 
 
@@ -47,7 +50,7 @@ init flags url key =
         config =
             Config.init flags.maybeConfig
     in
-    ( Model url key session config
+    ( Model url key session config ""
     , Cmd.none
     )
 
@@ -57,12 +60,27 @@ init flags url key =
 
 
 type Msg
-    = GotSession Session
+    = Login
+    | Logout
+    | GotAuthResult (Result AuthError AuthSuccess)
+    | GotSession Session
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
+        Login ->
+            ( model, login )
+
+        Logout ->
+            ( model, logout )
+
+        GotAuthResult (Ok authSuccess) ->
+            ( { model | authMessage = Api.authSuccessMessage authSuccess }, Cmd.none )
+
+        GotAuthResult (Err authError) ->
+            ( { model | authMessage = Api.authErrorMessage authError }, Cmd.none )
+
         GotSession session ->
             let
                 dbg =
@@ -77,7 +95,10 @@ update msg model =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Session.changes GotSession
+    Sub.batch
+        [ Session.changes GotSession
+        , Api.authResult (\authMessage -> GotAuthResult authMessage)
+        ]
 
 
 
@@ -96,11 +117,37 @@ view { page, toMsg } model =
                 [ a [ class "link", href (Route.toString Route.Top) ] [ text "Homepage" ]
                 , a [ class "link", href (Route.toString Route.NotFound) ] [ text "Not found" ]
                 , a [ class "link", href (Route.toString Route.ProtectedApplicationTemplate) ] [ text "Protected" ]
-                , div []
-                    [ text ("Token: " ++ Api.exposeToken (Session.cred model.session)) ]
-                , div [] [ text ("REST API URL: " ++ Config.restApiUrl model.config) ]
                 ]
             , div [ class "page" ] page.body
+            , div []
+                [ div []
+                    [ text ("Token: " ++ Api.exposeToken (Session.cred model.session)) ]
+                , div [] [ text ("REST API URL: " ++ Config.restApiUrl model.config) ]
+                , button [ onClick (toMsg Login) ] [ text "Login" ]
+                , button [ onClick (toMsg Logout) ] [ text "Logout" ]
+                , div [] [ text ("Auth Message: " ++ model.authMessage) ]
+                ]
             ]
         ]
     }
+
+
+
+-- AUTH
+
+
+login : Cmd msg
+login =
+    let
+        creds =
+            Encode.object
+                [ ( "username", Encode.string "test@email.com" )
+                , ( "password", Encode.string "password" )
+                ]
+    in
+    Api.login creds
+
+
+logout : Cmd msg
+logout =
+    Api.logout ()

--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -57,19 +57,27 @@ init flags url key =
 
 
 type Msg
-    = ReplaceMe
+    = GotSession Session
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
-        ReplaceMe ->
-            ( model, Cmd.none )
+        GotSession session ->
+            let
+                dbg =
+                    Debug.log "session" session
+            in
+            ( { model
+                | session = session
+              }
+            , Cmd.none
+            )
 
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Sub.none
+    Session.changes GotSession
 
 
 
@@ -87,6 +95,7 @@ view { page, toMsg } model =
             [ header [ class "navbar" ]
                 [ a [ class "link", href (Route.toString Route.Top) ] [ text "Homepage" ]
                 , a [ class "link", href (Route.toString Route.NotFound) ] [ text "Not found" ]
+                , a [ class "link", href (Route.toString Route.ProtectedApplicationTemplate) ] [ text "Protected" ]
                 , div []
                     [ text ("Token: " ++ Api.exposeToken (Session.cred model.session)) ]
                 , div [] [ text ("REST API URL: " ++ Config.restApiUrl model.config) ]

--- a/web/src/Spa/Page.elm
+++ b/web/src/Spa/Page.elm
@@ -143,7 +143,7 @@ protectedApplication page =
 
                 Nothing ->
                     ( Nothing
-                    , Nav.load (Route.toString Route.Top)
+                    , Nav.pushUrl shared.key (Route.toString Route.Top)
                     )
     }
 

--- a/web/src/Spa/Page.elm
+++ b/web/src/Spa/Page.elm
@@ -1,6 +1,7 @@
 module Spa.Page exposing
     ( Page
     , static, sandbox, element, application
+    , protectedApplication
     )
 
 {-|
@@ -11,8 +12,11 @@ module Spa.Page exposing
 
 -}
 
+import Browser.Navigation as Nav
+import Session
 import Shared
 import Spa.Document exposing (Document)
+import Spa.Generated.Route as Route
 import Spa.Url exposing (Url)
 
 
@@ -84,6 +88,64 @@ application :
     -> Page params model msg
 application page =
     page
+
+
+protectedApplication :
+    { init : Shared.Model -> Url params -> ( model, Cmd msg )
+    , update : msg -> model -> ( model, Cmd msg )
+    , view : model -> Document msg
+    , subscriptions : model -> Sub msg
+    , save : model -> Shared.Model -> Shared.Model
+    , load : Shared.Model -> model -> ( model, Cmd msg )
+    }
+    -> Page params (Maybe model) msg
+protectedApplication page =
+    { init =
+        \shared url ->
+            case Session.viewer shared.session of
+                Just viewer ->
+                    page.init shared url |> Tuple.mapFirst Just
+
+                Nothing ->
+                    ( Nothing
+                    , Nav.pushUrl url.key (Route.toString Route.Top)
+                    )
+    , update =
+        \msg maybeModel ->
+            case maybeModel of
+                Just model ->
+                    page.update msg model |> Tuple.mapFirst Just
+
+                Nothing ->
+                    ( Nothing, Cmd.none )
+    , view =
+        \maybeModel ->
+            case maybeModel of
+                Just model ->
+                    page.view model
+
+                Nothing ->
+                    { title = "Redirecting to login page", body = [] }
+    , subscriptions =
+        \maybeModel ->
+            case maybeModel of
+                Just model ->
+                    page.subscriptions model
+
+                Nothing ->
+                    Sub.none
+    , save = \_ shared -> shared
+    , load =
+        \shared model ->
+            case Session.viewer shared.session of
+                Just viewer ->
+                    ( model, Cmd.none )
+
+                Nothing ->
+                    ( Nothing
+                    , Nav.load (Route.toString Route.Top)
+                    )
+    }
 
 
 ignoreEffect : model -> ( model, Cmd msg )


### PR DESCRIPTION
This PR adds a `protectedApplication` to `Page.elm`. `protectedApplication` checks if the user is logged in before loading the page. If the user is logged in, the page loads. Otherwise, they are redirected to the login page. (At the moment, the login page is `Top`. We will want to update this to the actual login page when we bring it in.)

In addition, `protectedApplication`'s `load` function will check on the session and navigate the user to login page if a logout occurs. This makes it possible to log users out in all browser tabs.

`ProtectedApplicationTemplate.elm` is an example `protectedApplication` and a template that we can use as a starting point for other protected pages. Note that we need to use a `SafeModel` that is wrapped by `Model` because `elm-spa` needs `Model` internally (see https://www.elm-spa.dev/guide/authentication).

`Shared.elm` has login and logout functionality to test that everything works with the `Api` module and the backend. We can remove those parts when we bring in the actual login page and logout button.