### PR TITLE
Move instructor admin modules into SPA

### DIFF
--- a/web/elm.json
+++ b/web/elm.json
@@ -12,9 +12,12 @@
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
-            "elm/url": "1.0.0"
+            "elm/url": "1.0.0",
+            "y0hy0h/ordered-containers": "2.0.1"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }
@@ -26,8 +29,6 @@
         },
         "indirect": {
             "avh4/elm-fifo": "1.0.4",
-            "elm/bytes": "1.0.8",
-            "elm/file": "1.0.5",
             "elm/random": "1.0.0"
         }
     }

--- a/web/src/InstructorAdmin/Admin/Text.elm
+++ b/web/src/InstructorAdmin/Admin/Text.elm
@@ -1,0 +1,34 @@
+module InstructorAdmin.Admin.Text exposing (TextAPIEndpoint, URL, textAPIEndpointURL, textEndpointToString, toTextAPIEndpoint)
+
+
+type URL
+    = URL String
+
+
+type TextAPIEndpoint
+    = TextAPIEndpoint URL
+
+
+toURL : String -> URL
+toURL urlString =
+    URL urlString
+
+
+toTextAPIEndpoint : String -> TextAPIEndpoint
+toTextAPIEndpoint urlString =
+    TextAPIEndpoint (toURL urlString)
+
+
+urlToString : URL -> String
+urlToString (URL url) =
+    url
+
+
+textAPIEndpointURL : TextAPIEndpoint -> URL
+textAPIEndpointURL (TextAPIEndpoint url) =
+    url
+
+
+textEndpointToString : TextAPIEndpoint -> String
+textEndpointToString endpoint =
+    urlToString (textAPIEndpointURL endpoint)

--- a/web/src/InstructorAdmin/Text/Create.elm
+++ b/web/src/InstructorAdmin/Text/Create.elm
@@ -1,0 +1,127 @@
+module InstructorAdmin.Text.Create exposing (Flags, Mode(..), Model, Msg(..), Tab(..), TextField(..), TextViewParams)
+
+import Dict exposing (Dict)
+import Flags
+import Http
+import Instructor.Profile
+import InstructorAdmin.Admin.Text
+import InstructorAdmin.Text.Translations as Translations
+import InstructorAdmin.Text.Translations.Model as TranslationsModel
+import InstructorAdmin.Text.Translations.Msg as TranslationsMsg
+import Json.Encode
+import Menu.Items
+import Menu.Logout
+import Menu.Msg as MenuMsg
+import Text.Component exposing (TextComponent)
+import Text.Decode
+import Text.Field exposing (TextAuthor, TextDifficulty, TextIntro, TextSource, TextTags, TextTitle)
+import Text.Model exposing (Text, TextDifficulty)
+import Text.Update
+import Time
+
+
+type alias Flags =
+    Flags.AuthedFlags
+        { instructor_profile : Instructor.Profile.InstructorProfileParams
+        , text : Maybe Json.Encode.Value
+        , answer_feedback_limit : Int
+        , text_endpoint_url : String
+        , translation_flags : Translations.Flags
+        , tags : List String
+        }
+
+
+type alias InstructorUser =
+    String
+
+
+type alias Tags =
+    Dict String String
+
+
+type alias Filter =
+    List String
+
+
+type alias WriteLocked =
+    Bool
+
+
+type Mode
+    = EditMode
+    | CreateMode
+    | ReadOnlyMode InstructorUser
+
+
+type Tab
+    = TextTab
+    | TranslationsTab
+
+
+type TextField
+    = Title TextTitle
+    | Intro TextIntro
+    | Tags TextTags
+    | Author TextAuthor
+    | Source TextSource
+    | Difficulty Text.Field.TextDifficulty
+    | Conclusion Text.Field.TextConclusion
+
+
+type Msg
+    = UpdateTextDifficultyOptions (Result Http.Error (List Text.Model.TextDifficulty))
+    | TextTranslationMsg TranslationsMsg.Msg
+    | SubmitText
+    | Submitted (Result Http.Error Text.Decode.TextCreateResp)
+    | Updated (Result Http.Error Text.Decode.TextUpdateResp)
+    | TextComponentMsg Text.Update.Msg
+    | ToggleEditable TextField Bool
+    | UpdateTextAttributes String String
+    | UpdateTextCkEditors ( String, String )
+    | TextJSONDecode (Result String TextComponent)
+    | TextTagsDecode (Result String (Dict String String))
+    | ClearMessages Time.Time
+    | AddTagInput String String
+    | DeleteTag String
+    | ToggleLock
+    | TextLocked (Result Http.Error Text.Decode.TextLockResp)
+    | TextUnlocked (Result Http.Error Text.Decode.TextLockResp)
+    | DeleteText
+    | ConfirmTextDelete Bool
+    | TextDelete (Result Http.Error Text.Decode.TextDeleteResp)
+    | InitTextFieldEditors
+    | ToggleTab Tab
+    | LogOut MenuMsg.Msg
+    | LoggedOut (Result Http.Error Menu.Logout.LogOutResp)
+
+
+type alias Model =
+    { flags : Flags
+    , mode : Mode
+    , profile : Instructor.Profile.InstructorProfile
+    , menu_items : Menu.Items.MenuItems
+    , success_msg : Maybe String
+    , error_msg : Maybe String
+    , text_api_endpoint : InstructorAdmin.Admin.Text.TextAPIEndpoint
+    , text_component : TextComponent
+    , text_difficulties : List Text.Model.TextDifficulty
+    , text_translations_model : Maybe TranslationsModel.Model
+    , tags : Dict String String
+    , write_locked : Bool
+    , selected_tab : Tab
+    }
+
+
+type alias TextViewParams =
+    { text : Text.Model.Text
+    , text_component : TextComponent
+    , text_fields : Text.Field.TextFields
+    , profile : Instructor.Profile.InstructorProfile
+    , tags : Dict String String
+    , selected_tab : Tab
+    , write_locked : WriteLocked
+    , mode : Mode
+    , text_difficulties : List Text.Model.TextDifficulty
+    , text_translations_model : Maybe TranslationsModel.Model
+    , text_translation_msg : TranslationsMsg.Msg -> Msg
+    }

--- a/web/src/InstructorAdmin/Text/Translations.elm
+++ b/web/src/InstructorAdmin/Text/Translations.elm
@@ -1,0 +1,186 @@
+module InstructorAdmin.Text.Translations exposing
+    ( AddTextWordEndpoint(..)
+    , Flags
+    , Grammemes
+    , Id
+    , Instance
+    , MergeState(..)
+    , MergeTextWordEndpoint(..)
+    , Phrase
+    , SectionNumber(..)
+    , TextGroupDetails
+    , TextTranslationMatchEndpoint(..)
+    , TextWordId(..)
+    , Token
+    , Translation
+    , Translations
+    , URL(..)
+    , Word
+    , WordValues
+    , Words
+    , addTextWordEndpointToString
+    , expectedGrammemeKeys
+    , mergeTextWordEndpointToString
+    , sectionNumberToInt
+    , textTransMatchEndpointToString
+    , textWordIdToInt
+    )
+
+import Dict exposing (Dict)
+import Flags
+import Set exposing (Set)
+
+
+type SectionNumber
+    = SectionNumber Int
+
+
+sectionNumberToInt : SectionNumber -> Int
+sectionNumberToInt (SectionNumber sectionNumber) =
+    sectionNumber
+
+
+type TextWordId
+    = TextWordId Int
+
+
+textWordIdToInt : TextWordId -> Int
+textWordIdToInt (TextWordId id) =
+    id
+
+
+type alias Id =
+    String
+
+
+type alias Instance =
+    Int
+
+
+type alias Phrase =
+    String
+
+
+type alias Word =
+    String
+
+
+type alias Token =
+    String
+
+
+type alias Meaning =
+    String
+
+
+type alias WordValues =
+    { grammemes : Grammemes
+    , translations : Maybe (List String)
+    }
+
+
+type alias TextGroupDetails =
+    { id : Int
+    , instance : Int
+    , pos : Int
+    , length : Int
+    }
+
+
+type alias Words =
+    Dict Word WordValues
+
+
+type URL
+    = URL String
+
+
+type AddTextWordEndpoint
+    = AddTextWordEndpoint URL
+
+
+type MergeTextWordEndpoint
+    = MergeTextWordEndpoint URL
+
+
+type GroupWordEndpoint
+    = GroupWordEndpoint URL
+
+
+type TextTranslationMatchEndpoint
+    = TextTranslationMatchEndpoint URL
+
+
+type MergeState
+    = Mergeable
+    | Cancelable
+
+
+type alias Flags =
+    { add_as_text_word_endpoint_url : String
+    , merge_textword_endpoint_url : String
+    , text_translation_match_endpoint : String
+    , csrftoken : Flags.CSRFToken
+    }
+
+
+type alias Translation =
+    { id : Int
+    , endpoint : String
+    , correct_for_context : Bool
+    , text : String
+    }
+
+
+type alias Translations =
+    List Translation
+
+
+type alias Grammemes =
+    Dict String String
+
+
+urlToString : URL -> String
+urlToString (URL url) =
+    url
+
+
+mergeTextWordEndpointURL : MergeTextWordEndpoint -> URL
+mergeTextWordEndpointURL (MergeTextWordEndpoint url) =
+    url
+
+
+addTextWordEndpointURL : AddTextWordEndpoint -> URL
+addTextWordEndpointURL (AddTextWordEndpoint url) =
+    url
+
+
+textTransMatchEndpointURL : TextTranslationMatchEndpoint -> URL
+textTransMatchEndpointURL (TextTranslationMatchEndpoint url) =
+    url
+
+
+textTransMatchEndpointToString : TextTranslationMatchEndpoint -> String
+textTransMatchEndpointToString endpoint =
+    urlToString (textTransMatchEndpointURL endpoint)
+
+
+addTextWordEndpointToString : AddTextWordEndpoint -> String
+addTextWordEndpointToString endpoint =
+    urlToString (addTextWordEndpointURL endpoint)
+
+
+mergeTextWordEndpointToString : MergeTextWordEndpoint -> String
+mergeTextWordEndpointToString endpoint =
+    urlToString (mergeTextWordEndpointURL endpoint)
+
+
+expectedGrammemeKeys : Set String
+expectedGrammemeKeys =
+    Set.fromList
+        [ "pos"
+        , "tense"
+        , "aspect"
+        , "form"
+        , "mood"
+        ]

--- a/web/src/InstructorAdmin/Text/Translations/Decode.elm
+++ b/web/src/InstructorAdmin/Text/Translations/Decode.elm
@@ -1,0 +1,186 @@
+module InstructorAdmin.Text.Translations.Decode exposing
+    ( Flashcards
+    , TextWord
+    , TextWordMergeResp
+    , TextWordTranslationDeleteResp
+    , grammemesDecoder
+    , textGroupDetailsDecoder
+    , textTranslationRemoveRespDecoder
+    , textTranslationUpdateRespDecoder
+    , textWordDictInstancesDecoder
+    , textWordInstanceDecoder
+    , textWordInstancesDecoder
+    , textWordMergeDecoder
+    , wordDecoder
+    , wordsDecoder
+    )
+
+import Array exposing (Array)
+import Dict exposing (Dict)
+import InstructorAdmin.Text.Translations as Translations
+    exposing
+        ( Phrase
+        , SectionNumber(..)
+        , TextGroupDetails
+        , TextWordId(..)
+        , Translation
+        , WordValues
+        , Words
+        )
+import InstructorAdmin.Text.Translations.TextWord as TranslationsTextWord
+import InstructorAdmin.Text.Translations.Word.Kind as TranslationsWordKind
+import Json.Decode
+import Json.Decode.Pipeline exposing (required)
+import TextReader.TextWord
+import Util
+
+
+type alias TextWord =
+    { phrase : Phrase
+    , grammemes : List ( String, String )
+    , translation : Maybe String
+    }
+
+
+type alias Flashcards =
+    Dict Phrase TextReader.TextWord.TextWord
+
+
+type alias TextWords =
+    Dict Phrase TextWord
+
+
+type alias TextWordTranslationDeleteResp =
+    { text_word : TranslationsTextWord.TextWord
+    , translation : Translation
+    , deleted : Bool
+    }
+
+
+type alias TextWordMergeResp =
+    { phrase : String
+    , section : SectionNumber
+    , instance : Int
+    , text_words : List TranslationsTextWord.TextWord
+    , grouped : Bool
+    , error : Maybe String
+    }
+
+
+wordValuesDecoder : Json.Decode.Decoder WordValues
+wordValuesDecoder =
+    Json.Decode.succeed WordValues
+        |> required "grammemes" (Json.Decode.map Dict.fromList grammemesDecoder)
+        |> required "translations" (Json.Decode.nullable (Json.Decode.list Json.Decode.string))
+
+
+wordsDecoder : Json.Decode.Decoder Words
+wordsDecoder =
+    Json.Decode.dict wordValuesDecoder
+
+
+textWordMergeDecoder : Json.Decode.Decoder TextWordMergeResp
+textWordMergeDecoder =
+    Json.Decode.succeed TextWordMergeResp
+        |> required "phrase" Json.Decode.string
+        |> required "section" (Json.Decode.map SectionNumber Json.Decode.int)
+        |> required "instance" Json.Decode.int
+        |> required "text_words" textWordInstancesDecoder
+        |> required "grouped" Json.Decode.bool
+        |> required "error" (Json.Decode.nullable Json.Decode.string)
+
+
+textTranslationUpdateRespDecoder : Json.Decode.Decoder ( TranslationsTextWord.TextWord, Translation )
+textTranslationUpdateRespDecoder =
+    Json.Decode.map2 (\a b -> ( a, b ))
+        (Json.Decode.field "text_word" textWordInstanceDecoder)
+        (Json.Decode.field "translation" textWordTranslationsDecoder)
+
+
+textTranslationRemoveRespDecoder : Json.Decode.Decoder TextWordTranslationDeleteResp
+textTranslationRemoveRespDecoder =
+    Json.Decode.succeed TextWordTranslationDeleteResp
+        |> required "text_word" textWordInstanceDecoder
+        |> required "translation" textWordTranslationsDecoder
+        |> required "deleted" Json.Decode.bool
+
+
+textWordDictInstancesDecoder : Json.Decode.Decoder (Array (Dict Translations.Word (Array TranslationsTextWord.TextWord)))
+textWordDictInstancesDecoder =
+    Json.Decode.array (Json.Decode.dict (Json.Decode.array textWordInstanceDecoder))
+
+
+textWordInstancesDecoder : Json.Decode.Decoder (List TranslationsTextWord.TextWord)
+textWordInstancesDecoder =
+    Json.Decode.list textWordInstanceDecoder
+
+
+textWordTranslationsDecoder : Json.Decode.Decoder Translation
+textWordTranslationsDecoder =
+    Json.Decode.succeed Translation
+        |> required "id" Json.Decode.int
+        |> required "endpoint" Json.Decode.string
+        |> required "correct_for_context" Json.Decode.bool
+        |> required "text" Json.Decode.string
+
+
+textGroupDetailsDecoder : Json.Decode.Decoder TextGroupDetails
+textGroupDetailsDecoder =
+    Json.Decode.succeed TextGroupDetails
+        |> required "id" Json.Decode.int
+        |> required "instance" Json.Decode.int
+        |> required "pos" Json.Decode.int
+        |> required "length" Json.Decode.int
+
+
+wordDecoder : Json.Decode.Decoder TranslationsTextWord.WordKind
+wordDecoder =
+    Json.Decode.field "word_type" Json.Decode.string
+        |> Json.Decode.andThen wordHelpDecoder
+
+
+wordHelpDecoder : String -> Json.Decode.Decoder TranslationsTextWord.WordKind
+wordHelpDecoder wordType =
+    case wordType of
+        "single" ->
+            Json.Decode.field "group"
+                (Json.Decode.map TranslationsTextWord.SingleWord (Json.Decode.nullable textGroupDetailsDecoder))
+
+        "compound" ->
+            Json.Decode.succeed TranslationsTextWord.CompoundWord
+
+        _ ->
+            Json.Decode.fail "Unsupported word type"
+
+
+textWordEndpointsDecoder : Json.Decode.Decoder TranslationsTextWord.Endpoints
+textWordEndpointsDecoder =
+    Json.Decode.succeed TranslationsTextWord.Endpoints
+        |> required "text_word" Json.Decode.string
+        |> required "translations" Json.Decode.string
+
+
+textWordInstanceDecoder : Json.Decode.Decoder TranslationsTextWord.TextWord
+textWordInstanceDecoder =
+    Json.Decode.map8 TranslationsTextWord.new
+        (Json.Decode.field "id" (Json.Decode.map TextWordId Json.Decode.int))
+        (Json.Decode.field "text_section" (Json.Decode.map SectionNumber Json.Decode.int))
+        (Json.Decode.field "instance" Json.Decode.int)
+        (Json.Decode.field "phrase" Json.Decode.string)
+        (Json.Decode.field "grammemes" (Json.Decode.nullable (Json.Decode.map Dict.fromList grammemesDecoder)))
+        (Json.Decode.field "translations" (Json.Decode.nullable (Json.Decode.list textWordTranslationsDecoder)))
+        wordDecoder
+        (Json.Decode.field "endpoints" textWordEndpointsDecoder)
+
+
+grammemesDecoder : Json.Decode.Decoder (List ( String, String ))
+grammemesDecoder =
+    Json.Decode.list Util.stringTupleDecoder
+
+
+textWordDecoder : Json.Decode.Decoder TextWord
+textWordDecoder =
+    Json.Decode.succeed TextWord
+        |> required "phrase" Json.Decode.string
+        |> required "grammemes" grammemesDecoder
+        |> required "translation" (Json.Decode.nullable Json.Decode.string)

--- a/web/src/InstructorAdmin/Text/Translations/Encode.elm
+++ b/web/src/InstructorAdmin/Text/Translations/Encode.elm
@@ -1,0 +1,96 @@
+module InstructorAdmin.Text.Translations.Encode exposing
+    ( deleteTextTranslationEncode
+    , grammemesEncoder
+    , newTextTranslationEncoder
+    , textTranslationAsCorrectEncoder
+    , textTranslationsMergeEncoder
+    , textWordMergeEncoder
+    )
+
+import Dict exposing (Dict)
+import InstructorAdmin.Text.Translations exposing (Translation)
+import InstructorAdmin.Text.Translations.TextWord as TranslationsTextWord exposing (TextWord)
+import Json.Encode as Encode
+
+
+textTranslationEncoder : Translation -> Encode.Value
+textTranslationEncoder textTranslation =
+    Encode.object
+        [ ( "id", Encode.int textTranslation.id )
+        , ( "text", Encode.string textTranslation.text )
+        , ( "correct_for_context", Encode.bool textTranslation.correct_for_context )
+        ]
+
+
+textTranslationsMergeEncoder : List Translation -> List TextWord -> Encode.Value
+textTranslationsMergeEncoder textWordTranslations textWords =
+    Encode.object
+        [ ( "words"
+          , Encode.list Encode.object <|
+                List.map
+                    (\tw ->
+                        [ ( "id", Encode.int (TranslationsTextWord.idToInt tw) )
+                        , ( "word_type", Encode.string (TranslationsTextWord.wordType tw) )
+                        ]
+                    )
+                    textWords
+          )
+        , ( "translations"
+          , Encode.list Encode.object <|
+                List.map
+                    (\twt ->
+                        [ ( "correct_for_context", Encode.bool twt.correct_for_context )
+                        , ( "phrase", Encode.string twt.text )
+                        ]
+                    )
+                    textWordTranslations
+          )
+        ]
+
+
+textTranslationsEncoder : List Translation -> Encode.Value
+textTranslationsEncoder textTranslations =
+    Encode.list textTranslationEncoder textTranslations
+
+
+textTranslationAsCorrectEncoder : Translation -> Encode.Value
+textTranslationAsCorrectEncoder textTranslation =
+    Encode.object
+        [ ( "id", Encode.int textTranslation.id )
+        , ( "correct_for_context", Encode.bool textTranslation.correct_for_context )
+        ]
+
+
+textWordMergeEncoder : List TextWord -> Encode.Value
+textWordMergeEncoder textWords =
+    Encode.list Encode.int
+        (List.map (\textWord -> TranslationsTextWord.idToInt textWord) textWords)
+
+
+newTextTranslationEncoder : String -> Bool -> Encode.Value
+newTextTranslationEncoder translation correct_for_context =
+    Encode.object
+        [ ( "phrase", Encode.string translation )
+        , ( "correct_for_context", Encode.bool correct_for_context )
+        ]
+
+
+deleteTextTranslationEncode : Int -> Encode.Value
+deleteTextTranslationEncode translationId =
+    Encode.object
+        [ ( "id", Encode.int translationId )
+        ]
+
+
+encodeDict : (comparable -> String) -> (v -> Encode.Value) -> Dict comparable v -> Encode.Value
+encodeDict kName vValue dict =
+    Encode.object <|
+        List.map (\( k, v ) -> ( kName k, vValue v )) (Dict.toList dict)
+
+
+grammemesEncoder : TextWord -> Dict String String -> Encode.Value
+grammemesEncoder textWord grammemes =
+    Encode.object
+        [ ( "word_type", Encode.string (TranslationsTextWord.wordType textWord) )
+        , ( "grammemes", encodeDict identity Encode.string grammemes )
+        ]

--- a/web/src/InstructorAdmin/Text/Translations/Model.elm
+++ b/web/src/InstructorAdmin/Text/Translations/Model.elm
@@ -1,0 +1,511 @@
+module InstructorAdmin.Text.Translations.Model exposing
+    ( Model
+    , addTextTranslation
+    , addToMergeWords
+    , clearMerge
+    , completeMerge
+    , editWord
+    , editingGrammemeValue
+    , editingWord
+    , editingWordInstance
+    , getNewTranslationForWord
+    , getTextWords
+    , init
+    , inputGrammeme
+    , instanceCount
+    , isMergingWords
+    , mergeState
+    , mergingWord
+    , mergingWordInstances
+    , mergingWords
+    , newWordInstance
+    , refreshTextWordForWordInstance
+    , removeFromMergeWords
+    , removeTextTranslation
+    , selectGrammemeForEditing
+    , setGlobalEditLock
+    , setTextWord
+    , setTextWords
+    , uneditWord
+    , updateTextTranslation
+    , updateTranslationsForWord
+    )
+
+import Array exposing (Array)
+import Dict exposing (Dict)
+import InstructorAdmin.Text.Translations as Translations
+import InstructorAdmin.Text.Translations.TextWord as TranslationsTextWord
+import InstructorAdmin.Text.Translations.Word.Instance as TranslationsWordInstance
+import OrderedDict exposing (OrderedDict)
+import Text.Model
+
+
+type alias Grammemes =
+    Dict String (Maybe String)
+
+
+type alias Model =
+    { -- from the server, a dictionary of TextWords indexed by section number
+      words : Array (Dict Translations.Word (Array TranslationsTextWord.TextWord))
+    , merging_words : OrderedDict String TranslationsWordInstance.WordInstance
+    , editing_grammeme : Maybe String
+    , editing_grammemes : Dict String String
+    , editing_words : Dict Translations.Word Int
+    , editing_word_instances : Dict Translations.Word Bool
+    , edit_lock : Bool
+    , text : Text.Model.Text
+    , text_id : Int
+    , new_translations : Dict String String
+    , add_as_text_word_endpoint : Translations.AddTextWordEndpoint
+    , merge_textword_endpoint : Translations.MergeTextWordEndpoint
+    , text_translation_match_endpoint : Translations.TextTranslationMatchEndpoint
+    , flags : Translations.Flags
+    }
+
+
+init : Translations.Flags -> Int -> Text.Model.Text -> Model
+init flags text_id text =
+    { words = Array.empty
+    , merging_words = OrderedDict.empty
+    , editing_words = Dict.empty
+    , editing_grammeme = Nothing
+    , editing_grammemes = Dict.empty
+    , editing_word_instances = Dict.empty
+    , edit_lock = False
+    , text = text
+    , text_id = text_id
+    , new_translations = Dict.empty
+    , flags = flags
+    , add_as_text_word_endpoint = Translations.AddTextWordEndpoint (Translations.URL flags.add_as_text_word_endpoint_url)
+    , merge_textword_endpoint = Translations.MergeTextWordEndpoint (Translations.URL flags.merge_textword_endpoint_url)
+    , text_translation_match_endpoint =
+        Translations.TextTranslationMatchEndpoint (Translations.URL flags.text_translation_match_endpoint)
+    }
+
+
+clearEditingFields : Model -> Model
+clearEditingFields model =
+    { model | editing_grammemes = Dict.empty }
+
+
+selectGrammemeForEditing : Model -> String -> Model
+selectGrammemeForEditing model grammeme_name =
+    { model | editing_grammeme = Just grammeme_name }
+
+
+editingGrammeme : Model -> String
+editingGrammeme model =
+    let
+        firstGrammemeName =
+            "aspect"
+    in
+    Maybe.withDefault firstGrammemeName model.editing_grammeme
+
+
+editingGrammemeValue : Model -> TranslationsWordInstance.WordInstance -> String
+editingGrammemeValue model wordInstance =
+    let
+        grammemeName =
+            editingGrammeme model
+
+        wordInstanceGrammemes =
+            Maybe.withDefault "" (TranslationsWordInstance.grammemeValue wordInstance grammemeName)
+    in
+    Maybe.withDefault wordInstanceGrammemes (Dict.get grammemeName model.editing_grammemes)
+
+
+inputGrammeme : Model -> String -> Model
+inputGrammeme model newGrammemeValue =
+    let
+        editingGrammemeName =
+            editingGrammeme model
+    in
+    { model
+        | editing_grammemes =
+            Dict.insert editingGrammemeName newGrammemeValue model.editing_grammemes
+    }
+
+
+textWordToWordInstance : TranslationsTextWord.TextWord -> TranslationsWordInstance.WordInstance
+textWordToWordInstance textWord =
+    let
+        section_number =
+            TranslationsTextWord.sectionNumber textWord
+
+        phrase =
+            String.toLower (TranslationsTextWord.phrase textWord)
+
+        instance =
+            TranslationsTextWord.instance textWord
+    in
+    TranslationsWordInstance.new section_number instance phrase (Just textWord)
+
+
+refreshTextWordForWordInstance :
+    Model
+    -> TranslationsWordInstance.WordInstance
+    -> TranslationsWordInstance.WordInstance
+refreshTextWordForWordInstance model wordInstance =
+    let
+        sectionNumber =
+            TranslationsWordInstance.sectionNumber wordInstance
+
+        instance =
+            TranslationsWordInstance.instance wordInstance
+
+        phrase =
+            TranslationsWordInstance.token wordInstance
+    in
+    case getTextWord model sectionNumber instance phrase of
+        Just textWord ->
+            TranslationsWordInstance.setTextWord wordInstance textWord
+
+        Nothing ->
+            wordInstance
+
+
+newWordInstance :
+    Model
+    -> Translations.SectionNumber
+    -> Translations.Instance
+    -> Translations.Token
+    -> TranslationsWordInstance.WordInstance
+newWordInstance model sectionNumber instance token =
+    TranslationsWordInstance.new sectionNumber instance token (getTextWord model sectionNumber instance token)
+
+
+mergingWordInstances : Model -> List TranslationsWordInstance.WordInstance
+mergingWordInstances model =
+    OrderedDict.values (mergingWords model)
+
+
+mergeSiblings :
+    Model
+    -> TranslationsWordInstance.WordInstance
+    -> List TranslationsWordInstance.WordInstance
+mergeSiblings model wordInstance =
+    OrderedDict.values <| OrderedDict.remove (TranslationsWordInstance.id wordInstance) (mergingWords model)
+
+
+mergeState : Model -> TranslationsWordInstance.WordInstance -> Maybe Translations.MergeState
+mergeState model wordInstance =
+    let
+        otherMergingWords =
+            mergeSiblings model wordInstance
+    in
+    if mergingWord model wordInstance then
+        if List.length otherMergingWords >= 1 then
+            Just Translations.Mergeable
+
+        else
+            Just Translations.Cancelable
+
+    else
+        Nothing
+
+
+isTextWordPartOfCompoundWord : Model -> TranslationsTextWord.TextWord -> Maybe ( Int, Int, Int )
+isTextWordPartOfCompoundWord model textWord =
+    let
+        sectionNumber =
+            TranslationsTextWord.sectionNumber textWord
+
+        instance =
+            TranslationsTextWord.instance textWord
+
+        phrase =
+            TranslationsTextWord.phrase textWord
+    in
+    isPartOfCompoundWord model sectionNumber instance phrase
+
+
+isPartOfCompoundWord : Model -> Translations.SectionNumber -> Int -> String -> Maybe ( Int, Int, Int )
+isPartOfCompoundWord model section_number instance word =
+    case getTextWord model section_number instance word of
+        Just text_word ->
+            case TranslationsTextWord.group text_word of
+                Just group ->
+                    Just ( TranslationsTextWord.instance text_word, group.pos, group.length )
+
+                Nothing ->
+                    Nothing
+
+        Nothing ->
+            Nothing
+
+
+completeMerge :
+    Model
+    -> Translations.SectionNumber
+    -> Translations.Phrase
+    -> Translations.Instance
+    -> List TranslationsTextWord.TextWord
+    -> Model
+completeMerge model sectionNumber phrase instance textWords =
+    let
+        newModel =
+            setTextWords model textWords
+                |> clearMerge
+                |> uneditAllWords
+
+        mergedWordInstance =
+            newWordInstance newModel sectionNumber instance phrase
+    in
+    editWord newModel mergedWordInstance
+
+
+clearMerge : Model -> Model
+clearMerge model =
+    { model | merging_words = OrderedDict.empty }
+
+
+isMergingWords : Model -> Bool
+isMergingWords model =
+    not (OrderedDict.isEmpty model.merging_words)
+
+
+mergingWords : Model -> OrderedDict String TranslationsWordInstance.WordInstance
+mergingWords model =
+    model.merging_words
+
+
+mergingWord : Model -> TranslationsWordInstance.WordInstance -> Bool
+mergingWord model wordInstance =
+    OrderedDict.member (TranslationsWordInstance.id wordInstance) model.merging_words
+
+
+addToMergeWords : Model -> TranslationsWordInstance.WordInstance -> Model
+addToMergeWords model wordInstance =
+    { model
+        | merging_words =
+            OrderedDict.insert (TranslationsWordInstance.id wordInstance) wordInstance model.merging_words
+    }
+
+
+removeFromMergeWords : Model -> TranslationsWordInstance.WordInstance -> Model
+removeFromMergeWords model wordInstance =
+    { model
+        | merging_words =
+            OrderedDict.remove (TranslationsWordInstance.id wordInstance) model.merging_words
+    }
+
+
+instanceCount : Model -> Translations.SectionNumber -> Translations.Word -> Int
+instanceCount model sectionNumber word =
+    case getTextWords model sectionNumber (String.toLower word) of
+        Just textWords ->
+            Array.length textWords
+
+        Nothing ->
+            0
+
+
+getTextWords :
+    Model
+    -> Translations.SectionNumber
+    -> Translations.Phrase
+    -> Maybe (Array TranslationsTextWord.TextWord)
+getTextWords model sectionNumber phrase =
+    getSectionWords model sectionNumber
+        |> Maybe.andThen (Dict.get (String.toLower phrase))
+
+
+editingWord : Model -> String -> Bool
+editingWord model word =
+    Dict.member (String.toLower word) model.editing_words
+
+
+wordInstanceKey : TranslationsWordInstance.WordInstance -> String
+wordInstanceKey wordInstance =
+    TranslationsWordInstance.id wordInstance
+
+
+setGlobalEditLock : Model -> Bool -> Model
+setGlobalEditLock model value =
+    { model | edit_lock = value }
+
+
+editWord : Model -> TranslationsWordInstance.WordInstance -> Model
+editWord model wordInstance =
+    let
+        normalizedWord =
+            String.toLower (TranslationsWordInstance.word wordInstance)
+
+        newEditedWords =
+            case Dict.get normalizedWord model.editing_words of
+                Just refCount ->
+                    Dict.insert normalizedWord (refCount + 1) model.editing_words
+
+                Nothing ->
+                    Dict.insert normalizedWord 0 model.editing_words
+
+        newEditingWordInstances =
+            Dict.insert (wordInstanceKey wordInstance) True model.editing_word_instances
+    in
+    { model | editing_words = newEditedWords, editing_word_instances = newEditingWordInstances }
+
+
+uneditAllWords : Model -> Model
+uneditAllWords model =
+    { model
+        | editing_words = Dict.empty
+        , editing_word_instances = Dict.empty
+    }
+
+
+uneditWord : Model -> TranslationsWordInstance.WordInstance -> Model
+uneditWord model wordInstance =
+    let
+        word =
+            TranslationsWordInstance.word wordInstance
+
+        normalizedWord =
+            String.toLower word
+
+        newEditedWords =
+            case Dict.get normalizedWord model.editing_words of
+                Just refCount ->
+                    if (refCount - 1) == -1 then
+                        Dict.remove normalizedWord model.editing_words
+
+                    else
+                        Dict.insert normalizedWord (refCount - 1) model.editing_words
+
+                Nothing ->
+                    model.editing_words
+
+        newEditingWordInstances =
+            Dict.remove (wordInstanceKey wordInstance) model.editing_word_instances
+
+        cancelled_merge_model =
+            clearMerge model
+    in
+    { cancelled_merge_model
+        | editing_words = newEditedWords
+        , editing_word_instances = newEditingWordInstances
+        , editing_grammemes = Dict.empty
+    }
+
+
+editingWordInstance : Model -> TranslationsWordInstance.WordInstance -> Bool
+editingWordInstance model wordInstance =
+    Dict.member (TranslationsWordInstance.id wordInstance) model.editing_word_instances
+
+
+getTextWord :
+    Model
+    -> Translations.SectionNumber
+    -> Int
+    -> Translations.Phrase
+    -> Maybe TranslationsTextWord.TextWord
+getTextWord model sectionNumber instance phrase =
+    getTextWords model sectionNumber (String.toLower phrase)
+        |> Maybe.andThen (Array.get instance)
+
+
+setTextWords : Model -> List TranslationsTextWord.TextWord -> Model
+setTextWords model textWords =
+    let
+        -- ensure we're initializing the arrays in the right order
+        sortedTextWords =
+            List.sortBy (\textWord -> TranslationsTextWord.instance textWord) textWords
+
+        newModel =
+            clearEditingFields model
+    in
+    List.foldl (\textWord accModel -> setTextWord accModel textWord) newModel sortedTextWords
+
+
+getSectionWords :
+    Model
+    -> Translations.SectionNumber
+    -> Maybe (Dict Translations.Word (Array TranslationsTextWord.TextWord))
+getSectionWords model sectionNumber =
+    Array.get (Translations.sectionNumberToInt sectionNumber) model.words
+
+
+setSectionWords :
+    Model
+    -> Translations.SectionNumber
+    -> Dict Translations.Word (Array TranslationsTextWord.TextWord)
+    -> Model
+setSectionWords model sectionNumber words =
+    { model | words = Array.set (Translations.sectionNumberToInt sectionNumber) words model.words }
+
+
+setTextWordsForPhrase :
+    Model
+    -> Translations.SectionNumber
+    -> Translations.Phrase
+    -> Array TranslationsTextWord.TextWord
+    -> Model
+setTextWordsForPhrase model sectionNumber phrase textWords =
+    case getSectionWords model sectionNumber of
+        Just sectionWords ->
+            setSectionWords model sectionNumber (Dict.insert (String.toLower phrase) textWords sectionWords)
+
+        Nothing ->
+            model
+
+
+setTextWord : Model -> TranslationsTextWord.TextWord -> Model
+setTextWord model textWord =
+    let
+        sectionNumber =
+            TranslationsTextWord.sectionNumber textWord
+
+        phrase =
+            TranslationsTextWord.phrase textWord
+
+        instance =
+            TranslationsTextWord.instance textWord
+
+        newTextWords =
+            case getTextWords model sectionNumber phrase of
+                Just textWords ->
+                    Array.set instance textWord textWords
+
+                -- word not found
+                Nothing ->
+                    Array.fromList [ textWord ]
+    in
+    setTextWordsForPhrase model sectionNumber phrase newTextWords
+
+
+updateTextTranslation : Model -> TranslationsTextWord.TextWord -> Translations.Translation -> Model
+updateTextTranslation model textWord translation =
+    let
+        newTextWord =
+            TranslationsTextWord.updateTranslation
+                (TranslationsTextWord.setNoTRCorrectForContext textWord)
+                translation
+    in
+    setTextWord model newTextWord
+
+
+getNewTranslationForWord : Model -> TranslationsTextWord.TextWord -> Maybe String
+getNewTranslationForWord model textWord =
+    Dict.get (TranslationsTextWord.phrase textWord) model.new_translations
+
+
+updateTranslationsForWord : Model -> TranslationsTextWord.TextWord -> String -> Model
+updateTranslationsForWord model textWord translationText =
+    let
+        phrase =
+            TranslationsTextWord.phrase textWord
+    in
+    { model | new_translations = Dict.insert phrase translationText model.new_translations }
+
+
+addTextTranslation : Model -> TranslationsTextWord.TextWord -> Translations.Translation -> Model
+addTextTranslation model newTextWord _ =
+    setTextWord model newTextWord
+
+
+removeTextTranslation : Model -> TranslationsTextWord.TextWord -> Translations.Translation -> Model
+removeTextTranslation model textWord translation =
+    let
+        newTextWord =
+            TranslationsTextWord.removeTranslation textWord translation
+    in
+    setTextWord model newTextWord

--- a/web/src/InstructorAdmin/Text/Translations/Msg.elm
+++ b/web/src/InstructorAdmin/Text/Translations/Msg.elm
@@ -1,0 +1,46 @@
+module InstructorAdmin.Text.Translations.Msg exposing (Msg(..))
+
+import Array exposing (Array)
+import Dict exposing (Dict)
+import Http
+import InstructorAdmin.Text.Translations as Translations exposing (Translation)
+import InstructorAdmin.Text.Translations.Decode as TranslationsDecode
+import InstructorAdmin.Text.Translations.TextWord exposing (TextWord)
+import InstructorAdmin.Text.Translations.Word.Instance exposing (WordInstance)
+
+
+type Msg
+    = -- action msgs
+      -- merges
+      AddToMergeWords WordInstance
+    | RemoveFromMergeWords WordInstance
+    | MergeWords (List WordInstance)
+    | AddedTextWordsForMerge (List TextWord)
+    | MergeFail Http.Error
+      -- words
+    | AddTextWord WordInstance
+    | EditWord WordInstance
+    | CloseEditWord WordInstance
+    | DeleteTextWord TextWord
+      -- translations
+    | MakeCorrectForContext Translation
+    | UpdateNewTranslationForTextWord TextWord String
+    | SubmitNewTranslationForTextWord TextWord
+    | DeleteTranslation TextWord Translation
+    | MatchTranslations WordInstance
+      -- grammemes
+    | SelectGrammemeForEditing WordInstance String
+    | InputGrammeme WordInstance String
+    | SaveEditedGrammemes WordInstance
+    | RemoveGrammeme WordInstance String
+      -- result msgs
+      -- words
+    | MergedWords (Result Http.Error TranslationsDecode.TextWordMergeResp)
+    | DeletedTextWord (Result Http.Error TextWord)
+    | UpdatedTextWord (Result Http.Error TextWord)
+    | UpdatedTextWords (Result Http.Error (List TextWord))
+      -- translations
+    | UpdateTextTranslations (Result Http.Error (Array (Dict Translations.Word (Array TextWord))))
+    | UpdateTextTranslation (Result Http.Error ( TextWord, Translation ))
+    | SubmittedTextTranslation (Result Http.Error ( TextWord, Translation ))
+    | DeletedTranslation (Result Http.Error TranslationsDecode.TextWordTranslationDeleteResp)

--- a/web/src/InstructorAdmin/Text/Translations/Subscriptions.elm
+++ b/web/src/InstructorAdmin/Text/Translations/Subscriptions.elm
@@ -1,0 +1,6 @@
+module InstructorAdmin.Text.Translations.Subscriptions exposing (subscriptions)
+
+
+subscriptions : Sub msg
+subscriptions =
+    Sub.none

--- a/web/src/InstructorAdmin/Text/Translations/TextWord.elm
+++ b/web/src/InstructorAdmin/Text/Translations/TextWord.elm
@@ -1,0 +1,232 @@
+module InstructorAdmin.Text.Translations.TextWord exposing
+    ( Endpoints
+    , TextWord
+    , grammemeValue
+    , grammemes
+    , group
+    , idToInt
+    , instance
+    , new
+    , phrase
+    , removeTranslation
+    , sectionNumber
+    , setNoTRCorrectForContext
+    , strToWordType
+    , textWordEndpoint
+    , translations
+    , translationsEndpoint
+    , updateTranslation
+    , wordKindToGroup
+    , wordType
+    , wordTypeToString
+    )
+
+import Dict
+import InstructorAdmin.Text.Translations as Translations
+    exposing
+        ( Grammemes
+        , Instance
+        , Phrase
+        , SectionNumber
+        , TextGroupDetails
+        , TextWordId
+        , Translation
+        , Translations
+        )
+import InstructorAdmin.Text.Translations.Word.Kind exposing (WordKind(..))
+
+
+type alias Endpoints =
+    { text_word : String
+    , translations : String
+    }
+
+
+type TextWord
+    = TextWord TextWordId SectionNumber Instance Phrase (Maybe Grammemes) (Maybe Translations) WordKind Endpoints
+
+
+grammemeValue : TextWord -> String -> Maybe String
+grammemeValue textWord grammemeName =
+    grammemes textWord
+        |> Maybe.andThen (Dict.get grammemeName)
+
+
+grammemes : TextWord -> Maybe Grammemes
+grammemes (TextWord _ _ _ _ maybeGrammemes _ _ _) =
+    maybeGrammemes
+
+
+strToWordType : ( String, Maybe TextGroupDetails ) -> WordKind
+strToWordType ( str, groupDetails ) =
+    case str of
+        "single" ->
+            SingleWord groupDetails
+
+        "compound" ->
+            CompoundWord
+
+        _ ->
+            SingleWord groupDetails
+
+
+wordTypeToString : WordKind -> String
+wordTypeToString word =
+    case word of
+        SingleWord _ ->
+            "single"
+
+        CompoundWord ->
+            "compound"
+
+
+wordType : TextWord -> String
+wordType textWord =
+    wordTypeToString (wordKind textWord)
+
+
+sectionNumber : TextWord -> SectionNumber
+sectionNumber (TextWord _ section _ _ _ _ _ _) =
+    section
+
+
+wordKind : TextWord -> WordKind
+wordKind (TextWord _ _ _ _ _ _ wk _) =
+    wk
+
+
+instance : TextWord -> Int
+instance (TextWord _ _ inst _ _ _ _ _) =
+    inst
+
+
+wordKindToGroup : WordKind -> Maybe TextGroupDetails
+wordKindToGroup word =
+    case word of
+        SingleWord groupDetails ->
+            groupDetails
+
+        CompoundWord ->
+            Nothing
+
+
+group : TextWord -> Maybe TextGroupDetails
+group (TextWord _ _ _ _ _ _ word _) =
+    wordKindToGroup word
+
+
+endpoints : TextWord -> Endpoints
+endpoints (TextWord _ _ _ _ _ _ _ endpnts) =
+    endpnts
+
+
+translationsEndpoint : TextWord -> String
+translationsEndpoint textWord =
+    (endpoints textWord).translations
+
+
+textWordEndpoint : TextWord -> String
+textWordEndpoint textWord =
+    (endpoints textWord).text_word
+
+
+id : TextWord -> TextWordId
+id (TextWord wordId _ _ _ _ _ _ _) =
+    wordId
+
+
+idToInt : TextWord -> Int
+idToInt textWord =
+    Translations.textWordIdToInt (id textWord)
+
+
+new :
+    TextWordId
+    -> SectionNumber
+    -> Instance
+    -> Phrase
+    -> Maybe Grammemes
+    -> Maybe Translations
+    -> WordKind
+    -> Endpoints
+    -> TextWord
+new wordId section inst phr maybeGrammemes maybeTranslations word endpnts =
+    TextWord wordId section inst phr maybeGrammemes maybeTranslations word endpnts
+
+
+phrase : TextWord -> Phrase
+phrase (TextWord _ _ _ phrs _ _ _ _) =
+    phrs
+
+
+translations : TextWord -> Maybe Translations
+translations (TextWord _ _ _ _ _ maybeTranslations _ _) =
+    maybeTranslations
+
+
+setTranslations : TextWord -> Maybe Translations -> TextWord
+setTranslations (TextWord wordId section inst phrs maybeGrammemes _ word endpnts) newTranslations =
+    TextWord wordId section inst phrs maybeGrammemes newTranslations word endpnts
+
+
+addTranslation : TextWord -> Translation -> TextWord
+addTranslation textWord translation =
+    let
+        newTranslations =
+            translations textWord
+                |> Maybe.map (List.map (\tr -> { tr | correct_for_context = False }))
+                |> Maybe.map (\trs -> trs ++ [ translation ])
+    in
+    setTranslations textWord newTranslations
+
+
+removeTranslation : TextWord -> Translation -> TextWord
+removeTranslation textWord textWordTranslation =
+    case translations textWord of
+        Just trs ->
+            let
+                newTranslations =
+                    List.filter (\tr -> tr.id /= textWordTranslation.id) trs
+            in
+            setTranslations textWord (Just newTranslations)
+
+        -- no translations
+        Nothing ->
+            textWord
+
+
+updateTranslation : TextWord -> Translation -> TextWord
+updateTranslation textWord textWordTranslation =
+    case translations textWord of
+        Just trs ->
+            let
+                newTranslations =
+                    List.map
+                        (\tr ->
+                            if tr.id == textWordTranslation.id then
+                                textWordTranslation
+
+                            else
+                                tr
+                        )
+                        trs
+            in
+            setTranslations textWord (Just newTranslations)
+
+        -- word has no translations
+        Nothing ->
+            textWord
+
+
+setNoTRCorrectForContext : TextWord -> TextWord
+setNoTRCorrectForContext textWord =
+    case translations textWord of
+        Just trs ->
+            let
+                newTranslations =
+                    List.map (\tr -> { tr | correct_for_context = False }) trs
+            in
+            setTranslations textWord (Just newTranslations)
+
+        Nothing ->
+            textWord

--- a/web/src/InstructorAdmin/Text/Translations/Update.elm
+++ b/web/src/InstructorAdmin/Text/Translations/Update.elm
@@ -1,0 +1,451 @@
+module InstructorAdmin.Text.Translations.Update exposing
+    ( retrieveTextWords
+    , update
+    )
+
+import Array
+import Dict exposing (Dict)
+import Flags
+import Http
+import InstructorAdmin.Admin.Text
+import InstructorAdmin.Text.Translations as Translations exposing (..)
+import InstructorAdmin.Text.Translations.Decode as TranslationsDecode
+import InstructorAdmin.Text.Translations.Encode as TranslationsEncode
+import InstructorAdmin.Text.Translations.Model as TranslationsModel exposing (..)
+import InstructorAdmin.Text.Translations.Msg exposing (Msg)
+import InstructorAdmin.Text.Translations.TextWord as TranslationsTextWord exposing (TextWord)
+import InstructorAdmin.Text.Translations.Word.Instance as TranslationsWordInstance exposing (WordInstance)
+import InstructorAdmin.Text.Translations.Word.Instance.Encode as TranslationsWordInstanceEncode
+import Task
+import Utils.HttpHelpers as HttpHelpers
+
+
+update : (Msg -> msg) -> Msg -> Model -> ( Model, Cmd msg )
+update parentMsg msg model =
+    case msg of
+        MatchTranslations wordInstance ->
+            ( model, matchTranslations parentMsg model wordInstance )
+
+        UpdatedTextWords (Ok textWords) ->
+            ( TranslationsModel.setTextWords model textWords, Cmd.none )
+
+        UpdatedTextWord (Ok textWord) ->
+            ( TranslationsModel.setTextWord model textWord, Cmd.none )
+
+        EditWord wordInstance ->
+            ( TranslationsModel.editWord model wordInstance, Cmd.none )
+
+        CloseEditWord wordInstance ->
+            ( TranslationsModel.uneditWord model wordInstance, Cmd.none )
+
+        MakeCorrectForContext translation ->
+            ( model, updateTranslationAsCorrect parentMsg model.flags.csrftoken translation )
+
+        UpdateTextTranslation (Ok ( textWord, translation )) ->
+            ( TranslationsModel.updateTextTranslation model textWord translation, Cmd.none )
+
+        UpdatedTextWords (Err err) ->
+            let
+                _ =
+                    Debug.log "error updating text words" err
+            in
+            ( model, Cmd.none )
+
+        UpdatedTextWord (Err err) ->
+            let
+                _ =
+                    Debug.log "error updating text word" err
+            in
+            ( model, Cmd.none )
+
+        MergeWords wordInstances ->
+            mergeWords parentMsg model model.flags.csrftoken wordInstances
+
+        MergedWords (Ok mergeResp) ->
+            if mergeResp.grouped then
+                ( TranslationsModel.completeMerge
+                    model
+                    mergeResp.section
+                    mergeResp.phrase
+                    mergeResp.instance
+                    mergeResp.text_words
+                , Cmd.none
+                )
+
+            else
+                let
+                    _ =
+                        Debug.log "error merging text words" mergeResp.error
+                in
+                ( TranslationsModel.clearMerge model, Cmd.none )
+
+        MergedWords (Err err) ->
+            let
+                _ =
+                    Debug.log "error merging text words" err
+            in
+            ( model, Cmd.none )
+
+        AddToMergeWords wordInstance ->
+            ( TranslationsModel.addToMergeWords model wordInstance, Cmd.none )
+
+        RemoveFromMergeWords wordInstance ->
+            ( TranslationsModel.removeFromMergeWords model wordInstance, Cmd.none )
+
+        AddedTextWordsForMerge textWords ->
+            let
+                newModel =
+                    TranslationsModel.setTextWords model textWords
+
+                -- update merging words with text words
+                mergingWordInstances =
+                    List.map
+                        (\wordInstance ->
+                            if (TranslationsWordInstance.hasTextWord >> not) wordInstance then
+                                TranslationsModel.refreshTextWordForWordInstance newModel wordInstance
+
+                            else
+                                wordInstance
+                        )
+                        (TranslationsModel.mergingWordInstances newModel)
+            in
+            -- merge
+            ( newModel, postMergeWords parentMsg newModel model.flags.csrftoken mergingWordInstances )
+
+        MergeFail err ->
+            let
+                _ =
+                    Debug.log "merge failure" err
+            in
+            ( setGlobalEditLock model False, Cmd.none )
+
+        DeleteTextWord _ ->
+            ( model, Cmd.none )
+
+        DeletedTextWord _ ->
+            ( model, Cmd.none )
+
+        -- handle user-friendly msgs
+        UpdateTextTranslation (Err err) ->
+            let
+                _ =
+                    Debug.log "error decoding text translation" err
+            in
+            ( model, Cmd.none )
+
+        UpdateTextTranslations (Ok words) ->
+            ( { model | words = words }, Cmd.none )
+
+        -- handle user-friendly msgs
+        UpdateTextTranslations (Err err) ->
+            let
+                _ =
+                    Debug.log "error decoding text translations" err
+            in
+            ( model, Cmd.none )
+
+        UpdateNewTranslationForTextWord textWord translationTxt ->
+            ( TranslationsModel.updateTranslationsForWord model textWord translationTxt, Cmd.none )
+
+        AddTextWord wordInstance ->
+            ( model, addAsTextWord parentMsg model model.flags.csrftoken wordInstance )
+
+        SubmitNewTranslationForTextWord textWord ->
+            case TranslationsModel.getNewTranslationForWord model textWord of
+                Just translationText ->
+                    ( model, postTranslation parentMsg model.flags.csrftoken textWord translationText True )
+
+                Nothing ->
+                    ( model, Cmd.none )
+
+        SubmittedTextTranslation (Ok ( textWord, translation )) ->
+            ( TranslationsModel.addTextTranslation model textWord translation, Cmd.none )
+
+        -- handle user-friendly msgs
+        SubmittedTextTranslation (Err err) ->
+            let
+                _ =
+                    Debug.log "error decoding adding text translations" err
+            in
+            ( model, Cmd.none )
+
+        DeleteTranslation textWord textTranslation ->
+            ( model, deleteTranslation parentMsg model.flags.csrftoken textWord textTranslation )
+
+        DeletedTranslation (Ok resp) ->
+            ( TranslationsModel.removeTextTranslation model resp.text_word resp.translation, Cmd.none )
+
+        -- handle user-friendly msgs
+        DeletedTranslation (Err err) ->
+            let
+                _ =
+                    Debug.log "error deleting text translations" err
+            in
+            ( model, Cmd.none )
+
+        SelectGrammemeForEditing _ grammemeName ->
+            ( TranslationsModel.selectGrammemeForEditing model grammemeName, Cmd.none )
+
+        InputGrammeme _ grammemeValue ->
+            ( TranslationsModel.inputGrammeme model grammemeValue, Cmd.none )
+
+        SaveEditedGrammemes wordInstance ->
+            ( model, updateGrammemes parentMsg model.flags.csrftoken wordInstance model.editing_grammemes )
+
+        RemoveGrammeme _ _ ->
+            ( model, Cmd.none )
+
+
+mergeWords : (Msg -> msg) -> Model -> Flags.CSRFToken -> List WordInstance -> ( Model, Cmd msg )
+mergeWords parentMsg model _ wordInstances =
+    if TranslationsWordInstance.canMergeWords wordInstances then
+        -- all word instances are ready to merge
+        ( model, postMergeWords parentMsg model model.flags.csrftoken wordInstances )
+
+    else
+        -- lock editing on the page and instantiate some asynchronous tasks to associate text words with these
+        -- word instances
+        let
+            wordInstancesWithNoTextWords =
+                List.filter (TranslationsWordInstance.hasTextWord >> not) wordInstances
+        in
+        ( setGlobalEditLock model True
+        , attemptToAddTextWords parentMsg model model.flags.csrftoken wordInstancesWithNoTextWords
+        )
+
+
+handleAddTextWords : (Msg -> msg) -> List WordInstance -> Result Http.Error (List TextWord) -> msg
+handleAddTextWords parentMsg _ result =
+    case result of
+        Err err ->
+            (MergeFail >> parentMsg) err
+
+        Ok textWords ->
+            (AddedTextWordsForMerge >> parentMsg) textWords
+
+
+attemptToAddTextWords : (Msg -> msg) -> Model -> Flags.CSRFToken -> List WordInstance -> Cmd msg
+attemptToAddTextWords parentMsg model csrftoken wordInstancesWithNoTextWord =
+    Task.attempt (handleAddTextWords parentMsg wordInstancesWithNoTextWord) <|
+        Task.sequence <|
+            List.map Http.toTask <|
+                List.map (addAsTextWordRequest model csrftoken) wordInstancesWithNoTextWord
+
+
+addAsTextWordRequest : Model -> Flags.CSRFToken -> WordInstance -> Http.Request TextWord
+addAsTextWordRequest model csrftoken wordInstance =
+    let
+        endpointUri =
+            Translations.addTextWordEndpointToString model.add_as_text_word_endpoint
+
+        headers =
+            [ Http.header "X-CSRFToken" csrftoken ]
+
+        encodedTextWord =
+            TranslationsWordInstanceEncode.textWordAddEncoder model.text_id wordInstance
+
+        body =
+            Http.jsonBody encodedTextWord
+    in
+    HttpHelpers.post_with_headers endpointUri headers body TranslationsDecode.textWordInstanceDecoder
+
+
+addAsTextWord : (Msg -> msg) -> Model -> Flags.CSRFToken -> WordInstance -> Cmd msg
+addAsTextWord parentMsg model csrftoken wordInstance =
+    Http.send (parentMsg << UpdatedTextWord) (addAsTextWordRequest model csrftoken wordInstance)
+
+
+postMergeWords : (Msg -> msg) -> Model -> Flags.CSRFToken -> List WordInstance -> Cmd msg
+postMergeWords parentMsg model csrftoken wordInstances =
+    let
+        endpointUrl =
+            Translations.mergeTextWordEndpointToString model.merge_textword_endpoint
+
+        headers =
+            [ Http.header "X-CSRFToken" csrftoken ]
+
+        textWords =
+            List.filterMap (\instance -> TranslationsWordInstance.textWord instance) wordInstances
+
+        encodedTextWordIds =
+            TranslationsEncode.textWordMergeEncoder textWords
+
+        body =
+            Http.jsonBody encodedTextWordIds
+
+        request =
+            HttpHelpers.post_with_headers endpointUrl headers body TranslationsDecode.textWordMergeDecoder
+    in
+    Http.send (parentMsg << MergedWords) request
+
+
+matchTranslations : (Msg -> msg) -> Model -> WordInstance -> Cmd msg
+matchTranslations parentMsg model wordInstance =
+    let
+        word =
+            String.toLower (TranslationsWordInstance.word wordInstance)
+
+        sectionNumber =
+            TranslationsWordInstance.sectionNumber wordInstance
+    in
+    case TranslationsWordInstance.textWord wordInstance of
+        Just textWord ->
+            case TranslationsTextWord.translations textWord of
+                Just newTranslations ->
+                    let
+                        matchTransltns =
+                            putMatchTranslations parentMsg model.text_translation_match_endpoint model.flags.csrftoken
+                    in
+                    case TranslationsModel.getTextWords model sectionNumber word of
+                        Just textWords ->
+                            matchTransltns newTranslations (Array.toList textWords)
+
+                        -- no text words associated with this word
+                        Nothing ->
+                            Cmd.none
+
+                -- no translations to match
+                Nothing ->
+                    Cmd.none
+
+        -- no text word
+        Nothing ->
+            Cmd.none
+
+
+deleteTranslation : (Msg -> msg) -> Flags.CSRFToken -> TextWord -> Translation -> Cmd msg
+deleteTranslation msg csrftoken _ translation =
+    let
+        headers =
+            [ Http.header "X-CSRFToken" csrftoken ]
+
+        encodedTranslation =
+            TranslationsEncode.deleteTextTranslationEncode translation.id
+
+        body =
+            Http.jsonBody encodedTranslation
+
+        request =
+            HttpHelpers.delete_with_headers
+                translation.endpoint
+                headers
+                body
+                TranslationsDecode.textTranslationRemoveRespDecoder
+    in
+    Http.send (msg << DeletedTranslation) request
+
+
+putMatchTranslations : (Msg -> msg) -> TextTranslationMatchEndpoint -> Flags.CSRFToken -> List Translation -> List TextWord -> Cmd msg
+putMatchTranslations msg textTranslationApiMatchEndpoint csrftoken translations textWords =
+    let
+        endpointUri =
+            Translations.textTransMatchEndpointToString textTranslationApiMatchEndpoint
+
+        headers =
+            [ Http.header "X-CSRFToken" csrftoken ]
+
+        encodedMergeRequest =
+            TranslationsEncode.textTranslationsMergeEncoder translations textWords
+
+        body =
+            Http.jsonBody encodedMergeRequest
+
+        request =
+            HttpHelpers.put_with_headers endpointUri headers body TranslationsDecode.textWordInstancesDecoder
+    in
+    Http.send (msg << UpdatedTextWords) request
+
+
+updateGrammemes : (Msg -> msg) -> Flags.CSRFToken -> WordInstance -> Dict String String -> Cmd msg
+updateGrammemes msg csrftoken wordInstance grammemes =
+    case TranslationsWordInstance.textWord wordInstance of
+        Just textWord ->
+            let
+                headers =
+                    [ Http.header "X-CSRFToken" csrftoken ]
+
+                textWordEndpoint =
+                    TranslationsTextWord.textWordEndpoint textWord
+
+                encodedGrammemes =
+                    TranslationsEncode.grammemesEncoder textWord grammemes
+
+                body =
+                    Http.jsonBody encodedGrammemes
+
+                request =
+                    HttpHelpers.put_with_headers
+                        textWordEndpoint
+                        headers
+                        body
+                        TranslationsDecode.textWordInstanceDecoder
+            in
+            Http.send (msg << UpdatedTextWord) request
+
+        -- no text word to update
+        Nothing ->
+            Cmd.none
+
+
+postTranslation : (Msg -> msg) -> Flags.CSRFToken -> TextWord -> String -> Bool -> Cmd msg
+postTranslation msg csrftoken textWord translationText correctForContext =
+    let
+        endpointUri =
+            TranslationsTextWord.translationsEndpoint textWord
+
+        headers =
+            [ Http.header "X-CSRFToken" csrftoken ]
+
+        encodedTranslation =
+            TranslationsEncode.newTextTranslationEncoder translationText correctForContext
+
+        body =
+            Http.jsonBody encodedTranslation
+
+        request =
+            HttpHelpers.post_with_headers endpointUri headers body TranslationsDecode.textTranslationUpdateRespDecoder
+    in
+    Http.send (msg << SubmittedTextTranslation) request
+
+
+updateTranslationAsCorrect : (Msg -> msg) -> Flags.CSRFToken -> Translation -> Cmd msg
+updateTranslationAsCorrect msg csrftoken translation =
+    let
+        headers =
+            [ Http.header "X-CSRFToken" csrftoken ]
+
+        encodedTranslation =
+            TranslationsEncode.textTranslationAsCorrectEncoder { translation | correct_for_context = True }
+
+        body =
+            Http.jsonBody encodedTranslation
+
+        request =
+            HttpHelpers.put_with_headers
+                translation.endpoint
+                headers
+                body
+                TranslationsDecode.textTranslationUpdateRespDecoder
+    in
+    Http.send (msg << UpdateTextTranslation) request
+
+
+retrieveTextWords : (Msg -> msg) -> InstructorAdmin.Admin.Text.TextAPIEndpoint -> Maybe Int -> Cmd msg
+retrieveTextWords msg textApiEndpoint textId =
+    case textId of
+        Just id ->
+            let
+                textApiEndpointUrl =
+                    InstructorAdmin.Admin.Text.textEndpointToString textApiEndpoint
+
+                request =
+                    Http.get
+                        (String.join "?"
+                            [ String.join "" [ textApiEndpointUrl, String.fromInt id, "/" ], "text_words=list" ]
+                        )
+                        TranslationsDecode.textWordDictInstancesDecoder
+            in
+            Http.send (msg << UpdateTextTranslations) request
+
+        Nothing ->
+            Cmd.none

--- a/web/src/InstructorAdmin/Text/Translations/View.elm
+++ b/web/src/InstructorAdmin/Text/Translations/View.elm
@@ -1,0 +1,433 @@
+module InstructorAdmin.Text.Translations.View exposing (..)
+
+import Array
+import Dict
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import HtmlParser
+import InstructorAdmin.Text.Translations exposing (..)
+import InstructorAdmin.Text.Translations.Model as TranslationsModel exposing (..)
+import InstructorAdmin.Text.Translations.Msg exposing (Msg)
+import InstructorAdmin.Text.Translations.TextWord as TranslationsTextWord exposing (TextWord)
+import InstructorAdmin.Text.Translations.Word.Instance as TranslationsWordInstance exposing (WordInstance)
+import OrderedDict
+import Set
+import Text.Section.Model
+import Text.Section.Words.Tag
+import VirtualDom
+
+
+wordInstanceOnClick : Model -> (Msg -> msg) -> WordInstance -> Html.Attribute msg
+wordInstanceOnClick model parentMsg wordInstance =
+    if TranslationsModel.isMergingWords model then
+        -- subsequent clicks on word instances will add them to the list of words to be merged
+        if TranslationsModel.mergingWord model wordInstance then
+            onClick (parentMsg (RemoveFromMergeWords wordInstance))
+
+        else
+            onClick (parentMsg (AddToMergeWords wordInstance))
+
+    else
+        onClick (parentMsg (EditWord wordInstance))
+
+
+tagWord : Model -> (Msg -> msg) -> Int -> Int -> String -> Html msg
+tagWord model parentMsg sectionNumber instance originalToken =
+    let
+        id =
+            String.join "-" [ "section", String.fromInt sectionNumber, "instance", String.fromInt instance, originalToken ]
+
+        token =
+            String.toLower originalToken
+    in
+    if token == " " then
+        VirtualDom.text token
+
+    else
+        let
+            wordInstance =
+                TranslationsModel.newWordInstance
+                    model
+                    (SectionNumber sectionNumber)
+                    instance
+                    token
+
+            editingWord =
+                TranslationsModel.editingWord model token
+
+            mergingWord =
+                TranslationsModel.mergingWord model wordInstance
+        in
+        Html.node "span"
+            [ Html.Attributes.id id
+            , classList [ ( "defined_word", True ), ( "cursor", True ) ]
+            ]
+            [ span
+                [ classList
+                    [ ( "edit-highlight", editingWord )
+                    , ( "merge-highlight", mergingWord && not editingWord )
+                    ]
+                , wordInstanceOnClick model parentMsg wordInstance
+                ]
+                [ VirtualDom.text originalToken
+                ]
+            , view_edit model parentMsg wordInstance
+            ]
+
+
+tagSection : Model -> (Msg -> msg) -> Text.Section.Model.TextSection -> Html msg
+tagSection model msg section =
+    let
+        sectionNumber =
+            SectionNumber section.order
+    in
+    div [ id ("section-" ++ String.fromInt section.order), class "section" ]
+        (Text.Section.Words.Tag.tagWordsAndToVDOM
+            (tagWord model msg section.order)
+            (isPartOfCompoundWord model sectionNumber)
+            (HtmlParser.parse section.body)
+        )
+
+
+view_edit : Model -> (Msg -> msg) -> WordInstance -> Html msg
+view_edit model parentMsg wordInstance =
+    let
+        editingWord =
+            TranslationsModel.editingWordInstance model wordInstance
+    in
+    div
+        [ class "edit_overlay"
+        , classList [ ( "hidden", not editingWord ) ]
+        ]
+        [ div [ class "edit_menu" ] <|
+            [ view_overlay_close_btn parentMsg wordInstance
+            , view_word_instance model parentMsg wordInstance
+            , view_btns model parentMsg wordInstance
+            ]
+        ]
+
+
+view_btns : Model -> (Msg -> msg) -> WordInstance -> Html msg
+view_btns model parentMsg wordInstance =
+    let
+        word =
+            TranslationsWordInstance.word wordInstance
+
+        sectionNumber =
+            TranslationsWordInstance.sectionNumber wordInstance
+
+        normalizedWord =
+            String.toLower word
+
+        instanceCount =
+            TranslationsModel.instanceCount model sectionNumber normalizedWord
+    in
+    div [ class "text_word_options" ] <|
+        [ view_make_compound_text_word model parentMsg wordInstance
+        , view_delete_text_word parentMsg wordInstance
+        ]
+            ++ (if instanceCount > 1 then
+                    [ view_match_translations parentMsg wordInstance ]
+
+                else
+                    []
+               )
+
+
+view_make_compound_text_word_on_click : Model -> (Msg -> msg) -> WordInstance -> Html.Attribute msg
+view_make_compound_text_word_on_click model parentMsg wordInstance =
+    case TranslationsModel.mergeState model wordInstance of
+        Just mergeState ->
+            case mergeState of
+                Cancelable ->
+                    onClick (parentMsg (RemoveFromMergeWords wordInstance))
+
+                Mergeable ->
+                    onClick (parentMsg (MergeWords (TranslationsModel.mergingWordInstances model)))
+
+        Nothing ->
+            onClick (parentMsg (AddToMergeWords wordInstance))
+
+
+view_make_compound_text_word : Model -> (Msg -> msg) -> WordInstance -> Html msg
+view_make_compound_text_word model parentMsg wordInstance =
+    let
+        mergeState =
+            TranslationsModel.mergeState model wordInstance
+
+        mergeTxt =
+            case mergeState of
+                Just state ->
+                    case state of
+                        Mergeable ->
+                            "Merge together"
+
+                        Cancelable ->
+                            "Cancel merge"
+
+                Nothing ->
+                    "Merge"
+    in
+    div [ class "text-word-option" ]
+        (case TranslationsWordInstance.textWord wordInstance of
+            Just _ ->
+                [ div
+                    [ attribute "title" "Merge into compound word."
+                    , classList [ ( "merge-highlight", TranslationsModel.mergingWord model wordInstance ) ]
+                    , view_make_compound_text_word_on_click model parentMsg wordInstance
+                    ]
+                    [ Html.text mergeTxt
+                    ]
+                ]
+
+            Nothing ->
+                []
+        )
+
+
+view_delete_text_word : (Msg -> msg) -> WordInstance -> Html msg
+view_delete_text_word parentMsg wordInstance =
+    let
+        textWord =
+            TranslationsWordInstance.textWord
+    in
+    div [ class "text-word-option" ]
+        (case textWord wordInstance of
+            Just textWord ->
+                [ div
+                    [ attribute "title" "Delete this word instance from glossing."
+                    , onClick (parentMsg (DeleteTextWord textWord))
+                    ]
+                    [ Html.text "Delete"
+                    ]
+                ]
+
+            Nothing ->
+                []
+        )
+
+
+view_correct_for_context : Bool -> List (Html msg)
+view_correct_for_context correct =
+    if correct then
+        [ div [ class "correct_checkmark", attribute "title" "Correct for the context." ]
+            [ Html.img
+                [ attribute "src" "/static/img/circle_check.svg"
+                , attribute "height" "12px"
+                , attribute "width" "12px"
+                ]
+                []
+            ]
+        ]
+
+    else
+        []
+
+
+view_add_as_text_word : (Msg -> msg) -> WordInstance -> Html msg
+view_add_as_text_word msg wordInstance =
+    div [ class "add_as_text_word" ]
+        [ div []
+            [ Html.text "Add as text word."
+            ]
+        , div []
+            [ Html.img
+                [ attribute "src" "/static/img/add.svg"
+                , attribute "height" "17px"
+                , attribute "width" "17px"
+                , attribute "title" "Add a new translation."
+                , onClick (msg (AddTextWord wordInstance))
+                ]
+                []
+            ]
+        ]
+
+
+view_add_translation : (Msg -> msg) -> TextWord -> Html msg
+view_add_translation msg textWord =
+    div [ class "add_translation" ]
+        [ div []
+            [ Html.input
+                [ attribute "type" "text"
+                , placeholder "Add a translation"
+                , onInput (UpdateNewTranslationForTextWord textWord >> msg)
+                ]
+                []
+            ]
+        , div []
+            [ Html.img
+                [ attribute "src" "/static/img/add.svg"
+                , attribute "height" "17px"
+                , attribute "width" "17px"
+                , attribute "title" "Add a new translation."
+                , onClick (msg (SubmitNewTranslationForTextWord textWord))
+                ]
+                []
+            ]
+        ]
+
+
+view_translation_delete : (Msg -> msg) -> TextWord -> Translation -> Html msg
+view_translation_delete msg textWord translation =
+    div [ class "translation_delete" ]
+        [ Html.img
+            [ attribute "src" "/static/img/delete.svg"
+            , attribute "height" "17px"
+            , attribute "width" "17px"
+            , attribute "title" "Delete this translation."
+            , onClick (msg (DeleteTranslation textWord translation))
+            ]
+            []
+        ]
+
+
+view_text_word_translation : (Msg -> msg) -> TextWord -> Translation -> Html msg
+view_text_word_translation msg textWord translation =
+    div [ classList [ ( "translation", True ) ] ]
+        [ div
+            [ classList [ ( "editable", True ), ( "phrase", True ) ]
+            , onClick (msg (MakeCorrectForContext translation))
+            ]
+            [ Html.text translation.text ]
+        , div [ class "icons" ] <|
+            view_correct_for_context translation.correct_for_context
+                ++ [ view_translation_delete msg textWord translation ]
+        ]
+
+
+view_exit_btn : Html msg
+view_exit_btn =
+    Html.img
+        [ attribute "src" "/static/img/cancel.svg"
+        , attribute "height" "13px"
+        , attribute "width" "13px"
+        , class "cursor"
+        ]
+        []
+
+
+view_overlay_close_btn : (Msg -> msg) -> WordInstance -> Html msg
+view_overlay_close_btn parentMsg wordInstance =
+    div [ class "edit_overlay_close_btn", onClick (parentMsg (CloseEditWord wordInstance)) ]
+        [ view_exit_btn
+        ]
+
+
+view_instance_word : Model -> (Msg -> msg) -> WordInstance -> Html msg
+view_instance_word model msg wordInstance =
+    let
+        word =
+            TranslationsWordInstance.word
+
+        wordTxt =
+            if TranslationsModel.mergingWord model wordInstance then
+                let
+                    mergingWords =
+                        List.map (\( k, v ) -> word v) <|
+                            OrderedDict.toList <|
+                                OrderedDict.remove
+                                    (wordInstanceKey wordInstance)
+                                    (TranslationsModel.mergingWords model)
+                in
+                String.join " " (word wordInstance :: mergingWords)
+
+            else
+                word wordInstance
+    in
+    div [ class "word" ]
+        [ Html.text wordTxt
+        , view_grammemes model msg wordInstance
+        ]
+
+
+view_word_instance : Model -> (Msg -> msg) -> WordInstance -> Html msg
+view_word_instance model msg wordInstance =
+    div [ class "word_instance" ] <|
+        [ view_instance_word model msg wordInstance
+        ]
+            ++ (case TranslationsWordInstance.textWord wordInstance of
+                    Just textWord ->
+                        case TranslationsTextWord.translations textWord of
+                            Just translationsList ->
+                                [ div [ class "translations" ] <|
+                                    List.map (view_text_word_translation msg textWord) translationsList
+                                        ++ [ view_add_translation msg textWord ]
+                                ]
+
+                            Nothing ->
+                                [ view_add_translation msg textWord ]
+
+                    Nothing ->
+                        [ view_add_as_text_word msg wordInstance ]
+               )
+
+
+view_match_translations : (Msg -> msg) -> WordInstance -> Html msg
+view_match_translations parentMsg wordInstance =
+    div [ class "text-word-option" ]
+        [ div
+            [ attribute "title" "Use these translations across all instances of this word"
+            , onClick (parentMsg (MatchTranslations wordInstance))
+            ]
+            [ Html.text "Save for all"
+            ]
+        ]
+
+
+view_grammeme : ( String, String ) -> Html msg
+view_grammeme ( grammeme, grammemeValue ) =
+    div [ class "grammeme" ] [ Html.text grammeme, Html.text " : ", Html.text grammemeValue ]
+
+
+view_add_grammemes : Model -> (Msg -> msg) -> WordInstance -> Html msg
+view_add_grammemes model msg wordInstance =
+    let
+        grammemeKeys =
+            Set.toList TranslationsWordInstance.grammemeKeys
+
+        grammemeValue =
+            TranslationsModel.editingGrammemeValue model wordInstance
+    in
+    div [ class "add" ]
+        [ select [ onInput (SelectGrammemeForEditing wordinstance >> msg) ]
+            (List.map (\grammeme -> option [ value grammeme ] [ Html.text grammeme ]) grammemeKeys)
+        , div [ onInput (InputGrammeme wordInstance >> msg) ]
+            [ Html.input [ placeholder "add/edit a grammeme..", value grammemeValue ] []
+            ]
+        , div []
+            [ Html.img
+                [ attribute "src" "/static/img/save.svg"
+                , attribute "height" "17px"
+                , attribute "width" "17px"
+                , attribute "title" "Save edited grammemes."
+                , onClick (msg (SaveEditedGrammemes wordInstance))
+                ]
+                []
+            ]
+        ]
+
+
+view_grammemes : Model -> (Msg -> msg) -> WordInstance -> Html msg
+view_grammemes model msg wordInstance =
+    div [ class "grammemes" ] <|
+        (case TranslationsWordInstance.grammemes wordInstance of
+            Just grammemes ->
+                List.map view_grammeme <| Dict.toList grammemes
+
+            Nothing ->
+                []
+        )
+            ++ [ view_add_grammemes model msg wordInstance ]
+
+
+view_translations : (Msg -> msg) -> Maybe Model -> Html msg
+view_translations msg translationModel =
+    case translationModel of
+        Just model ->
+            div [ id "translations_tab" ] (List.map (tagSection model msg) (Array.toList model.text.sections))
+
+        Nothing ->
+            div [ id "translations_tab" ]
+                [ Html.text "No translations available"
+                ]

--- a/web/src/InstructorAdmin/Text/Translations/Word/Instance.elm
+++ b/web/src/InstructorAdmin/Text/Translations/Word/Instance.elm
@@ -1,0 +1,107 @@
+module InstructorAdmin.Text.Translations.Word.Instance exposing
+    ( WordInstance
+    , canMergeWords
+    , grammemeKeys
+    , grammemeValue
+    , grammemes
+    , hasTextWord
+    , id
+    , instance
+    , new
+    , sectionNumber
+    , setTextWord
+    , textWord
+    , token
+    , word
+    , wordInstanceSectionNumberToInt
+    )
+
+import InstructorAdmin.Text.Translations as Translations exposing (Grammemes, Id, Instance, SectionNumber, Token)
+import InstructorAdmin.Text.Translations.TextWord as TranslationsTextWord exposing (TextWord)
+import Set exposing (Set)
+
+
+type WordInstance
+    = WordInstance SectionNumber Instance Token (Maybe TextWord)
+
+
+setTextWord : WordInstance -> TextWord -> WordInstance
+setTextWord (WordInstance sectNum inst tok _) newTextWord =
+    WordInstance sectNum inst tok (Just newTextWord)
+
+
+canMergeWords : List WordInstance -> Bool
+canMergeWords wordInstances =
+    List.all hasTextWord wordInstances
+
+
+hasTextWord : WordInstance -> Bool
+hasTextWord (WordInstance _ _ _ maybeTextWord) =
+    case maybeTextWord of
+        Just _ ->
+            True
+
+        Nothing ->
+            False
+
+
+grammemeValue : WordInstance -> String -> Maybe String
+grammemeValue wordInstance grammemeName =
+    textWord wordInstance
+        |> Maybe.andThen (\tw -> TranslationsTextWord.grammemeValue tw grammemeName)
+
+
+grammemeKeys : Set String
+grammemeKeys =
+    Translations.expectedGrammemeKeys
+
+
+grammemes : WordInstance -> Maybe Grammemes
+grammemes wordInstance =
+    textWord wordInstance
+        |> Maybe.andThen TranslationsTextWord.grammemes
+
+
+sectionNumber : WordInstance -> SectionNumber
+sectionNumber (WordInstance sectNum _ _ _) =
+    sectNum
+
+
+wordInstanceSectionNumberToInt : WordInstance -> Int
+wordInstanceSectionNumberToInt wordInstance =
+    Translations.sectionNumberToInt (sectionNumber wordInstance)
+
+
+id : WordInstance -> Id
+id (WordInstance sectNum inst tok _) =
+    String.join "_" [ String.fromInt (Translations.sectionNumberToInt sectNum), String.fromInt inst, String.join "_" (String.words (String.toLower tok)) ]
+
+
+token : WordInstance -> Token
+token (WordInstance _ _ tok _) =
+    tok
+
+
+textWord : WordInstance -> Maybe TextWord
+textWord (WordInstance _ _ _ maybeTextWord) =
+    maybeTextWord
+
+
+instance : WordInstance -> Instance
+instance (WordInstance _ inst _ _) =
+    inst
+
+
+word : WordInstance -> Token
+word (WordInstance _ _ tok _) =
+    tok
+
+
+normalizeToken : String -> String
+normalizeToken =
+    String.toLower
+
+
+new : SectionNumber -> Instance -> Token -> Maybe TextWord -> WordInstance
+new sectNum inst tok maybeTextWord =
+    WordInstance sectNum inst tok maybeTextWord

--- a/web/src/InstructorAdmin/Text/Translations/Word/Instance/Encode.elm
+++ b/web/src/InstructorAdmin/Text/Translations/Word/Instance/Encode.elm
@@ -1,0 +1,14 @@
+module InstructorAdmin.Text.Translations.Word.Instance.Encode exposing (textWordAddEncoder)
+
+import InstructorAdmin.Text.Translations.Word.Instance as TranslationsWordInstance exposing (WordInstance)
+import Json.Encode as Encode
+
+
+textWordAddEncoder : Int -> WordInstance -> Encode.Value
+textWordAddEncoder textId wordInstance =
+    Encode.object
+        [ ( "text", Encode.int textId )
+        , ( "text_section", Encode.int (TranslationsWordInstance.wordInstanceSectionNumberToInt wordInstance) )
+        , ( "instance", Encode.int (TranslationsWordInstance.instance wordInstance) )
+        , ( "phrase", Encode.string (TranslationsWordInstance.word wordInstance) )
+        ]

--- a/web/src/InstructorAdmin/Text/Translations/Word/Kind.elm
+++ b/web/src/InstructorAdmin/Text/Translations/Word/Kind.elm
@@ -1,0 +1,8 @@
+module InstructorAdmin.Text.Translations.Word.Kind exposing (WordKind(..))
+
+import InstructorAdmin.Text.Translations exposing (TextGroupDetails)
+
+
+type WordKind
+    = SingleWord (Maybe TextGroupDetails)
+    | CompoundWord


### PR DESCRIPTION
This PR moves the instructor admin modules into the SPA directory and renames modules and imports as needed. It also adds `y0hy0h/ordered-containers` back in as a dependency.

Note that this doesn't complete #129 because the `Admin.elm` and `Create_Edit_Text.elm` pages still need to be added. This last bit of work is blocked by #107, #126, and #128 (i.e. authentication and a few imports).