### PR TITLE
Add text modules

### DIFF
--- a/web/elm.json
+++ b/web/elm.json
@@ -7,19 +7,25 @@
     "dependencies": {
         "direct": {
             "NoRedInk/elm-json-decode-pipeline": "1.0.0",
+            "PanagiotisGeorgiadis/elm-datetime": "1.3.0",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/url": "1.0.0",
+            "waratuman/json-extra": "1.0.2",
             "y0hy0h/ordered-containers": "2.0.1"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
+            "elm/parser": "1.1.0",
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.2",
+            "justinmimbs/timezone-data": "2.1.4",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3",
+            "waratuman/time-extra": "1.1.0"
         }
     },
     "test-dependencies": {

--- a/web/src/TextReader.elm
+++ b/web/src/TextReader.elm
@@ -1,0 +1,13 @@
+module TextReader exposing (..)
+
+
+type Selected
+    = Selected Bool
+
+
+type AnsweredCorrectly
+    = AnsweredCorrectly Bool
+
+
+type FeedbackViewable
+    = FeedbackViewable Bool

--- a/web/src/TextReader/Answer/Decode.elm
+++ b/web/src/TextReader/Answer/Decode.elm
@@ -1,0 +1,21 @@
+module TextReader.Answer.Decode exposing (..)
+
+import Array exposing (Array)
+import Json.Decode
+import Json.Decode.Pipeline exposing (required)
+import TextReader.Answer.Model exposing (Answer)
+
+
+answerDecoder : Json.Decode.Decoder Answer
+answerDecoder =
+    Json.Decode.succeed Answer
+        |> required "id" Json.Decode.int
+        |> required "question_id" Json.Decode.int
+        |> required "text" Json.Decode.string
+        |> required "order" Json.Decode.int
+        |> required "feedback" Json.Decode.string
+
+
+answersDecoder : Json.Decode.Decoder (Array Answer)
+answersDecoder =
+    Json.Decode.array answerDecoder

--- a/web/src/TextReader/Answer/Model.elm
+++ b/web/src/TextReader/Answer/Model.elm
@@ -1,0 +1,59 @@
+module TextReader.Answer.Model exposing (..)
+
+
+type alias AnswerCorrect =
+    Bool
+
+
+type alias Answer =
+    { id : Int
+    , question_id : Int
+    , text : String
+    , order : Int
+    , answered_correctly : Maybe Bool
+    , feedback : String
+    }
+
+
+type TextAnswer
+    = TextAnswer Answer
+
+
+initTextAnswer : Answer -> TextAnswer
+initTextAnswer ans =
+    TextAnswer ans
+
+
+correct : TextAnswer -> Bool
+correct text_answer =
+    case (answer text_answer).answered_correctly of
+        Just is_correct ->
+            is_correct
+
+        Nothing ->
+            False
+
+
+answered : TextAnswer -> Bool
+answered text_answer =
+    case (answer text_answer).answered_correctly of
+        Just _ ->
+            True
+
+        Nothing ->
+            False
+
+
+feedback_viewable : TextAnswer -> Bool
+feedback_viewable text_answer =
+    answered text_answer
+
+
+selected : TextAnswer -> Bool
+selected text_answer =
+    answered text_answer
+
+
+answer : TextAnswer -> Answer
+answer (TextAnswer ans) =
+    ans

--- a/web/src/TextReader/Decode.elm
+++ b/web/src/TextReader/Decode.elm
@@ -1,0 +1,68 @@
+module TextReader.Decode exposing (..)
+
+import Json.Decode
+import Json.Decode.Pipeline exposing (required)
+import TextReader.Model exposing (..)
+import TextReader.Section.Decode
+import TextReader.Section.Model exposing (Section)
+import TextReader.Text.Decode
+
+
+commandRespDecoder : String -> Json.Decode.Decoder CmdResp
+commandRespDecoder cmdStr =
+    case cmdStr of
+        "intro" ->
+            startDecoder
+
+        "in_progress" ->
+            sectionDecoder InProgressResp
+
+        "exception" ->
+            Json.Decode.map ExceptionResp (Json.Decode.field "result" exceptionDecoder)
+
+        "complete" ->
+            Json.Decode.map CompleteResp (Json.Decode.field "result" textScoresDecoder)
+
+        "add_flashcard_phrase" ->
+            Json.Decode.map
+                AddToFlashcardsResp
+                (Json.Decode.field "result" TextReader.Section.Decode.textWordInstanceDecoder)
+
+        "remove_flashcard_phrase" ->
+            Json.Decode.map
+                RemoveFromFlashcardsResp
+                (Json.Decode.field "result" TextReader.Section.Decode.textWordInstanceDecoder)
+
+        _ ->
+            Json.Decode.fail ("Command " ++ cmdStr ++ " not supported")
+
+
+sectionDecoder : (Section -> CmdResp) -> Json.Decode.Decoder CmdResp
+sectionDecoder cmd_resp =
+    Json.Decode.map cmd_resp (Json.Decode.field "result" TextReader.Section.Decode.sectionDecoder)
+
+
+startDecoder : Json.Decode.Decoder CmdResp
+startDecoder =
+    Json.Decode.map StartResp (Json.Decode.field "result" TextReader.Text.Decode.textDecoder)
+
+
+exceptionDecoder : Json.Decode.Decoder Exception
+exceptionDecoder =
+    Json.Decode.succeed Exception
+        |> required "code" Json.Decode.string
+        |> required "error_msg" Json.Decode.string
+
+
+textScoresDecoder : Json.Decode.Decoder TextScores
+textScoresDecoder =
+    Json.Decode.succeed TextScores
+        |> required "num_of_sections" Json.Decode.int
+        |> required "complete_sections" Json.Decode.int
+        |> required "section_scores" Json.Decode.int
+        |> required "possible_section_scores" Json.Decode.int
+
+
+wsRespDecoder : Json.Decode.Decoder CmdResp
+wsRespDecoder =
+    Json.Decode.field "command" Json.Decode.string |> Json.Decode.andThen commandRespDecoder

--- a/web/src/TextReader/Encode.elm
+++ b/web/src/TextReader/Encode.elm
@@ -1,0 +1,53 @@
+module TextReader.Encode exposing (..)
+
+import Json.Encode
+import TextReader.Answer.Model
+import TextReader.Model exposing (..)
+
+
+jsonToString : Json.Encode.Value -> String
+jsonToString =
+    Json.Encode.encode 0
+
+
+commandRequestToString : CmdReq -> String
+commandRequestToString cmdReq =
+    jsonToString <| sendCommand cmdReq
+
+
+sendCommand : CmdReq -> Json.Encode.Value
+sendCommand cmdReq =
+    case cmdReq of
+        NextReq ->
+            Json.Encode.object
+                [ ( "command", Json.Encode.string "next" )
+                ]
+
+        PrevReq ->
+            Json.Encode.object
+                [ ( "command", Json.Encode.string "prev" )
+                ]
+
+        AnswerReq text_answer ->
+            let
+                textReaderAnswer =
+                    TextReader.Answer.Model.answer text_answer
+            in
+            Json.Encode.object
+                [ ( "command", Json.Encode.string "answer" )
+                , ( "answer_id", Json.Encode.int textReaderAnswer.id )
+                ]
+
+        AddToFlashcardsReq reader_word ->
+            Json.Encode.object
+                [ ( "command", Json.Encode.string "add_flashcard_phrase" )
+                , ( "instance", Json.Encode.string (String.fromInt (TextReader.Model.instance reader_word)) )
+                , ( "phrase", Json.Encode.string (TextReader.Model.phrase reader_word) )
+                ]
+
+        RemoveFromFlashcardsReq reader_word ->
+            Json.Encode.object
+                [ ( "command", Json.Encode.string "remove_flashcard_phrase" )
+                , ( "instance", Json.Encode.string (String.fromInt (TextReader.Model.instance reader_word)) )
+                , ( "phrase", Json.Encode.string (TextReader.Model.phrase reader_word) )
+                ]

--- a/web/src/TextReader/Flashcard/Student.elm
+++ b/web/src/TextReader/Flashcard/Student.elm
@@ -1,0 +1,41 @@
+module TextReader.Flashcard.Student exposing (..)
+
+import Dict exposing (Dict)
+import InstructorAdmin.Text.Translations.Decode as TranslationsDecode exposing (Flashcards, TextWord)
+import Student.Profile exposing (StudentProfile)
+import TextReader.TextWord
+
+
+type StudentFlashcards
+    = StudentFlashcards StudentProfile TranslationsDecode.Flashcards
+
+
+newStudentFlashcards : StudentProfile -> Maybe TranslationsDecode.Flashcards -> StudentFlashcards
+newStudentFlashcards student_profile cards =
+    StudentFlashcards student_profile (Maybe.withDefault Dict.empty cards)
+
+
+flashcards : StudentFlashcards -> Flashcards
+flashcards (StudentFlashcards _ cards) =
+    cards
+
+
+addFlashcard : StudentFlashcards -> TextReader.TextWord.TextWord -> StudentFlashcards
+addFlashcard (StudentFlashcards profile cards) text_word =
+    let
+        phrase =
+            TextReader.TextWord.phrase text_word
+    in
+    StudentFlashcards profile (Dict.insert phrase text_word cards)
+
+
+removeFlashcard : StudentFlashcards -> TextReader.TextWord.TextWord -> StudentFlashcards
+removeFlashcard (StudentFlashcards profile cards) text_word =
+    let
+        phrase =
+            TextReader.TextWord.phrase text_word
+
+        new_flashcards =
+            Dict.remove phrase cards
+    in
+    StudentFlashcards profile new_flashcards

--- a/web/src/TextReader/Model.elm
+++ b/web/src/TextReader/Model.elm
@@ -1,0 +1,145 @@
+module TextReader.Model exposing (..)
+
+import Dict exposing (Dict)
+import InstructorAdmin.Text.Translations exposing (Id, Instance, Phrase)
+import Menu.Items
+import Profile.Flags as Flags
+import Text.Resource
+import TextReader.Answer.Model exposing (Answer, AnswerCorrect, TextAnswer)
+import TextReader.Section.Model exposing (Section)
+import TextReader.Text.Model exposing (Text)
+import TextReader.TextWord
+import User.Profile
+import User.Profile.TextReader.Flashcards
+
+
+type Progress
+    = Init
+    | ViewIntro
+    | ViewSection Section
+    | Complete TextScores
+
+
+type alias Exception =
+    { code : String, error_msg : String }
+
+
+type alias Gloss =
+    Dict String Bool
+
+
+type alias Flashcards =
+    Dict String Bool
+
+
+type TextReaderWord
+    = TextReaderWord Id Instance Phrase (Maybe TextReader.TextWord.TextWord)
+
+
+new : Id -> Instance -> Phrase -> Maybe TextReader.TextWord.TextWord -> TextReaderWord
+new id inst phr text_word =
+    TextReaderWord id inst phr text_word
+
+
+identifier : TextReaderWord -> Id
+identifier (TextReaderWord id _ _ _) =
+    id
+
+
+textWord : TextReaderWord -> Maybe TextReader.TextWord.TextWord
+textWord (TextReaderWord _ _ _ text_word) =
+    text_word
+
+
+instance : TextReaderWord -> Instance
+instance (TextReaderWord _ inst _ _) =
+    inst
+
+
+phrase : TextReaderWord -> Phrase
+phrase (TextReaderWord _ _ phr _) =
+    phr
+
+
+gloss : TextReaderWord -> Gloss -> Gloss
+gloss reader_word glosses =
+    Dict.insert (identifier reader_word) True (Dict.insert (String.toLower (phrase reader_word)) True glosses)
+
+
+ungloss : TextReaderWord -> Gloss -> Gloss
+ungloss reader_word glosses =
+    Dict.remove (identifier reader_word) (Dict.remove (String.toLower (phrase reader_word)) glosses)
+
+
+toggleGloss : TextReaderWord -> Gloss -> Gloss
+toggleGloss reader_word glosses =
+    if selected reader_word glosses then
+        ungloss reader_word glosses
+
+    else
+        gloss reader_word glosses
+
+
+
+-- this is for any instance of a word
+
+
+glossed : TextReaderWord -> Gloss -> Bool
+glossed reader_word gls =
+    Dict.member (String.toLower (phrase reader_word)) gls
+
+
+
+-- this is for a particular instance of a word (using `identifer`)
+
+
+selected : TextReaderWord -> Gloss -> Bool
+selected reader_word gls =
+    Dict.member (identifier reader_word) gls
+
+
+type CmdReq
+    = NextReq
+    | PrevReq
+    | AnswerReq TextAnswer
+    | AddToFlashcardsReq TextReaderWord
+    | RemoveFromFlashcardsReq TextReaderWord
+
+
+type CmdResp
+    = StartResp Text
+    | InProgressResp Section
+    | CompleteResp TextScores
+    | AddToFlashcardsResp TextReader.TextWord.TextWord
+    | RemoveFromFlashcardsResp TextReader.TextWord.TextWord
+    | ExceptionResp Exception
+
+
+type alias TextScores =
+    { num_of_sections : Int
+    , complete_sections : Int
+    , section_scores : Int
+    , possible_section_scores : Int
+    }
+
+
+type alias Flags =
+    Flags.Flags
+        { text_id : Int
+        , text_url : String
+        , flashcards : List TextReader.TextWord.TextWordParams
+        , text_reader_ws_addr : String
+        }
+
+
+type alias Model =
+    { text : Text
+    , text_url : Text.Resource.TextReadingURL
+    , profile : User.Profile.Profile
+    , menu_items : Menu.Items.MenuItems
+    , flashcard : User.Profile.TextReader.Flashcards.ProfileFlashcards
+    , progress : Progress
+    , gloss : Gloss
+    , exception : Maybe Exception
+    , flags : Flags
+    }

--- a/web/src/TextReader/Msg.elm
+++ b/web/src/TextReader/Msg.elm
@@ -1,0 +1,27 @@
+module TextReader.Msg exposing (..)
+
+import Http
+import Menu.Logout
+import Menu.Msg as MenuMsg
+import TextReader.Answer.Model exposing (TextAnswer)
+import TextReader.Model exposing (TextReaderWord)
+import TextReader.Question.Model exposing (TextQuestion)
+import TextReader.Section.Model exposing (Section)
+
+import Json.Decode
+import WebSocket
+
+type Msg
+    = Select TextAnswer
+    | ViewFeedback Section TextQuestion TextAnswer Bool
+    | PrevSection
+    | NextSection
+    | StartOver
+    | Gloss TextReaderWord
+    | UnGloss TextReaderWord
+    | ToggleGloss TextReaderWord
+    | AddToFlashcards TextReaderWord
+    | RemoveFromFlashcards TextReaderWord
+    | WebSocketResp (Result Json.Decode.Error WebSocket.WebSocketMsg)
+    | LogOut MenuMsg.Msg
+    | LoggedOut (Result Http.Error Menu.Logout.LogOutResp)

--- a/web/src/TextReader/Question/Decode.elm
+++ b/web/src/TextReader/Question/Decode.elm
@@ -1,0 +1,43 @@
+module TextReader.Question.Decode exposing (..)
+
+import Array exposing (Array)
+import DateTime
+import Json.Decode
+import Json.Decode.Extra exposing (posix)
+import Json.Decode.Pipeline exposing (required)
+import TextReader.Answer.Model exposing (Answer)
+import TextReader.Question.Model exposing (Question, TextQuestion)
+
+
+answerDecoder : Json.Decode.Decoder Answer
+answerDecoder =
+    Json.Decode.succeed Answer
+        |> required "id" Json.Decode.int
+        |> required "question_id" Json.Decode.int
+        |> required "text" Json.Decode.string
+        |> required "order" Json.Decode.int
+        |> required "answered_correctly" (Json.Decode.nullable Json.Decode.bool)
+        |> required "feedback" Json.Decode.string
+
+
+answersDecoder : Json.Decode.Decoder (Array Answer)
+answersDecoder =
+    Json.Decode.array answerDecoder
+
+
+questionDecoder : Json.Decode.Decoder Question
+questionDecoder =
+    Json.Decode.succeed Question
+        |> required "id" Json.Decode.int
+        |> required "text_section_id" Json.Decode.int
+        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        |> required "body" Json.Decode.string
+        |> required "order" Json.Decode.int
+        |> required "answers" answersDecoder
+        |> required "question_type" Json.Decode.string
+
+
+questionsDecoder : Json.Decode.Decoder (Array Question)
+questionsDecoder =
+    Json.Decode.array questionDecoder

--- a/web/src/TextReader/Question/Model.elm
+++ b/web/src/TextReader/Question/Model.elm
@@ -1,0 +1,57 @@
+module TextReader.Question.Model exposing (..)
+
+import Array exposing (Array)
+import DateTime exposing (DateTime)
+import TextReader.Answer.Model exposing (Answer, TextAnswer)
+
+
+type alias Question =
+    { id : Int
+    , text_section_id : Int
+    , created_dt : Maybe DateTime
+    , modified_dt : Maybe DateTime
+    , body : String
+    , order : Int
+    , answers : Array Answer
+    , question_type : String
+    }
+
+
+type alias AnsweredCorrectly =
+    Maybe Bool
+
+
+type TextQuestion
+    = TextQuestion Question AnsweredCorrectly (Array TextAnswer)
+
+
+initTextQuestion : Question -> TextQuestion
+initTextQuestion q =
+    TextQuestion q
+        Nothing
+        (Array.map TextReader.Answer.Model.initTextAnswer q.answers)
+
+
+answered : TextQuestion -> Bool
+answered text_question =
+    case answered_correctly text_question of
+        Just correct ->
+            correct
+
+        Nothing ->
+            False
+
+
+question : TextQuestion -> Question
+question (TextQuestion q _ _) =
+    q
+
+
+answers : TextQuestion -> Array TextAnswer
+answers (TextQuestion _ _ ans) =
+    ans
+
+
+answered_correctly : TextQuestion -> Maybe Bool
+answered_correctly (TextQuestion _ is_answered_correctly _) =
+    is_answered_correctly

--- a/web/src/TextReader/Section/Decode.elm
+++ b/web/src/TextReader/Section/Decode.elm
@@ -1,0 +1,57 @@
+module TextReader.Section.Decode exposing (..)
+
+import Array exposing (Array)
+import Dict exposing (Dict)
+import InstructorAdmin.Text.Translations exposing (..)
+import InstructorAdmin.Text.Translations.Decode as TranslationsDecode
+import Json.Decode
+import Json.Decode.Pipeline exposing (required)
+import TextReader.Question.Decode
+import TextReader.Section.Model exposing (Section, TextSection, Words)
+import TextReader.TextWord
+
+
+sectionDecoder : Json.Decode.Decoder Section
+sectionDecoder =
+    Json.Decode.map TextReader.Section.Model.newSection textSectionDecoder
+
+
+textWordTranslationDecoder : Json.Decode.Decoder TextReader.TextWord.Translation
+textWordTranslationDecoder =
+    Json.Decode.succeed TextReader.TextWord.Translation
+        |> required "correct_for_context" Json.Decode.bool
+        |> required "text" Json.Decode.string
+
+
+textWordTranslationsDecoder : Json.Decode.Decoder (Maybe (List TextReader.TextWord.Translation))
+textWordTranslationsDecoder =
+    Json.Decode.nullable (Json.Decode.list textWordTranslationDecoder)
+
+
+textWordInstanceDecoder : Json.Decode.Decoder TextReader.TextWord.TextWord
+textWordInstanceDecoder =
+    Json.Decode.map6 TextReader.TextWord.new
+        (Json.Decode.field "id" Json.Decode.int)
+        (Json.Decode.field "instance" Json.Decode.int)
+        (Json.Decode.field "phrase" Json.Decode.string)
+        (Json.Decode.field "grammemes"
+            (Json.Decode.nullable (Json.Decode.map Dict.fromList TranslationsDecode.grammemesDecoder))
+        )
+        (Json.Decode.field "translations" textWordTranslationsDecoder)
+        TranslationsDecode.wordDecoder
+
+
+textWordDictInstancesDecoder : Json.Decode.Decoder (Dict Phrase (Array TextReader.TextWord.TextWord))
+textWordDictInstancesDecoder =
+    Json.Decode.dict (Json.Decode.array textWordInstanceDecoder)
+
+
+textSectionDecoder : Json.Decode.Decoder TextSection
+textSectionDecoder =
+    Json.Decode.succeed TextSection
+        |> required "order" Json.Decode.int
+        |> required "body" Json.Decode.string
+        |> required "question_count" Json.Decode.int
+        |> required "questions" TextReader.Question.Decode.questionsDecoder
+        |> required "num_of_sections" Json.Decode.int
+        |> required "translations" textWordDictInstancesDecoder

--- a/web/src/TextReader/Section/Model.elm
+++ b/web/src/TextReader/Section/Model.elm
@@ -1,0 +1,94 @@
+module TextReader.Section.Model exposing (..)
+
+import Array exposing (Array)
+import Dict exposing (Dict)
+import InstructorAdmin.Text.Translations exposing (..)
+import TextReader.Question.Model exposing (Question, TextQuestion)
+import TextReader.TextWord exposing (TextWord)
+
+
+type Section
+    = Section TextSection (Array TextQuestion)
+
+
+type alias Words =
+    Dict String (Array TextWord)
+
+
+type alias TextSection =
+    { order : Int
+    , body : String
+    , question_count : Int
+    , questions : Array TextReader.Question.Model.Question
+    , num_of_sections : Int
+    , translations : Words
+    }
+
+
+emptyTextSection : TextSection
+emptyTextSection =
+    { order = 0
+    , body = ""
+    , question_count = 0
+    , questions = Array.fromList []
+    , num_of_sections = 0
+    , translations = Dict.empty
+    }
+
+
+getTextWords : Section -> Phrase -> Maybe (Array TextWord)
+getTextWords section phrase =
+    Dict.get phrase (translations section)
+
+
+getTextWord : Section -> Instance -> Phrase -> Maybe TextWord
+getTextWord section instance phrase =
+    case getTextWords section phrase of
+        Just text_words ->
+            Array.get instance text_words
+
+        -- word not found
+        Nothing ->
+            Nothing
+
+
+questions : Section -> Array TextQuestion
+questions (Section _ qs) =
+    qs
+
+
+textSection : Section -> TextSection
+textSection (Section text_section _) =
+    text_section
+
+
+translations : Section -> Words
+translations section =
+    (textSection section).translations
+
+
+newSection : TextSection -> Section
+newSection text_section =
+    Section text_section (Array.map TextReader.Question.Model.initTextQuestion text_section.questions)
+
+
+complete : Section -> Bool
+complete section =
+    List.all (\answered -> answered) <|
+        Array.toList <|
+            Array.map (\question -> TextReader.Question.Model.answered question) (questions section)
+
+
+score : Section -> Int
+score section =
+    List.sum <|
+        Array.toList <|
+            Array.map
+                (\question ->
+                    if Maybe.withDefault False (TextReader.Question.Model.answered_correctly question) then
+                        1
+
+                    else
+                        0
+                )
+                (questions section)

--- a/web/src/TextReader/Text/Decode.elm
+++ b/web/src/TextReader/Text/Decode.elm
@@ -1,0 +1,24 @@
+module TextReader.Text.Decode exposing (..)
+
+import DateTime
+import Json.Decode
+import Json.Decode.Extra exposing (posix)
+import Json.Decode.Pipeline exposing (required)
+import TextReader.Text.Model exposing (Text)
+
+
+textDecoder : Json.Decode.Decoder Text
+textDecoder =
+    Json.Decode.succeed Text
+        |> required "id" Json.Decode.int
+        |> required "title" Json.Decode.string
+        |> required "introduction" Json.Decode.string
+        |> required "author" Json.Decode.string
+        |> required "source" Json.Decode.string
+        |> required "difficulty" Json.Decode.string
+        |> required "conclusion" (Json.Decode.nullable Json.Decode.string)
+        |> required "created_by" (Json.Decode.nullable Json.Decode.string)
+        |> required "last_modified_by" (Json.Decode.nullable Json.Decode.string)
+        |> required "tags" (Json.Decode.nullable (Json.Decode.list Json.Decode.string))
+        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))

--- a/web/src/TextReader/Text/Model.elm
+++ b/web/src/TextReader/Text/Model.elm
@@ -1,0 +1,36 @@
+module TextReader.Text.Model exposing (..)
+
+import DateTime exposing (DateTime)
+
+
+type alias Text =
+    { id : Int
+    , title : String
+    , introduction : String
+    , author : String
+    , source : String
+    , difficulty : String
+    , conclusion : Maybe String
+    , created_by : Maybe String
+    , last_modified_by : Maybe String
+    , tags : Maybe (List String)
+    , created_dt : Maybe DateTime
+    , modified_dt : Maybe DateTime
+    }
+
+
+emptyText : Text
+emptyText =
+    { id = 0
+    , title = ""
+    , introduction = ""
+    , author = ""
+    , source = ""
+    , difficulty = ""
+    , conclusion = Nothing
+    , created_by = Nothing
+    , last_modified_by = Nothing
+    , tags = Nothing
+    , created_dt = Nothing
+    , modified_dt = Nothing
+    }

--- a/web/src/TextReader/TextWord.elm
+++ b/web/src/TextReader/TextWord.elm
@@ -1,0 +1,113 @@
+module TextReader.TextWord exposing (..)
+
+import Dict exposing (Dict)
+import InstructorAdmin.Text.Translations exposing (..)
+import InstructorAdmin.Text.Translations.TextWord as TranslationsTextWord
+import InstructorAdmin.Text.Translations.Word.Kind as TranslationsWordKind
+
+
+type alias Translation =
+    { correct_for_context : Bool
+    , text : String
+    }
+
+
+type alias Translations =
+    List Translation
+
+
+type alias TextWordParams =
+    { id : Int
+    , instance : Int
+    , phrase : String
+    , grammemes : Maybe (List ( String, String ))
+    , translations : Maybe Translations
+    , word : ( String, Maybe TextGroupDetails )
+    }
+
+
+type TextWord
+    = TextWord Int Instance Phrase (Maybe Grammemes) (Maybe Translations) TranslationsWordKind.WordKind
+
+
+instance : TextWord -> Instance
+instance (TextWord _ inst _ _ _ _) =
+    inst
+
+
+phrase : TextWord -> Phrase
+phrase (TextWord _ _ phr _ _ _) =
+    phr
+
+
+word : TextWord -> TranslationsWordKind.WordKind
+word (TextWord _ _ _ _ _ word_kind) =
+    word_kind
+
+
+wordType : TextWord -> String
+wordType text_word =
+    TranslationsTextWord.wordTypeToString (word text_word)
+
+
+group : TextWord -> Maybe TextGroupDetails
+group (TextWord _ _ _ _ _ w) =
+    TranslationsTextWord.wordKindToGroup w
+
+
+grammemes : TextWord -> Maybe Grammemes
+grammemes (TextWord _ _ _ grams _ _) =
+    grams
+
+
+grammemesToString : TextWord -> String
+grammemesToString text_word =
+    case grammemes text_word of
+        Just grs ->
+            String.join ", " <|
+                List.map (\( g, v ) -> g ++ ": " ++ v) <|
+                    Dict.toList grs
+
+        Nothing ->
+            ""
+
+
+hasTranslations : TextWord -> Bool
+hasTranslations text_word =
+    case translations text_word of
+        Just trs ->
+            True
+
+        Nothing ->
+            False
+
+
+translations : TextWord -> Maybe Translations
+translations (TextWord _ _ _ _ trans _) =
+    trans
+
+
+new : Int -> Instance -> Phrase -> Maybe Grammemes -> Maybe Translations -> TranslationsWordKind.WordKind -> TextWord
+new id inst phr grams trans w =
+    TextWord id inst phr grams trans w
+
+
+newGrammemeFromList : Maybe (List ( String, String )) -> Grammemes
+newGrammemeFromList grams =
+    case grams of
+        Just grs ->
+            Dict.fromList grs
+
+        Nothing ->
+            Dict.empty
+
+
+newFromParams : TextWordParams -> TextWord
+newFromParams params =
+    TextWord
+        params.id
+        params.instance
+        params.phrase
+        (Just (newGrammemeFromList params.grammemes))
+        params.translations
+        (TranslationsTextWord.strToWordType params.word)

--- a/web/src/TextReader/Update.elm
+++ b/web/src/TextReader/Update.elm
@@ -1,0 +1,43 @@
+module TextReader.Update exposing (..)
+
+import Json.Decode
+import TextReader.Decode
+import TextReader.Model exposing (..)
+import TextReader.Msg exposing (Msg(..))
+import User.Profile.TextReader.Flashcards
+
+
+routeCmdResp : Model -> CmdResp -> ( Model, Cmd Msg )
+routeCmdResp model cmd_resp =
+    case cmd_resp of
+        StartResp text ->
+            ( { model | text = text, exception = Nothing, progress = ViewIntro }, Cmd.none )
+
+        InProgressResp section ->
+            ( { model | exception = Nothing, progress = ViewSection section }, Cmd.none )
+
+        CompleteResp text_scores ->
+            ( { model | exception = Nothing, progress = Complete text_scores }, Cmd.none )
+
+        AddToFlashcardsResp text_word ->
+            ( { model | flashcard = User.Profile.TextReader.Flashcards.addFlashcard model.flashcard text_word }, Cmd.none )
+
+        RemoveFromFlashcardsResp text_word ->
+            ( { model | flashcard = User.Profile.TextReader.Flashcards.removeFlashcard model.flashcard text_word }, Cmd.none )
+
+        ExceptionResp exception ->
+            ( { model | exception = Just exception }, Cmd.none )
+
+
+handleWSResp : Model -> String -> ( Model, Cmd Msg )
+handleWSResp model str =
+    case Json.Decode.decodeString TextReader.Decode.wsRespDecoder str of
+        Ok cmd_resp ->
+            routeCmdResp model cmd_resp
+
+        Err err ->
+            let
+                _ =
+                    Debug.log "websocket decode error" err
+            in
+            ( model, Cmd.none )

--- a/web/src/TextReader/View.elm
+++ b/web/src/TextReader/View.elm
@@ -1,0 +1,337 @@
+module TextReader.View exposing (..)
+
+import Array exposing (Array)
+import Dict exposing (Dict)
+import Html exposing (Html, div, span)
+import Html.Attributes exposing (attribute, class, classList, id)
+import Html.Events exposing (onClick, onMouseLeave)
+import HtmlParser
+import HtmlParser.Util
+import Text.Section.Words.Tag
+import TextReader.Answer.Model exposing (TextAnswer)
+import TextReader.Model exposing (..)
+import TextReader.Msg exposing (Msg(..))
+import TextReader.Question.Model exposing (TextQuestion)
+import TextReader.Section.Model exposing (Section, Words)
+import TextReader.Text.Model exposing (Text)
+import TextReader.TextWord
+import User.Profile.TextReader.Flashcards
+import VirtualDom
+
+
+tagWord : Model -> Section -> Int -> String -> Html Msg
+tagWord model text_reader_section instance token =
+    let
+        id =
+            String.join "_" [ String.fromInt instance, token ]
+
+        textreader_textword =
+            TextReader.Section.Model.getTextWord text_reader_section instance token
+
+        reader_word =
+            TextReader.Model.new id instance token textreader_textword
+    in
+    case token == " " of
+        True ->
+            VirtualDom.text token
+
+        False ->
+            case textreader_textword of
+                Just text_word ->
+                    if TextReader.TextWord.hasTranslations text_word then
+                        view_defined_word model reader_word text_word token
+
+                    else
+                        VirtualDom.text token
+
+                Nothing ->
+                    VirtualDom.text token
+
+
+view_defined_word : Model -> TextReader.Model.TextReaderWord -> TextReader.TextWord.TextWord -> String -> Html Msg
+view_defined_word model reader_word text_word token =
+    Html.node "span"
+        [ classList
+            [ ( "defined-word", True )
+            , ( "cursor", True )
+            ]
+        , onClick (ToggleGloss reader_word)
+        ]
+        [ span [ classList [ ( "highlighted", TextReader.Model.glossed reader_word model.gloss ) ] ]
+            [ VirtualDom.text token
+            ]
+        , view_gloss model reader_word text_word
+        ]
+
+
+view_answer : Section -> TextQuestion -> TextAnswer -> Html Msg
+view_answer text_section text_question text_answer =
+    let
+        question_answered =
+            TextReader.Question.Model.answered text_question
+
+        on_click =
+            if question_answered then
+                onClick (ViewFeedback text_section text_question text_answer True)
+
+            else
+                onClick (Select text_answer)
+
+        answer =
+            TextReader.Answer.Model.answer text_answer
+
+        answer_selected =
+            TextReader.Answer.Model.selected text_answer
+
+        is_correct =
+            TextReader.Answer.Model.correct text_answer
+
+        view_feedback =
+            TextReader.Answer.Model.feedback_viewable text_answer
+    in
+    div
+        [ classList <|
+            [ ( "answer", True )
+            , ( "answer-selected", answer_selected )
+            ]
+                ++ (if answer_selected || view_feedback then
+                        if is_correct then
+                            [ ( "correct", is_correct ) ]
+
+                        else
+                            [ ( "incorrect", not is_correct ) ]
+
+                    else
+                        []
+                   )
+        , on_click
+        ]
+        [ div [ classList [ ( "answer-text", True ), ( "bolder", answer_selected ) ] ] [ Html.text answer.text ]
+        , if answer_selected || view_feedback then
+            div [ class "answer-feedback" ] [ Html.em [] [ Html.text answer.feedback ] ]
+
+          else
+            Html.text ""
+        ]
+
+
+view_question : Section -> TextQuestion -> Html Msg
+view_question text_section text_question =
+    let
+        question =
+            TextReader.Question.Model.question text_question
+
+        answers =
+            TextReader.Question.Model.answers text_question
+
+        text_question_id =
+            String.join "_" [ "question", String.fromInt question.order ]
+    in
+    div [ class "question", attribute "id" text_question_id ]
+        [ div [ class "question-body" ] [ Html.text question.body ]
+        , div [ class "answers" ]
+            (Array.toList <| Array.map (view_answer text_section text_question) answers)
+        ]
+
+
+view_questions : Section -> Html Msg
+view_questions section =
+    let
+        text_reader_questions =
+            TextReader.Section.Model.questions section
+    in
+    div [ id "questions" ] (Array.toList <| Array.map (view_question section) text_reader_questions)
+
+
+view_translation : TextReader.TextWord.Translation -> Html Msg
+view_translation translation =
+    div [ class "translation" ] [ Html.text translation.text ]
+
+
+view_translations : Maybe (List TextReader.TextWord.Translation) -> Html Msg
+view_translations defs =
+    div [ class "translations" ]
+        (case defs of
+            Just translations ->
+                List.map view_translation (List.filter (\tr -> tr.correct_for_context) translations)
+
+            Nothing ->
+                []
+        )
+
+
+view_word_and_grammemes : TextReaderWord -> TextReader.TextWord.TextWord -> Html Msg
+view_word_and_grammemes reader_word text_word =
+    div []
+        [ Html.text <| TextReader.Model.phrase reader_word ++ " (" ++ TextReader.TextWord.grammemesToString text_word ++ ")"
+        ]
+
+
+view_flashcard_words : Model -> Html Msg
+view_flashcard_words model =
+    div []
+        (List.map (\( normal_form, text_word ) -> div [] [ Html.text normal_form ])
+            (Dict.toList <| Maybe.withDefault Dict.empty <| User.Profile.TextReader.Flashcards.flashcards model.flashcard)
+        )
+
+
+view_flashcard_options : Model -> TextReaderWord -> Html Msg
+view_flashcard_options model reader_word =
+    let
+        phrase =
+            TextReader.Model.phrase reader_word
+
+        flashcards =
+            Maybe.withDefault Dict.empty (User.Profile.TextReader.Flashcards.flashcards model.flashcard)
+
+        add =
+            div [ class "cursor", onClick (AddToFlashcards reader_word) ] [ Html.text "Add to Flashcards" ]
+
+        remove =
+            div [ class "cursor", onClick (RemoveFromFlashcards reader_word) ] [ Html.text "Remove from Flashcards" ]
+    in
+    div [ class "gloss-flashcard-options" ]
+        (if Dict.member phrase flashcards then
+            [ remove ]
+
+         else
+            [ add ]
+        )
+
+
+view_gloss : Model -> TextReaderWord -> TextReader.TextWord.TextWord -> Html Msg
+view_gloss model reader_word text_word =
+    span []
+        [ span
+            [ classList [ ( "gloss-overlay", True ), ( "gloss-menu", True ) ]
+            , onMouseLeave (UnGloss reader_word)
+            , classList [ ( "hidden", not (TextReader.Model.selected reader_word model.gloss) ) ]
+            ]
+            [ view_word_and_grammemes reader_word text_word
+            , view_translations (TextReader.TextWord.translations text_word)
+            , view_flashcard_options model reader_word
+            ]
+        ]
+
+
+isPartOfCompoundWord : Section -> Int -> String -> Maybe ( Int, Int, Int )
+isPartOfCompoundWord section instance word =
+    case TextReader.Section.Model.getTextWord section instance word of
+        Just text_word ->
+            case TextReader.TextWord.group text_word of
+                Just group ->
+                    Just ( group.instance, group.pos, group.length )
+
+                Nothing ->
+                    Nothing
+
+        Nothing ->
+            Nothing
+
+
+view_text_section : Model -> Section -> Html Msg
+view_text_section model text_reader_section =
+    let
+        text_section =
+            TextReader.Section.Model.textSection text_reader_section
+
+        text_body_vdom =
+            Text.Section.Words.Tag.tagWordsAndToVDOM
+                (tagWord model text_reader_section)
+                (isPartOfCompoundWord text_reader_section)
+                (HtmlParser.parse text_section.body)
+
+        section_title =
+            "Section " ++ String.fromInt (text_section.order + 1) ++ "/" ++ String.fromInt text_section.num_of_sections
+    in
+    div [ id "text-body" ] <|
+        [ div [ id "title" ] [ Html.text section_title ]
+        , div [ id "body" ] text_body_vdom
+        , view_questions text_reader_section
+        ]
+
+
+view_text_introduction : Text -> Html Msg
+view_text_introduction text =
+    div [ attribute "id" "text-intro" ] (HtmlParser.Util.toVirtualDom <| HtmlParser.parse text.introduction)
+
+
+view_text_conclusion : Text -> Html Msg
+view_text_conclusion text =
+    div [ attribute "id" "text-conclusion" ]
+        (HtmlParser.Util.toVirtualDom <| HtmlParser.parse (Maybe.withDefault "" text.conclusion))
+
+
+view_prev_btn : Html Msg
+view_prev_btn =
+    div [ onClick PrevSection, class "prev-btn" ]
+        [ Html.text "Previous"
+        ]
+
+
+view_next_btn : Html Msg
+view_next_btn =
+    div [ onClick NextSection, class "next-btn" ]
+        [ Html.text "Next"
+        ]
+
+
+view_text_complete : Model -> TextScores -> Html Msg
+view_text_complete model scores =
+  div [id "complete"] [
+    div [attribute "id" "text-score"] [
+      div [] [
+        Html.text
+          (  "You answered "
+          ++ (toString scores.section_scores)
+          ++ " out of "
+          ++ (toString scores.possible_section_scores)
+          ++ " questions correctly for this text.")
+      ]
+    ]
+  , view_text_conclusion model.text
+  , div [id "nav"] [
+      view_prev_btn
+    , div [onClick StartOver] [ Html.text "Start Over" ]
+    ]
+  ]
+
+
+view_exceptions : Model -> Html Msg
+view_exceptions model =
+    div [ class "exception" ]
+        (case model.exception of
+            Just exception ->
+                [ Html.text exception.error_msg
+                ]
+
+            Nothing ->
+                []
+        )
+
+
+view_content : Model -> Html Msg
+view_content model =
+    let
+        content =
+            case model.progress of
+                ViewIntro ->
+                    [ view_text_introduction model.text
+                    , div [ id "nav", onClick NextSection ]
+                        [ div [ class "start-btn" ] [ Html.text "Start" ]
+                        ]
+                    ]
+
+                ViewSection section ->
+                    [ view_text_section model section
+                    , view_exceptions model
+                    , div [ id "nav" ] [ view_prev_btn, view_next_btn ]
+                    ]
+
+                Complete text_scores ->
+                    [ view_text_complete model text_scores ]
+
+                _ ->
+                    []
+    in
+    div [ id "text-section" ] content

--- a/web/src/TextReader/WebSocket.elm
+++ b/web/src/TextReader/WebSocket.elm
@@ -1,0 +1,50 @@
+port module TextReader.WebSocket exposing (..)
+
+import TextReader.Msg exposing (Msg(..))
+import TextReader.Model
+import TextReader.Encode
+
+import Json.Decode
+import Json.Encode
+
+import WebSocket
+
+port receiveSocketMsg : (Json.Decode.Value -> msg) -> Sub msg
+port sendSocketCommand : Json.Encode.Value -> Cmd msg
+
+wsReceive = receiveSocketMsg <| WebSocket.receive WebSocketResp
+wsSend = WebSocket.send sendSocketCommand
+
+
+type WebSocketAddress
+    = WebSocketAddress String
+
+
+webSocketName : String
+webSocketName =
+    "textreader"
+
+toString : WebSocketAddress -> String
+toString (WebSocketAddress addr) =
+    addr
+
+toAddress : String -> WebSocketAddress
+toAddress addr =
+    WebSocketAddress addr
+
+listen : Sub Msg
+listen =
+    wsReceive
+
+connect : WebSocketAddress -> String -> Cmd Msg
+connect address protocol =
+    wsSend <| WebSocket.Connect {name = webSocketName, address = toString address, protocol = protocol}
+
+disconnect : Cmd Msg
+disconnect =
+    wsSend <| WebSocket.Close {name = webSocketName}
+
+sendCommand : TextReader.Model.CmdReq -> Cmd Msg
+sendCommand cmdReq =
+      wsSend
+   <| WebSocket.Send {name = webSocketName, content = TextReader.Encode.commandRequestToString cmdReq}

--- a/web/src/TextSearch.elm
+++ b/web/src/TextSearch.elm
@@ -1,0 +1,564 @@
+module TextSearch exposing (Flags, Model, Msg(..), init, main, subscriptions, update, updateResults, view, view_content, view_difficulties, view_difficulty_filter_hint, view_help_msg, view_search_filters, view_search_footer, view_search_results, view_status_filter_hint, view_statuses, view_tags, view_topic_filter_hint)
+
+import Browser
+import Dict exposing (Dict)
+import Help.View exposing (ArrowPlacement(..), ArrowPosition(..))
+import Html exposing (Html, div, option)
+import Html.Attributes exposing (attribute, class, classList, id)
+import Html.Events exposing (onClick)
+import Http exposing (..)
+import InstructorAdmin.Admin.Text as AdminText
+import Menu.Items
+import Menu.Logout
+import Menu.Msg as MenuMsg
+import Ports exposing (clearInputText)
+import Profile.Flags as Flags
+import Student.Profile
+import Text.Decode
+import Text.Model exposing (Text)
+import Text.Search exposing (TextSearch)
+import Text.Search.Difficulty exposing (DifficultySearch)
+import Text.Search.Option
+import Text.Search.ReadingStatus exposing (TextReadStatus, TextReadStatusSearch)
+import Text.Search.Tag exposing (TagSearch)
+import TextSearch.Help exposing (TextSearchHelp)
+import User.Profile
+import Utils.Date
+import Views
+
+
+
+-- UPDATE
+
+
+type Msg
+    = AddDifficulty String Bool
+    | SelectTag String Bool
+    | SelectStatus TextReadStatus Bool
+    | TextSearch (Result Http.Error (List Text.Model.TextListItem))
+      -- help messages
+    | CloseHelp TextSearch.Help.TextHelp
+    | PrevHelp
+    | NextHelp
+      -- site-wide messages
+    | LogOut MenuMsg.Msg
+    | LoggedOut (Result Http.Error Menu.Logout.LogOutResp)
+
+
+type alias Flags =
+    Flags.Flags
+        { text_difficulties : List Text.Model.TextDifficulty
+        , text_statuses : List ( String, String )
+        , text_api_endpoint_url : String
+        , welcome : Bool
+        , text_tags : List String
+        }
+
+
+type alias Model =
+    { results : List Text.Model.TextListItem
+    , profile : User.Profile.Profile
+    , menu_items : Menu.Items.MenuItems
+    , text_search : TextSearch
+    , text_api_endpoint : AdminText.TextAPIEndpoint
+    , help : TextSearch.Help.TextSearchHelp
+    , error_msg : Maybe String
+    , flags : Flags
+    }
+
+
+init : Flags -> ( Model, Cmd Msg )
+init flags =
+    let
+        tag_search =
+            Text.Search.Tag.new "text_tag_search"
+                (Text.Search.Option.newOptions (List.map (\tag -> ( tag, tag )) flags.text_tags))
+
+        difficulty_search =
+            Text.Search.Difficulty.new "text_difficulty_search" (Text.Search.Option.newOptions flags.text_difficulties)
+
+        profile =
+            User.Profile.initProfile flags
+
+        status_search =
+            Text.Search.ReadingStatus.new "text_status_search" (Text.Search.Option.newOptions flags.text_statuses)
+
+        text_api_endpoint =
+            AdminText.TextAPIEndpoint (AdminText.URL flags.text_api_endpoint_url)
+
+        default_search =
+            Text.Search.new text_api_endpoint tag_search difficulty_search status_search
+
+        text_search =
+            case profile of
+                User.Profile.Student student_profile ->
+                    case Student.Profile.studentDifficultyPreference student_profile of
+                        Just difficulty ->
+                            Text.Search.addDifficultyToSearch default_search (Tuple.first difficulty) True
+
+                        _ ->
+                            default_search
+
+                _ ->
+                    default_search
+
+        text_search_help =
+            TextSearch.Help.init
+
+        menu_items =
+            Menu.Items.initMenuItems flags
+    in
+    ( { results = []
+      , profile = profile
+      , menu_items = menu_items
+      , text_search = text_search
+      , text_api_endpoint = text_api_endpoint
+      , help = text_search_help
+      , error_msg = Nothing
+      , flags = flags
+      }
+    , updateResults text_api_endpoint text_search
+    )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none
+
+
+updateResults : AdminText.TextAPIEndpoint -> TextSearch -> Cmd Msg
+updateResults text_api_endpoint text_search =
+    let
+        text_api_endpoint_url =
+            AdminText.textEndpointToString text_api_endpoint
+
+        filter_params =
+            Text.Search.filterParams text_search
+
+        query_string =
+            String.join "" [ text_api_endpoint_url, "?" ] ++ String.join "&" filter_params
+
+        request =
+            Http.get query_string Text.Decode.textListDecoder
+    in
+    if List.length filter_params > 0 then
+        Http.send TextSearch request
+
+    else
+        Cmd.none
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        AddDifficulty difficulty select ->
+            let
+                new_text_search =
+                    Text.Search.addDifficultyToSearch model.text_search difficulty select
+            in
+            ( { model | text_search = new_text_search, results = [] }, updateResults model.text_api_endpoint new_text_search )
+
+        SelectStatus status selected ->
+            let
+                status_search =
+                    Text.Search.statusSearch model.text_search
+
+                new_status_search =
+                    Text.Search.ReadingStatus.selectStatus status_search status selected
+
+                new_text_search =
+                    Text.Search.setStatusSearch model.text_search new_status_search
+            in
+            ( { model | text_search = new_text_search, results = [] }, updateResults model.text_api_endpoint new_text_search )
+
+        SelectTag tag_name selected ->
+            let
+                tag_search =
+                    Text.Search.tagSearch model.text_search
+
+                tag_search_input_id =
+                    Text.Search.Tag.inputID tag_search
+
+                new_tag_search =
+                    Text.Search.Tag.select_tag tag_search tag_name selected
+
+                new_text_search =
+                    Text.Search.setTagSearch model.text_search new_tag_search
+            in
+            ( { model | text_search = new_text_search, results = [] }
+            , Cmd.batch [ clearInputText tag_search_input_id, updateResults model.text_api_endpoint new_text_search ]
+            )
+
+        TextSearch result ->
+            case result of
+                Ok texts ->
+                    ( { model | results = texts }, Cmd.none )
+
+                Err err ->
+                    let
+                        _ =
+                            Debug.log "error retrieving results" err
+                    in
+                    ( { model | error_msg = Just "An error occurred.  Please contact an administrator." }, Cmd.none )
+
+        CloseHelp help_msg ->
+            ( { model | help = TextSearch.Help.setVisible model.help help_msg False }, Cmd.none )
+
+        PrevHelp ->
+            ( { model | help = TextSearch.Help.prev model.help }, TextSearch.Help.scrollToPrevMsg model.help )
+
+        NextHelp ->
+            ( { model | help = TextSearch.Help.next model.help }, TextSearch.Help.scrollToNextMsg model.help )
+
+        LogOut _ ->
+            ( model, User.Profile.logout model.profile model.flags.csrftoken LoggedOut )
+
+        LoggedOut (Ok logout_resp) ->
+            ( model, Ports.redirect logout_resp.redirect )
+
+        LoggedOut (Err err) ->
+            ( model, Cmd.none )
+
+
+main : Program Flags Model Msg
+main =
+    Browser.element
+        { init = init
+        , view = view
+        , subscriptions = subscriptions
+        , update = update
+        }
+
+
+view_tags : TagSearch -> Html Msg
+view_tags tag_search =
+    let
+        tags =
+            Text.Search.Tag.optionsToDict tag_search
+
+        tag_search_id =
+            Text.Search.Tag.inputID tag_search
+
+        view_tag tag_search_option =
+            let
+                selected =
+                    Text.Search.Option.selected tag_search_option
+
+                tag_value =
+                    Text.Search.Option.value tag_search_option
+
+                tag_label =
+                    Text.Search.Option.label tag_search_option
+            in
+            div
+                [ onClick (SelectTag tag_value (not selected))
+                , classList
+                    [ ( "text_tag", True )
+                    , ( "text_tag_selected", selected )
+                    ]
+                ]
+                [ Html.text tag_label
+                ]
+    in
+    div [ id "text_tags" ]
+        [ div [ class "text_tags" ] (List.map view_tag (Dict.values tags))
+        ]
+
+
+view_difficulties : DifficultySearch -> List (Html Msg)
+view_difficulties difficulty_search =
+    let
+        difficulties =
+            Text.Search.Difficulty.options difficulty_search
+
+        view_difficulty difficulty_search_option =
+            let
+                selected =
+                    Text.Search.Option.selected difficulty_search_option
+
+                value =
+                    Text.Search.Option.value difficulty_search_option
+
+                label =
+                    Text.Search.Option.label difficulty_search_option
+            in
+            div
+                [ classList [ ( "difficulty_option", True ), ( "difficulty_option_selected", selected ) ]
+                , onClick (AddDifficulty value (not selected))
+                ]
+                [ Html.text label
+                ]
+    in
+    List.map view_difficulty difficulties
+
+
+view_statuses : TextReadStatusSearch -> List (Html Msg)
+view_statuses status_search =
+    let
+        statuses =
+            Text.Search.ReadingStatus.options status_search
+
+        view_status ( value, status_option ) =
+            let
+                selected =
+                    Text.Search.Option.selected status_option
+
+                label =
+                    Text.Search.Option.label status_option
+
+                status =
+                    Text.Search.ReadingStatus.valueToStatus value
+            in
+            div
+                [ classList [ ( "text_status", True ), ( "text_status_option_selected", selected ) ]
+                , onClick (SelectStatus status (not selected))
+                ]
+                [ Html.text label
+                ]
+    in
+    List.map view_status <| List.map (\option -> ( Text.Search.Option.value option, option )) statuses
+
+
+view_search_filters : Model -> Html Msg
+view_search_filters model =
+    div [ id "text_search_filters" ]
+        [ div [ id "text_search_filters_label" ] [ Html.text "Filters" ]
+        , div [ class "search_filter" ] <|
+            [ div [ class "search_filter_title" ] [ Html.text "Difficulty" ]
+            , div [] (view_difficulties (Text.Search.difficultySearch model.text_search))
+            ]
+                ++ view_difficulty_filter_hint model
+        , div [ class "search_filter" ]
+            [ div [ class "search_filter_title" ] [ Html.text "Tags" ]
+            , div [] <| [ view_tags (Text.Search.tagSearch model.text_search) ] ++ view_topic_filter_hint model
+            ]
+        , div [ class "search_filter" ] <|
+            [ div [ class "search_filter_title" ] [ Html.text "Read Status" ]
+            , div [] (view_statuses (Text.Search.statusSearch model.text_search))
+            ]
+                ++ view_status_filter_hint model
+        ]
+
+
+view_search_results : List Text.Model.TextListItem -> Html Msg
+view_search_results textListItems =
+    let
+        view_search_result textItem =
+            let
+                commaDelimitedTags =
+                    case textItem.tags of
+                        Just tags ->
+                            String.join ", " tags
+
+                        Nothing ->
+                            ""
+
+                sectionsCompleted =
+                    case textItem.text_sections_complete of
+                        Just sections_complete ->
+                            String.fromInt sections_complete ++ " / " ++ String.fromInt textItem.text_section_count
+
+                        Nothing ->
+                            "0 / " ++ String.fromInt textItem.text_section_count
+
+                lastRead =
+                    case textItem.last_read_dt of
+                        Just dt ->
+                            Utils.Date.monthDayYearFormat dt
+
+                        Nothing ->
+                            ""
+
+                questionsCorrect =
+                    case textItem.questions_correct of
+                        Just correct ->
+                            String.fromInt (Tuple.first correct) ++ " out of " ++ String.fromInt (Tuple.second correct)
+
+                        Nothing ->
+                            "None"
+            in
+            div [ class "search_result" ]
+                [ div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.a [ attribute "href" textItem.uri ] [ Html.text textItem.title ] ]
+                    , div [ class "sub_description" ] [ Html.text "Title" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text textItem.difficulty ]
+                    , div [ class "sub_description" ] [ Html.text "Difficulty" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text textItem.author ]
+                    , div [ class "sub_description" ] [ Html.text "Author" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text sectionsCompleted ]
+                    , div [ class "sub_description" ] [ Html.text "Sections Complete" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text commaDelimitedTags ]
+                    , div [ class "sub_description" ] [ Html.text "Tags" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text lastRead ]
+                    , div [ class "sub_description" ] [ Html.text "Last Read" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text questionsCorrect ]
+                    , div [ class "sub_description" ] [ Html.text "Questions Correct" ]
+                    ]
+                ]
+    in
+    div [ id "text_search_results" ] (List.map view_search_result textListItems)
+
+
+view_search_footer : Model -> Html Msg
+view_search_footer model =
+    let
+        results_length =
+            List.length model.results
+
+        entries =
+            if results_length == 1 then
+                "entry"
+
+            else
+                "entries"
+
+        success_txt =
+            String.join " " [ "Showing", String.fromInt results_length, entries ]
+
+        txt =
+            case model.error_msg of
+                Just msg ->
+                    msg
+
+                Nothing ->
+                    success_txt
+    in
+    div [ id "footer_items" ]
+        [ div [ id "footer", class "message" ]
+            [ Html.text txt
+            ]
+        ]
+
+
+view_help_msg : Model -> Html Msg
+view_help_msg model =
+    div [ id "text_search_help_msg" ]
+        [ div []
+            [ Html.text "Welcome."
+            ]
+        , div []
+            [ Html.text
+                """Use this page to find texts for your proficiency level and on topics that are of interest to you."""
+            ]
+        , div []
+            [ Html.text
+                """To walk through a demonstration of how the text and questions appear, please select Intermediate-Mid
+       from the Difficulty tags and then Other from the the Topic tags, and Unread from the Status Filters.
+       A text entitled Demo Text should appear at the top of the list.  Click on the title to go to this text."""
+            ]
+        ]
+
+
+view_topic_filter_hint : Model -> List (Html Msg)
+view_topic_filter_hint model =
+    let
+        topic_filter_help =
+            TextSearch.Help.topic_filter_help
+
+        hint_attributes =
+            { id = TextSearch.Help.popupToID topic_filter_help
+            , visible = TextSearch.Help.isVisible model.help topic_filter_help
+            , text = TextSearch.Help.helpMsg topic_filter_help
+            , cancel_event = onClick (CloseHelp topic_filter_help)
+            , next_event = onClick NextHelp
+            , prev_event = onClick PrevHelp
+            , addl_attributes = [ class "difficulty_filter_hint" ]
+            , arrow_placement = ArrowUp ArrowLeft
+            }
+    in
+    if model.flags.welcome then
+        [ Help.View.view_hint_overlay hint_attributes
+        ]
+
+    else
+        []
+
+
+view_difficulty_filter_hint : Model -> List (Html Msg)
+view_difficulty_filter_hint model =
+    let
+        difficulty_filter_help =
+            TextSearch.Help.difficulty_filter_help
+
+        hint_attributes =
+            { id = TextSearch.Help.popupToID difficulty_filter_help
+            , visible = TextSearch.Help.isVisible model.help difficulty_filter_help
+            , text = TextSearch.Help.helpMsg difficulty_filter_help
+            , cancel_event = onClick (CloseHelp difficulty_filter_help)
+            , next_event = onClick NextHelp
+            , prev_event = onClick PrevHelp
+            , addl_attributes = [ class "difficulty_filter_hint" ]
+            , arrow_placement = ArrowUp ArrowLeft
+            }
+    in
+    if model.flags.welcome then
+        [ Help.View.view_hint_overlay hint_attributes
+        ]
+
+    else
+        []
+
+
+view_status_filter_hint : Model -> List (Html Msg)
+view_status_filter_hint model =
+    let
+        status_filter_help =
+            TextSearch.Help.status_filter_help
+
+        hint_attributes =
+            { id = TextSearch.Help.popupToID status_filter_help
+            , visible = TextSearch.Help.isVisible model.help status_filter_help
+            , text = TextSearch.Help.helpMsg status_filter_help
+            , cancel_event = onClick (CloseHelp status_filter_help)
+            , next_event = onClick NextHelp
+            , prev_event = onClick PrevHelp
+            , addl_attributes = [ class "status_filter_hint" ]
+            , arrow_placement = ArrowUp ArrowLeft
+            }
+    in
+    if model.flags.welcome then
+        [ Help.View.view_hint_overlay hint_attributes
+        ]
+
+    else
+        []
+
+
+view_content : Model -> Html Msg
+view_content model =
+    div [ id "text_search" ] <|
+        (if model.flags.welcome then
+            [ view_help_msg model ]
+
+         else
+            []
+        )
+            ++ [ view_search_filters model
+               , view_search_results model.results
+               , view_search_footer model
+               ]
+
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model =
+    div []
+        [ Views.view_authed_header model.profile model.menu_items LogOut
+        , view_content model
+        , Views.view_footer
+        ]

--- a/web/src/TextSearch/Help.elm
+++ b/web/src/TextSearch/Help.elm
@@ -1,0 +1,120 @@
+module TextSearch.Help exposing (..)
+
+import Help exposing (CurrentHelpMsgIndex, HelpMsgID, HelpMsgOverlayID, HelpMsgStr, HelpMsgVisible)
+import Help.PopUp exposing (Help)
+
+
+type TextHelp
+    = DifficultyFilterHelp HelpMsgStr
+    | TopicFilterHelp HelpMsgStr
+    | StatusFilterHelp HelpMsgStr
+
+
+type TextSearchHelp
+    = TextSearchHelp (Help TextHelp)
+
+
+difficulty_filter_help : TextHelp
+difficulty_filter_help =
+    DifficultyFilterHelp
+        """The preferred difficulty that you selected on your User page is pre-selected here.
+     You can choose additional difficulty levels or deselect difficulty levels as you please."""
+
+
+topic_filter_help : TextHelp
+topic_filter_help =
+    TopicFilterHelp
+        """Click on topics that interest you from this list of tags in order to see a list of texts that deal with these
+     topics."""
+
+
+status_filter_help : TextHelp
+status_filter_help =
+    StatusFilterHelp
+        """As you use this site, texts will be sorted into three categories: Unread (ones that you’ve not yet read),
+     In Progress (those that you started but haven’t finished), and Previously Read (ones that you’ve read before).
+     You can access and (re)read any of these texts at any time."""
+
+
+helpMsg : TextHelp -> HelpMsgStr
+helpMsg help_msg =
+    case help_msg of
+        DifficultyFilterHelp h ->
+            h
+
+        TopicFilterHelp h ->
+            h
+
+        StatusFilterHelp h ->
+            h
+
+
+popupToOverlayID : TextHelp -> HelpMsgOverlayID
+popupToOverlayID help_popup =
+    popupToID help_popup ++ "_overlay"
+
+
+popupToID : TextHelp -> HelpMsgID
+popupToID help_popup =
+    case help_popup of
+        DifficultyFilterHelp _ ->
+            "difficulty_filter_hint"
+
+        TopicFilterHelp _ ->
+            "topic_filter_hint"
+
+        StatusFilterHelp _ ->
+            "status_filter_hint"
+
+
+help_msgs : List TextHelp
+help_msgs =
+    [ difficulty_filter_help
+    , topic_filter_help
+    , status_filter_help
+    ]
+
+
+init : TextSearchHelp
+init =
+    TextSearchHelp (Help.PopUp.init help_msgs popupToOverlayID popupToID)
+
+
+help : TextSearchHelp -> Help TextHelp
+help (TextSearchHelp student_help) =
+    student_help
+
+
+setVisible : TextSearchHelp -> TextHelp -> HelpMsgVisible -> TextSearchHelp
+setVisible student_profile_help help_msg visible =
+    TextSearchHelp (Help.PopUp.setVisible (help student_profile_help) help_msg visible)
+
+
+isVisible : TextSearchHelp -> TextHelp -> HelpMsgVisible
+isVisible student_profile_help msg =
+    Help.PopUp.isVisible (help student_profile_help) msg
+
+
+scrollToNextMsg : TextSearchHelp -> Cmd msg
+scrollToNextMsg student_profile_help =
+    Help.PopUp.scrollToNextMsg (help student_profile_help)
+
+
+scrollToPrevMsg : TextSearchHelp -> Cmd msg
+scrollToPrevMsg student_profile_help =
+    Help.PopUp.scrollToPrevMsg (help student_profile_help)
+
+
+next : TextSearchHelp -> TextSearchHelp
+next student_profile_help =
+    TextSearchHelp (Help.PopUp.next (help student_profile_help))
+
+
+prev : TextSearchHelp -> TextSearchHelp
+prev student_profile_help =
+    TextSearchHelp (Help.PopUp.prev (help student_profile_help))
+
+
+scrollToFirstMsg : TextSearchHelp -> Cmd msg
+scrollToFirstMsg student_profile_help =
+    Help.PopUp.scrollToFirstMsg (help student_profile_help)


### PR DESCRIPTION
This PR moves the text modules from `text/ui/` into the SPA directory and renames imports as needed. It also adds `PanagiotisGeorgiadis/elm-datetime` and `waratuman/json-extra` back in as dependencies.

Note that this doesn't complete #126 because the `Text.elm` page still needs to be added. Adding this page is blocked by #107 and #128 (i.e. authentication and a few imports).