### PR TITLE
Divide Django JWT auth endpoint per user type

### DIFF
--- a/ereadingtool/test/user.py
+++ b/ereadingtool/test/user.py
@@ -72,17 +72,28 @@ class TestUser(TestCase):
 
         return user, user_passwd, instructor
 
-    def login(self, client: Client,
+    def instructor_login(self, client: Client,
+              user: Optional[ReaderUser] = None,
+              username: Optional[AnyStr] = None,
+              password: Optional[AnyStr] = None) -> Client:
+        return self.login(client, reverse_lazy('api-instructor-login'), user, username, password)
+
+    def student_login(self, client: Client,
+              user: Optional[ReaderUser] = None,
+              username: Optional[AnyStr] = None,
+              password: Optional[AnyStr] = None) -> Client:
+        return self.login(client, reverse_lazy('api-student-login'), user, username, password)
+
+    def login(self, client: Client, endpoint,
               user: Optional[ReaderUser] = None,
               username: Optional[AnyStr] = None,
               password: Optional[AnyStr] = None) -> Client:
 
         # get JWT token
-        login_resp = client.post(reverse_lazy('jwt-token-auth'),
-                                          json.dumps({
-                                           'username': username or user.username,
-                                           'password': password
-                                          }), content_type='application/json')
+        login_resp = client.post(endpoint, json.dumps({
+            'username': username or user.username,
+            'password': password
+        }), content_type='application/json')
 
         login_resp_json = json.loads(login_resp.content.decode('utf8'))
 
@@ -103,7 +114,7 @@ class TestUser(TestCase):
         else:
             user, user_passwd = user_and_pass
 
-        client = self.login(client, user=user, password=user_passwd)
+        client = self.instructor_login(client, user=user, password=user_passwd)
 
         return client
 
@@ -114,7 +125,7 @@ class TestUser(TestCase):
         else:
             user, user_passwd = user_and_pass
 
-        client = self.login(client, user=user, password=user_passwd)
+        client = self.student_login(client, user=user, password=user_passwd)
 
         return client
 

--- a/user/forms.py
+++ b/user/forms.py
@@ -1,20 +1,16 @@
 from django import forms
-from django.db.models import Sum, F, DateTimeField
-from django.db.models.functions import Now
-
 from django.contrib.auth import password_validation
 from django.contrib.auth.forms import AuthenticationForm as BaseAuthenticationForm
 from django.core.validators import validate_email
-
 from django.utils.translation import ugettext_lazy as _
 
-from text.models import TextDifficulty
-from user.models import ReaderUser
-
-from user.instructor.models import Instructor
-from user.student.models import Student
+from jwt_auth.forms import JSONWebTokenForm
 
 from invite.models import Invite
+from text.models import TextDifficulty
+from user.instructor.models import Instructor
+from user.models import ReaderUser
+from user.student.models import Student
 
 
 class SignUpForm(forms.ModelForm):
@@ -160,11 +156,11 @@ class AuthenticationForm(BaseAuthenticationForm):
         return username
 
 
-class InstructorLoginForm(AuthenticationForm):
+class InstructorLoginForm(JSONWebTokenForm):
     pass
 
 
-class StudentLoginForm(AuthenticationForm):
+class StudentLoginForm(JSONWebTokenForm):
     pass
 
 

--- a/user/forms.py
+++ b/user/forms.py
@@ -4,8 +4,6 @@ from django.contrib.auth.forms import AuthenticationForm as BaseAuthenticationFo
 from django.core.validators import validate_email
 from django.utils.translation import ugettext_lazy as _
 
-from jwt_auth.forms import JSONWebTokenForm
-
 from invite.models import Invite
 from text.models import TextDifficulty
 from user.instructor.models import Instructor
@@ -156,11 +154,11 @@ class AuthenticationForm(BaseAuthenticationForm):
         return username
 
 
-class InstructorLoginForm(JSONWebTokenForm):
+class InstructorLoginForm(AuthenticationForm):
     pass
 
 
-class StudentLoginForm(JSONWebTokenForm):
+class StudentLoginForm(AuthenticationForm):
     pass
 
 

--- a/user/test/instructor.py
+++ b/user/test/instructor.py
@@ -78,7 +78,7 @@ class TestInstructorUser(TestUserBase, TestCase):
         self.assertEquals(resp.status_code, 403)
 
     def test_instructor_invite_can_expire(self):
-        admin_client = self.login(Client(), user=self.instructor_admin_user, password=self.instructor_admin_password)
+        admin_client = self.instructor_login(Client(), user=self.instructor_admin_user, password=self.instructor_admin_password)
 
         invitee_email = 'test-invite@test.com'
 
@@ -108,7 +108,7 @@ class TestInstructorUser(TestUserBase, TestCase):
         self.assertIn('invite_code', resp_content)
 
     def test_instructor_invite(self):
-        admin_client = self.login(Client(), user=self.instructor_admin_user, password=self.instructor_admin_password)
+        admin_client = self.instructor_login(Client(), user=self.instructor_admin_user, password=self.instructor_admin_password)
 
         invitee_email = 'test-invite@test.com'
 

--- a/user/test/student.py
+++ b/user/test/student.py
@@ -206,7 +206,7 @@ class TestStudentUser(TestData, TestUser, TestCase):
 
         student_anonymous_client = self.test_student_signup(student_signup_params)
 
-        student_client = self.login(
+        student_client = self.student_login(
             student_anonymous_client,
             username=student_signup_params['email'], password=student_signup_params['password']
         )

--- a/user/views/api.py
+++ b/user/views/api.py
@@ -38,7 +38,7 @@ class APIView(View):
         if not errors:
             errors['all'] = 'An unspecified error has occurred.'
 
-        return JsonResponse(json.dumps(errors), status=400)
+        return JsonResponse(errors, status=400)
 
     def post(self, request: HttpRequest, *args, **kwargs) -> JsonResponse:
         errors = params = {}

--- a/user/views/api.py
+++ b/user/views/api.py
@@ -1,10 +1,10 @@
 import json
 
 from django import forms
-from django.http import HttpResponse, HttpRequest
+from django.http import JsonResponse, HttpRequest
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
-from django.views.decorators.csrf import csrf_protect
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import View
 
@@ -13,11 +13,11 @@ class APIView(View):
     def form(self, request: HttpRequest, params: dict) -> 'forms.Form':
         raise NotImplementedError
 
-    def post_success(self, request: HttpRequest, form: 'forms.Form') -> HttpResponse:
+    def post_success(self, request: HttpRequest, form: 'forms.Form') -> JsonResponse:
         raise NotImplementedError
 
     @method_decorator(sensitive_post_parameters())
-    @method_decorator(csrf_protect)
+    @method_decorator(csrf_exempt)
     @method_decorator(never_cache)
     def dispatch(self, request, *args, **kwargs):
         return super(APIView, self).dispatch(request, *args, **kwargs)
@@ -31,16 +31,16 @@ class APIView(View):
 
         return errors
 
-    def post_json_error(self, error: json.JSONDecodeError) -> HttpResponse:
-        return HttpResponse(errors={"errors": {'json': str(error)}}, status=400)
+    def post_json_error(self, error: json.JSONDecodeError) -> JsonResponse:
+        return JsonResponse(errors={"errors": {'json': str(error)}}, status=400)
 
-    def post_error(self, errors: dict) -> HttpResponse:
+    def post_error(self, errors: dict) -> JsonResponse:
         if not errors:
             errors['all'] = 'An unspecified error has occurred.'
 
-        return HttpResponse(json.dumps(errors), status=400)
+        return JsonResponse(json.dumps(errors), status=400)
 
-    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+    def post(self, request: HttpRequest, *args, **kwargs) -> JsonResponse:
         errors = params = {}
 
         try:

--- a/user/views/instructor.py
+++ b/user/views/instructor.py
@@ -127,13 +127,11 @@ class InstructorLoginAPIView(APIView):
         instructor = reader_user.instructor
 
         # customize payload re-using only the 'original issued at time' and expiration
-        final_payload = {
+        return JsonResponse({
             'id': instructor.pk,
             'orig_iat': jwt_payload['orig_iat'],
             'exp': jwt_payload['exp']
-        }
-
-        return JsonResponse(jwt_get_json_with_token(token))
+        })
 
 
 class InstructorLogoutAPIView(LoginRequiredMixin, View):


### PR DESCRIPTION
Removes `/token-auth/` endpoint.

Makes 

`api/instructor/login/`
`api/student/login/`

into JWT auth endpoints returning customized JWT payloads.

This closes #147 .

