### PR TITLE
Add HTTP wrapper replacements for HttpHelpers

### DIFF
--- a/web/src/Api.elm
+++ b/web/src/Api.elm
@@ -6,10 +6,13 @@ port module Api exposing
     , authErrorMessage
     , authResult
     , authSuccessMessage
+    , delete
     , exposeToken
     , get
     , login
     , logout
+    , post
+    , put
     , viewerChanges
     )
 
@@ -240,6 +243,81 @@ get url maybeCred toMsg decoder =
                 Nothing ->
                     []
         , body = Http.emptyBody
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+put :
+    String
+    -> Maybe Cred
+    -> (Result Http.Error a -> msg)
+    -> Http.Body
+    -> Decode.Decoder a
+    -> Cmd msg
+put url maybeCred toMsg body decoder =
+    Http.request
+        { method = "PUT"
+        , url = url
+        , expect = Http.expectJson toMsg decoder
+        , headers =
+            case maybeCred of
+                Just cred ->
+                    [ credHeader cred ]
+
+                Nothing ->
+                    []
+        , body = body
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+post :
+    String
+    -> Maybe Cred
+    -> (Result Http.Error a -> msg)
+    -> Http.Body
+    -> Decode.Decoder a
+    -> Cmd msg
+post url maybeCred toMsg body decoder =
+    Http.request
+        { method = "POST"
+        , url = url
+        , expect = Http.expectJson toMsg decoder
+        , headers =
+            case maybeCred of
+                Just cred ->
+                    [ credHeader cred ]
+
+                Nothing ->
+                    []
+        , body = body
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+delete :
+    String
+    -> Maybe Cred
+    -> (Result Http.Error a -> msg)
+    -> Http.Body
+    -> Decode.Decoder a
+    -> Cmd msg
+delete url maybeCred toMsg body decoder =
+    Http.request
+        { method = "DELETE"
+        , url = url
+        , expect = Http.expectJson toMsg decoder
+        , headers =
+            case maybeCred of
+                Just cred ->
+                    [ credHeader cred ]
+
+                Nothing ->
+                    []
+        , body = body
         , timeout = Nothing
         , tracker = Nothing
         }


### PR DESCRIPTION
Adds replacements for the wrapper functions that we had in `HttpHelpers.elm`. There are a couple of changes in the way these wrappers will be used.

#### New Elm Http library

We have upgraded to `elm/http` v2.0.0, which means we no longer need to make a request which we later send. Instead, the new API creates commands directly without having to send them. In practice, this means we pass in the `Msg` constructor that handles the HTTP response and the wrapper function returns a `Cmd msg`. (see https://elm-lang.org/news/working-with-files#simplifying-elm-http-.)

#### Maybe Cred instead of CSRF tokens

We need to pass in `Maybe Cred` instead of a `List Http.Header` that contains a CSRF token. Now that we are using JWTs, we won't need the CSRF token, but we will need `Maybe Cred` to tell us whether the user is logged in or not. `Maybe Cred` is available by calling something like `Session.cred shared.session` where `shared` is the model in `Shared.elm`.

In practice, this means all HTTP calls need to be aware of the shared model. We will need to get pages wired up to pass the shared model down to where it is needed.