### PR TITLE
Add text search page

### DIFF
--- a/web/elm.json
+++ b/web/elm.json
@@ -18,6 +18,7 @@
             "elm-explorations/markdown": "1.0.0",
             "hecrj/html-parser": "2.4.0",
             "panthershark/email-parser": "1.0.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3",
             "waratuman/json-extra": "1.0.2",
             "y0hy0h/ordered-containers": "2.0.1"
         },
@@ -28,7 +29,6 @@
             "elm/virtual-dom": "1.0.2",
             "justinmimbs/timezone-data": "2.1.4",
             "rtfeldman/elm-hex": "1.0.0",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3",
             "waratuman/time-extra": "1.1.0"
         }
     },

--- a/web/public/css/text.css
+++ b/web/public/css/text.css
@@ -1,0 +1,248 @@
+#text-section {
+    display: grid;
+
+    grid-template-columns: 10% [body-col] auto 10%;
+    grid-template-rows: 10% [body-row] auto 10%;
+
+    font-family: "Lora,Palatino,Times,Times New Roman,serif";
+    font-size: 20px;
+    line-height: 1.7;
+    letter-spacing: 0;
+
+    padding-top: 50px;
+}
+
+#complete {
+    grid-column: body-col;
+}
+
+#text-body {
+    grid-column: body-col;
+    grid-row: body-row;
+
+    display: grid;
+
+    grid-template-rows: auto auto auto;
+}
+
+#text-body > #body {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+#nav {
+    grid-column: 2;
+    display: grid;
+
+    padding-top: 25px;
+
+    grid-template-columns: 50% 50%;
+
+    grid-template-rows: minmax(25px, 50px);
+    align-items: center;
+}
+
+#nav > div {
+    text-align: center;
+    color: white;
+    background-color: #0054a6;
+
+    cursor: pointer;
+
+    margin-right: 5px;
+    transition: background 0.3s ease-out;
+}
+
+#nav > div:hover {
+    background-color: #00458a;
+}
+
+.exception {
+    grid-column: 2;
+    display: grid;
+    font-size: 20px;
+    font-style: italic;
+    color: #bf2639;
+}
+
+.nav > div {
+    display: inline-block;
+
+    cursor: pointer;
+
+    margin: 15px;
+
+    background: #f9f9f9;
+    text-align: center;
+
+    padding: 2px;
+    border: solid 1px white;
+    border-radius: 5px;
+}
+
+.start-btn {
+    grid-column: 1 / 3;
+}
+
+#text-score {
+    display: grid;
+    grid-column: 2;
+
+    margin: 50px 15px 15px 15px;
+}
+
+#text-intro {
+    grid-column: 2;
+    display: grid;
+
+    margin-top: 100px;
+
+    align-items: center;
+    justify-items: center;
+}
+
+#text-conclusion {
+    grid-column: 2;
+    display: grid;
+
+    align-items: center;
+    justify-items: center;
+}
+
+#title {
+    font-size: 20px;
+}
+
+#questions {
+    display: grid;
+    padding-top: 15px;
+
+    border-top: rgb(238, 238, 238) solid 1px;
+
+    grid-template-columns: auto;
+    grid-row-gap: 50px;
+    row-gap: 50px;
+}
+
+.question {
+    display: grid;
+    grid-template-columns: auto;
+}
+
+.question-body {
+    font-size: 18px;
+    margin-bottom: 30px;
+}
+
+.answer-selected {
+    background: #FFFFFF !important;
+}
+
+.correct {
+    border-color: #07e200 !important;
+}
+
+.incorrect {
+    border-color: #fc3605 !important;
+}
+
+.answer {
+    background: #f9f9f9;
+    margin-bottom: 15px;
+    padding: 10px;
+
+    border: solid 1px lightgrey;
+    border-radius: 5px;
+    font-size: 17px;
+    cursor: pointer;
+
+    transition: border 0.2s ease-out;
+}
+
+.answer:hover {
+    border: solid 1px #0071bc;
+}
+
+.answer-feedback {
+    margin-top: 10px;
+}
+
+.answer-text {
+    font-size: 18px;
+}
+
+.bolder {
+    font-weight: bolder;
+}
+
+.gloss-menu {
+    position: relative;
+}
+
+.translations {
+    padding-top: 10px;
+    border-top: solid 0.5px lightgrey;
+}
+
+.gloss-flashcard-options {
+    display: grid;
+
+    margin-top: 10px;
+
+    border-top: solid 0.5px lightgrey;
+
+    grid-template-columns: auto auto;
+}
+
+.gloss-flashcard-options > div:nth-child(1) {
+    margin-top: 5px;
+    grid-column: 1 / 3;
+}
+
+.gloss-overlay {
+    display: grid;
+    position: absolute;
+
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
+
+    grid-template-columns: auto;
+    grid-template-rows: auto auto auto;
+
+    margin-top: 5px;
+
+    z-index: 2;
+    max-width: 200px;
+
+    background: #FFFFFF;
+
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+
+    padding: 5px;
+
+    border: solid 0.5px lightgrey;
+    border-radius: 2px;
+    box-shadow: 0 1px 16px rgba(0,0,0,.1);
+}
+
+@media only screen and (min-device-width : 320px) and (max-device-width : 480px) {
+    .header {
+        display: flex;
+    }
+
+    .menu {
+        display: flex;
+        flex-wrap: wrap;
+
+        align-items: center;
+    }
+
+    .footer_items {
+        margin-top: 0;
+    }
+
+    #text-section {
+        padding-top: 0;
+    }
+
+}

--- a/web/public/css/text_search.css
+++ b/web/public/css/text_search.css
@@ -1,0 +1,286 @@
+#text_search {
+    display: grid;
+
+    grid-row-gap: 35px;
+    row-gap: 35px;
+
+    grid-column-gap: 15px;
+    column-gap: 15px;
+
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 18px;
+    font-weight: 200;
+
+    margin-top: 60px;
+
+    grid-template-columns: 4% auto 4%;
+}
+
+#text_search_filters {
+    grid-column: 2;
+
+    border: solid 0.5px lightgrey;
+    background: white;
+
+    padding: 10px 10px 10px 10px;
+
+    grid-row-gap: 15px;
+    row-gap: 15px;
+}
+
+#text_search_filters_label {
+    font-weight: bolder;
+}
+
+#text_search_results {
+    grid-column: 2;
+
+    display: grid;
+
+    grid-row-gap: 20px;
+    row-gap: 20px;
+}
+
+#text_search_help_msg {
+    display: grid;
+
+    grid-column: 2;
+
+    align-content: center;
+}
+
+.search_filter {
+    display: inline-block;
+    padding: 15px 15px 15px 15px;
+}
+
+.search_filter_title {
+    font-weight: bolder;
+    margin-bottom: 5px;
+}
+
+.search_result {
+    grid-column: 1;
+    display: grid;
+
+    align-items: center;
+    justify-items: center;
+
+    grid-template-columns: repeat(7, 1fr);
+
+    background: #f9f9f9;
+
+    border: solid 0.5px lightgrey;
+
+    grid-auto-rows: 150px;
+}
+
+.sub_description {
+    display: block;
+
+    text-align: center;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: #a4a4a4;
+    font-size: 17px;
+}
+
+#text_search_btn {
+    display: inline-block;
+    cursor: pointer;
+    background: white;
+
+    padding: 15px 15px 15px 15px;
+}
+
+#text_search_footer {
+    grid-column: 2;
+}
+
+#footer_items {
+    margin-bottom: 0;
+
+    display: grid;
+    grid-column: 2;
+    grid-template-columns: 4% auto 4%;
+
+    align-items: center;
+    justify-items: center;
+}
+
+#footer {
+    grid-column: 2 / 2;
+}
+
+.message {
+    margin: 8px;
+    color: #737373;
+}
+
+.difficulty_option {
+    display: grid;
+    cursor: pointer;
+
+    border: solid 1px #777777;
+
+    margin-top: 2px;
+    padding: 5px 5px 5px 5px;
+
+    align-content: center;
+    justify-content: center;
+
+    transition: all 0.1s ease-out;
+}
+
+.difficulty_option:hover {
+    color: white;
+
+    background-color: #0054a6;
+    border: solid 1px #333333;
+
+    filter: brightness(95%);
+}
+
+.difficulty_option_selected {
+    color: white;
+
+    background-color: #0054a6;
+    border: solid 1px #333333;
+
+    filter: brightness(95%);
+}
+
+
+.text_status {
+    display: grid;
+    cursor: pointer;
+
+    border: solid 1px #777777;
+
+    margin-top: 2px;
+    padding: 5px 5px 5px 5px;
+
+    align-content: center;
+    justify-content: center;
+
+    transition: all 0.1s ease-out;
+}
+
+.text_status_option_selected {
+    color: white;
+
+    background-color: #0054a6;
+    border: solid 1px #333333;
+
+    filter: brightness(95%);
+}
+
+.text_status:hover {
+    color: white;
+
+    background-color: #0054a6;
+    border: solid 1px #333333;
+
+    filter: brightness(95%);
+}
+
+.text_tag {
+    cursor: pointer;
+    margin: 5px 5px 5px 5px;
+
+    transition: all 0.05s ease-out;
+}
+
+.text_tag:hover {
+    color: white;
+
+    background-color: #0054a6;
+    border: solid 1px #333333;
+
+    filter: brightness(95%);
+}
+
+.text_tag_selected {
+    color: white;
+
+    background-color: #0054a6;
+    border: solid 1px #333333;
+
+    filter: brightness(95%);
+}
+
+.result_item_title {
+    text-align: center;
+}
+
+.result_item {
+    display: grid;
+
+    grid-template-rows: auto auto;
+}
+
+#text_search_help_msg > div {
+    margin-top: 5px;
+}
+
+
+@media only screen and (max-width:480px) {
+    .header {
+        display: flex;
+    }
+
+    #text_tag_search {
+        width: 250px;
+    }
+
+    #text_search_filters {
+        display: flex;
+        flex-direction: column;
+        flex-wrap: wrap;
+    }
+
+    .search_filter {
+        padding: 15px 0 0 0;
+    }
+
+    .difficulty_option {
+        display: flex;
+    }
+
+    .menu {
+        display: flex;
+        flex-wrap: wrap;
+
+        align-items: center;
+        justify-items: center;
+    }
+
+    .filter {
+        display: none;
+    }
+
+    #text_search_results {
+        grid-column: 2;
+        display: grid;
+
+        grid-row-gap: 20px;
+        row-gap: 20px;
+    }
+
+    .search_result {
+        grid-column: 1;
+        display: flex;
+        flex-direction: column;
+
+        font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-size: 20px;
+
+        padding: 15px 15px 15px 15px;
+
+        background: white;
+
+        border: solid 0.5px lightgrey;
+    }
+}

--- a/web/src/Api/Endpoint.elm
+++ b/web/src/Api/Endpoint.elm
@@ -1,6 +1,7 @@
 module Api.Endpoint exposing
     ( Endpoint
     , consentToResearch
+    , filterToStringQueryParam
     , forgotPassword
     , instructorSignup
     , request
@@ -8,6 +9,7 @@ module Api.Endpoint exposing
     , studentProfile
     , studentSignup
     , test
+    , textSearch
     , validateUsername
     )
 
@@ -87,6 +89,10 @@ studentSignup baseUrl =
     url baseUrl [ "api", "student", "signup" ] []
 
 
+
+-- PROFILE
+
+
 studentProfile : String -> Int -> Endpoint
 studentProfile baseUrl id =
     url baseUrl [ "api", "student", String.fromInt id ] []
@@ -100,3 +106,34 @@ consentToResearch baseUrl id =
 validateUsername : String -> Endpoint
 validateUsername baseUrl =
     url baseUrl [ "api", "username/" ] []
+
+
+
+-- TEXT SEARCH
+
+
+textSearch : String -> List QueryParameter -> Endpoint
+textSearch baseUrl queryParameters =
+    url baseUrl [ "api", "text/" ] queryParameters
+
+
+
+-- QUERY PARAMS
+
+
+{-| This conversion is meant to provide interoperability with the old way of
+building querystrings. It would be better to build these as QueryParamters
+from the start instead of converting after the fact.
+-}
+filterToStringQueryParam : String -> QueryParameter
+filterToStringQueryParam val =
+    let
+        keyValueList =
+            String.split "=" val
+    in
+    case keyValueList of
+        key :: value :: [] ->
+            Url.Builder.string key value
+
+        _ ->
+            Url.Builder.string "bad" "param"

--- a/web/src/InstructorAdmin/Admin/Text.elm
+++ b/web/src/InstructorAdmin/Admin/Text.elm
@@ -1,4 +1,10 @@
-module InstructorAdmin.Admin.Text exposing (TextAPIEndpoint, URL, textAPIEndpointURL, textEndpointToString, toTextAPIEndpoint)
+module InstructorAdmin.Admin.Text exposing
+    ( TextAPIEndpoint
+    , URL
+    , textAPIEndpointURL
+    , textEndpointToString
+    , toTextAPIEndpoint
+    )
 
 
 type URL

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -509,7 +509,7 @@ viewLowerMenu (SafeModel model) =
             (SafeModel model)
             ++ [ a
                     [ class "link"
-                    , href (Route.toString Route.NotFound)
+                    , href (Route.toString Route.Text__Search)
                     ]
                     [ text "Find a text to read" ]
                ]

--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -4,12 +4,12 @@ import Api
 import Api.Config as Config exposing (Config)
 import Api.Endpoint as Endpoint
 import Browser.Navigation exposing (Key)
-import Dict exposing (Dict)
+import Dict
 import Help.View exposing (ArrowPlacement(..), ArrowPosition(..))
 import Html exposing (..)
 import Html.Attributes exposing (attribute, class, classList, href, id)
 import Html.Events exposing (onClick)
-import Http exposing (..)
+import Http
 import InstructorAdmin.Admin.Text as AdminText
 import Ports exposing (clearInputText)
 import Session exposing (Session)
@@ -17,15 +17,15 @@ import Shared
 import Spa.Document exposing (Document)
 import Spa.Generated.Route as Route
 import Spa.Page as Page exposing (Page)
-import Spa.Url as Url exposing (Url)
+import Spa.Url exposing (Url)
 import Text.Decode
-import Text.Model exposing (Text)
+import Text.Model
 import Text.Search exposing (TextSearch)
 import Text.Search.Difficulty exposing (DifficultySearch)
 import Text.Search.Option
 import Text.Search.ReadingStatus exposing (TextReadStatus, TextReadStatusSearch)
 import Text.Search.Tag exposing (TagSearch)
-import TextSearch.Help exposing (TextSearchHelp)
+import TextSearch.Help
 import User.Profile exposing (Profile)
 import User.Student.Profile as StudentProfile
     exposing
@@ -148,7 +148,7 @@ init shared { params } =
         , textApiEndpoint = textApiEndpoint
         , help = textSearchHelp
         , errorMessage = Nothing
-        , welcome = False
+        , welcome = True
         }
     , updateResults shared.session shared.config textSearch
     )
@@ -164,9 +164,9 @@ type Msg
     | SelectStatus TextReadStatus Bool
     | TextSearch (Result Http.Error (List Text.Model.TextListItem))
       -- help messages
-    | CloseHelp TextSearch.Help.TextHelp
-    | PrevHelp
-    | NextHelp
+    | CloseHint TextSearch.Help.TextHelp
+    | PreviousHint
+    | NextHint
       -- site-wide messages
     | Logout
 
@@ -231,24 +231,19 @@ update msg (SafeModel model) =
                     in
                     ( SafeModel { model | errorMessage = Just "An error occurred.  Please contact an administrator." }, Cmd.none )
 
-        CloseHelp helpMessage ->
-            ( SafeModel model
-              -- ( SafeModel { model | help = TextSearch.Help.setVisible model.help helpMessage False }
+        CloseHint helpMessage ->
+            ( SafeModel { model | help = TextSearch.Help.setVisible model.help helpMessage False }
             , Cmd.none
             )
 
-        PrevHelp ->
-            ( SafeModel model
-              -- ( SafeModel { model | help = TextSearch.Help.prev model.help }
-            , Cmd.none
-              -- , TextSearch.Help.scrollToPrevMsg model.help
+        PreviousHint ->
+            ( SafeModel { model | help = TextSearch.Help.prev model.help }
+            , TextSearch.Help.scrollToPrevMsg model.help
             )
 
-        NextHelp ->
-            ( SafeModel model
-              -- ( SafeModel { model | help = TextSearch.Help.next model.help }
-            , Cmd.none
-              -- , TextSearch.Help.scrollToNextMsg model.help
+        NextHint ->
+            ( SafeModel { model | help = TextSearch.Help.next model.help }
+            , TextSearch.Help.scrollToNextMsg model.help
             )
 
         Logout ->
@@ -507,8 +502,6 @@ viewTags tagSearch =
         tags =
             Text.Search.Tag.optionsToDict tagSearch
 
-        -- tag_search_id =
-        --     Text.Search.Tag.inputID tagSearch
         viewTag tagSearchOption =
             let
                 selected =
@@ -603,9 +596,9 @@ viewTopicFilterHint (SafeModel model) =
             { id = TextSearch.Help.popupToID topicFilterHelp
             , visible = TextSearch.Help.isVisible model.help topicFilterHelp
             , text = TextSearch.Help.helpMsg topicFilterHelp
-            , cancel_event = onClick (CloseHelp topicFilterHelp)
-            , next_event = onClick NextHelp
-            , prev_event = onClick PrevHelp
+            , cancel_event = onClick (CloseHint topicFilterHelp)
+            , next_event = onClick NextHint
+            , prev_event = onClick PreviousHint
             , addl_attributes = [ class "difficulty_filter_hint" ]
             , arrow_placement = ArrowUp ArrowLeft
             }
@@ -628,9 +621,9 @@ viewDifficultyFilterHint (SafeModel model) =
             { id = TextSearch.Help.popupToID difficultyFilterHelp
             , visible = TextSearch.Help.isVisible model.help difficultyFilterHelp
             , text = TextSearch.Help.helpMsg difficultyFilterHelp
-            , cancel_event = onClick (CloseHelp difficultyFilterHelp)
-            , next_event = onClick NextHelp
-            , prev_event = onClick PrevHelp
+            , cancel_event = onClick (CloseHint difficultyFilterHelp)
+            , next_event = onClick NextHint
+            , prev_event = onClick PreviousHint
             , addl_attributes = [ class "difficulty_filter_hint" ]
             , arrow_placement = ArrowUp ArrowLeft
             }
@@ -653,9 +646,9 @@ viewStatusFilterHint (SafeModel model) =
             { id = TextSearch.Help.popupToID statusFilterHelp
             , visible = TextSearch.Help.isVisible model.help statusFilterHelp
             , text = TextSearch.Help.helpMsg statusFilterHelp
-            , cancel_event = onClick (CloseHelp statusFilterHelp)
-            , next_event = onClick NextHelp
-            , prev_event = onClick PrevHelp
+            , cancel_event = onClick (CloseHint statusFilterHelp)
+            , next_event = onClick NextHint
+            , prev_event = onClick PreviousHint
             , addl_attributes = [ class "status_filter_hint" ]
             , arrow_placement = ArrowUp ArrowLeft
             }

--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -1,0 +1,673 @@
+module Pages.Text.Search exposing (Model, Msg, Params, page)
+
+-- import Profile.Flags as Flags
+
+import Browser
+import Dict exposing (Dict)
+import Help.View exposing (ArrowPlacement(..), ArrowPosition(..))
+import Html exposing (..)
+import Html.Attributes exposing (attribute, class, classList, id)
+import Html.Events exposing (onClick)
+import Http exposing (..)
+import InstructorAdmin.Admin.Text as AdminText
+import Menu.Items
+import Menu.Logout
+import Menu.Msg as MenuMsg
+import Ports exposing (clearInputText)
+import Shared
+import Spa.Document exposing (Document)
+import Spa.Page as Page exposing (Page)
+import Spa.Url as Url exposing (Url)
+import Text.Decode
+import Text.Model exposing (Text)
+import Text.Search exposing (TextSearch)
+import Text.Search.Difficulty exposing (DifficultySearch)
+import Text.Search.Option
+import Text.Search.ReadingStatus exposing (TextReadStatus, TextReadStatusSearch)
+import Text.Search.Tag exposing (TagSearch)
+import TextSearch.Help exposing (TextSearchHelp)
+import User.Profile exposing (Profile)
+import User.Student.Profile as StudentProfile
+    exposing
+        ( StudentProfile(..)
+        , StudentURIs(..)
+        )
+import User.Student.Resource as StudentResource
+import Utils.Date
+import Views
+
+
+page : Page Params Model Msg
+page =
+    Page.protectedApplication
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        , save = save
+        , load = load
+        }
+
+
+
+-- INIT
+
+
+type alias Params =
+    ()
+
+
+type alias Model =
+    Maybe SafeModel
+
+
+type SafeModel
+    = SafeModel
+        { results : List Text.Model.TextListItem
+        , profile : User.Profile.Profile
+
+        -- , menu_items : Menu.Items.MenuItems
+        , text_search : TextSearch
+        , text_api_endpoint : AdminText.TextAPIEndpoint
+        , help : TextSearch.Help.TextSearchHelp
+        , error_msg : Maybe String
+        , welcome : Bool
+
+        -- , flags : Flags
+        }
+
+
+
+-- type alias Flags =
+--     Flags.Flags
+--         { text_difficulties : List Text.Model.TextDifficulty
+--         , text_statuses : List ( String, String )
+--         , text_api_endpoint_url : String
+--         , welcome : Bool
+--         , text_tags : List String
+--         }
+
+
+fakeProfile : Profile
+fakeProfile =
+    User.Profile.initProfile <|
+        { student_profile =
+            Just
+                { id = Just 0
+                , username = Just "fake name"
+                , email = "test@email.com"
+                , difficulty_preference = Nothing
+                , difficulties = Shared.difficulties
+                , uris =
+                    { logout_uri = "logout"
+                    , profile_uri = "profile"
+                    }
+                }
+        , instructor_profile = Nothing
+        }
+
+
+init : Shared.Model -> Url Params -> ( SafeModel, Cmd Msg )
+init shared { params } =
+    let
+        tag_search =
+            Text.Search.Tag.new "text_tag_search"
+                (Text.Search.Option.newOptions
+                    -- (List.map (\tag -> ( tag, tag )) flags.text_tags)
+                    (List.map (\tag -> ( tag, tag )) [])
+                )
+
+        difficulty_search =
+            Text.Search.Difficulty.new
+                "text_difficulty_search"
+                (Text.Search.Option.newOptions Shared.difficulties)
+
+        status_search =
+            Text.Search.ReadingStatus.new
+                "text_status_search"
+                -- (Text.Search.Option.newOptions flags.text_statuses)
+                (Text.Search.Option.newOptions [])
+
+        text_api_endpoint =
+            -- AdminText.TextAPIEndpoint
+            --     (AdminText.URL flags.text_api_endpoint_url)
+            AdminText.toTextAPIEndpoint "text-api-endpoint"
+
+        default_search =
+            Text.Search.new text_api_endpoint tag_search difficulty_search status_search
+
+        profile =
+            fakeProfile
+
+        text_search =
+            case profile of
+                User.Profile.Student student_profile ->
+                    case StudentProfile.studentDifficultyPreference student_profile of
+                        Just difficulty ->
+                            Text.Search.addDifficultyToSearch default_search (Tuple.first difficulty) True
+
+                        _ ->
+                            default_search
+
+                _ ->
+                    default_search
+
+        text_search_help =
+            TextSearch.Help.init
+
+        -- menu_items =
+        --     Menu.Items.initMenuItems flags
+    in
+    ( SafeModel
+        { results = []
+        , profile = fakeProfile
+
+        --   , menu_items = menu_items
+        , text_search = text_search
+        , text_api_endpoint = text_api_endpoint
+        , help = text_search_help
+        , error_msg = Nothing
+        , welcome = False
+
+        --   , flags = flags
+        }
+      -- , updateResults text_api_endpoint text_search
+    , Cmd.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = AddDifficulty String Bool
+    | SelectTag String Bool
+    | SelectStatus TextReadStatus Bool
+    | TextSearch (Result Http.Error (List Text.Model.TextListItem))
+      -- help messages
+    | CloseHelp TextSearch.Help.TextHelp
+    | PrevHelp
+    | NextHelp
+      -- site-wide messages
+    | LogOut MenuMsg.Msg
+    | LoggedOut (Result Http.Error Menu.Logout.LogOutResp)
+
+
+update : Msg -> SafeModel -> ( SafeModel, Cmd Msg )
+update msg (SafeModel model) =
+    case msg of
+        AddDifficulty difficulty select ->
+            let
+                new_text_search =
+                    Text.Search.addDifficultyToSearch model.text_search difficulty select
+            in
+            ( SafeModel { model | text_search = new_text_search, results = [] }
+              -- , updateResults model.text_api_endpoint new_text_search
+            , Cmd.none
+            )
+
+        SelectStatus status selected ->
+            let
+                status_search =
+                    Text.Search.statusSearch model.text_search
+
+                new_status_search =
+                    Text.Search.ReadingStatus.selectStatus status_search status selected
+
+                new_text_search =
+                    Text.Search.setStatusSearch model.text_search new_status_search
+            in
+            ( SafeModel { model | text_search = new_text_search, results = [] }
+            , updateResults model.text_api_endpoint new_text_search
+            )
+
+        SelectTag tag_name selected ->
+            let
+                tag_search =
+                    Text.Search.tagSearch model.text_search
+
+                tag_search_input_id =
+                    Text.Search.Tag.inputID tag_search
+
+                new_tag_search =
+                    Text.Search.Tag.select_tag tag_search tag_name selected
+
+                new_text_search =
+                    Text.Search.setTagSearch model.text_search new_tag_search
+            in
+            ( SafeModel { model | text_search = new_text_search, results = [] }
+            , Cmd.batch [ clearInputText tag_search_input_id, updateResults model.text_api_endpoint new_text_search ]
+            )
+
+        TextSearch result ->
+            case result of
+                Ok texts ->
+                    ( SafeModel { model | results = texts }, Cmd.none )
+
+                Err err ->
+                    let
+                        _ =
+                            Debug.log "error retrieving results" err
+                    in
+                    ( SafeModel { model | error_msg = Just "An error occurred.  Please contact an administrator." }, Cmd.none )
+
+        CloseHelp help_msg ->
+            ( SafeModel model
+              -- ( SafeModel { model | help = TextSearch.Help.setVisible model.help help_msg False }
+            , Cmd.none
+            )
+
+        PrevHelp ->
+            ( SafeModel model
+              -- ( SafeModel { model | help = TextSearch.Help.prev model.help }
+            , Cmd.none
+              -- , TextSearch.Help.scrollToPrevMsg model.help
+            )
+
+        NextHelp ->
+            ( SafeModel model
+              -- ( SafeModel { model | help = TextSearch.Help.next model.help }
+            , Cmd.none
+              -- , TextSearch.Help.scrollToNextMsg model.help
+            )
+
+        LogOut _ ->
+            ( SafeModel model
+            , Cmd.none
+              -- , User.Profile.logout model.profile model.flags.csrftoken LoggedOut
+            )
+
+        LoggedOut (Ok logout_resp) ->
+            ( SafeModel model, Ports.redirect logout_resp.redirect )
+
+        LoggedOut (Err err) ->
+            ( SafeModel model, Cmd.none )
+
+
+updateResults : AdminText.TextAPIEndpoint -> TextSearch -> Cmd Msg
+updateResults text_api_endpoint text_search =
+    let
+        text_api_endpoint_url =
+            AdminText.textEndpointToString text_api_endpoint
+
+        filter_params =
+            Text.Search.filterParams text_search
+
+        query_string =
+            String.join "" [ text_api_endpoint_url, "?" ] ++ String.join "&" filter_params
+
+        request =
+            Debug.todo "query text list"
+
+        -- Http.get query_string Text.Decode.textListDecoder
+    in
+    if List.length filter_params > 0 then
+        Debug.todo "text search request"
+        -- Http.send TextSearch request
+
+    else
+        Cmd.none
+
+
+
+-- VIEW
+
+
+view : SafeModel -> Document Msg
+view (SafeModel model) =
+    { title = "Search Texts"
+    , body =
+        [ div []
+            -- [ Views.view_authed_header model.profile model.menu_items LogOut
+            [ view_content (SafeModel model)
+            , Views.view_footer
+            ]
+        ]
+    }
+
+
+view_content : SafeModel -> Html Msg
+view_content (SafeModel model) =
+    div [ id "text_search" ] <|
+        (if model.welcome then
+            [ view_help_msg (SafeModel model) ]
+
+         else
+            []
+        )
+            ++ [ view_search_filters (SafeModel model)
+               , view_search_results model.results
+               , view_search_footer (SafeModel model)
+               ]
+
+
+view_help_msg : SafeModel -> Html Msg
+view_help_msg model =
+    div [ id "text_search_help_msg" ]
+        [ div []
+            [ Html.text "Welcome."
+            ]
+        , div []
+            [ Html.text
+                """Use this page to find texts for your proficiency level and on topics that are of interest to you."""
+            ]
+        , div []
+            [ Html.text
+                """To walk through a demonstration of how the text and questions appear, please select Intermediate-Mid
+       from the Difficulty tags and then Other from the the Topic tags, and Unread from the Status Filters.
+       A text entitled Demo Text should appear at the top of the list.  Click on the title to go to this text."""
+            ]
+        ]
+
+
+view_search_filters : SafeModel -> Html Msg
+view_search_filters (SafeModel model) =
+    div [ id "text_search_filters" ]
+        [ div [ id "text_search_filters_label" ] [ Html.text "Filters" ]
+        , div [ class "search_filter" ] <|
+            [ div [ class "search_filter_title" ] [ Html.text "Difficulty" ]
+            , div [] (view_difficulties (Text.Search.difficultySearch model.text_search))
+            ]
+                ++ view_difficulty_filter_hint (SafeModel model)
+        , div [ class "search_filter" ]
+            [ div [ class "search_filter_title" ] [ Html.text "Tags" ]
+            , div [] <|
+                [ view_tags (Text.Search.tagSearch model.text_search) ]
+                    ++ view_topic_filter_hint (SafeModel model)
+            ]
+        , div [ class "search_filter" ] <|
+            [ div [ class "search_filter_title" ] [ Html.text "Read Status" ]
+            , div [] (view_statuses (Text.Search.statusSearch model.text_search))
+            ]
+                ++ view_status_filter_hint (SafeModel model)
+        ]
+
+
+view_search_results : List Text.Model.TextListItem -> Html Msg
+view_search_results textListItems =
+    let
+        view_search_result textItem =
+            let
+                commaDelimitedTags =
+                    case textItem.tags of
+                        Just tags ->
+                            String.join ", " tags
+
+                        Nothing ->
+                            ""
+
+                sectionsCompleted =
+                    case textItem.text_sections_complete of
+                        Just sections_complete ->
+                            String.fromInt sections_complete ++ " / " ++ String.fromInt textItem.text_section_count
+
+                        Nothing ->
+                            "0 / " ++ String.fromInt textItem.text_section_count
+
+                lastRead =
+                    case textItem.last_read_dt of
+                        Just dt ->
+                            Utils.Date.monthDayYearFormat dt
+
+                        Nothing ->
+                            ""
+
+                questionsCorrect =
+                    case textItem.questions_correct of
+                        Just correct ->
+                            String.fromInt (Tuple.first correct) ++ " out of " ++ String.fromInt (Tuple.second correct)
+
+                        Nothing ->
+                            "None"
+            in
+            div [ class "search_result" ]
+                [ div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.a [ attribute "href" textItem.uri ] [ Html.text textItem.title ] ]
+                    , div [ class "sub_description" ] [ Html.text "Title" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text textItem.difficulty ]
+                    , div [ class "sub_description" ] [ Html.text "Difficulty" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text textItem.author ]
+                    , div [ class "sub_description" ] [ Html.text "Author" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text sectionsCompleted ]
+                    , div [ class "sub_description" ] [ Html.text "Sections Complete" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text commaDelimitedTags ]
+                    , div [ class "sub_description" ] [ Html.text "Tags" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text lastRead ]
+                    , div [ class "sub_description" ] [ Html.text "Last Read" ]
+                    ]
+                , div [ class "result_item" ]
+                    [ div [ class "result_item_title" ] [ Html.text questionsCorrect ]
+                    , div [ class "sub_description" ] [ Html.text "Questions Correct" ]
+                    ]
+                ]
+    in
+    div [ id "text_search_results" ] (List.map view_search_result textListItems)
+
+
+view_search_footer : SafeModel -> Html Msg
+view_search_footer (SafeModel model) =
+    let
+        results_length =
+            List.length model.results
+
+        entries =
+            if results_length == 1 then
+                "entry"
+
+            else
+                "entries"
+
+        success_txt =
+            String.join " " [ "Showing", String.fromInt results_length, entries ]
+
+        txt =
+            case model.error_msg of
+                Just msg ->
+                    msg
+
+                Nothing ->
+                    success_txt
+    in
+    div [ id "footer_items" ]
+        [ div [ id "footer", class "message" ]
+            [ Html.text txt
+            ]
+        ]
+
+
+view_tags : TagSearch -> Html Msg
+view_tags tag_search =
+    let
+        tags =
+            Text.Search.Tag.optionsToDict tag_search
+
+        tag_search_id =
+            Text.Search.Tag.inputID tag_search
+
+        view_tag tag_search_option =
+            let
+                selected =
+                    Text.Search.Option.selected tag_search_option
+
+                tag_value =
+                    Text.Search.Option.value tag_search_option
+
+                tag_label =
+                    Text.Search.Option.label tag_search_option
+            in
+            div
+                [ onClick (SelectTag tag_value (not selected))
+                , classList
+                    [ ( "text_tag", True )
+                    , ( "text_tag_selected", selected )
+                    ]
+                ]
+                [ Html.text tag_label
+                ]
+    in
+    div [ id "text_tags" ]
+        [ div [ class "text_tags" ] (List.map view_tag (Dict.values tags))
+        ]
+
+
+view_difficulties : DifficultySearch -> List (Html Msg)
+view_difficulties difficulty_search =
+    let
+        difficulties =
+            Text.Search.Difficulty.options difficulty_search
+
+        view_difficulty difficulty_search_option =
+            let
+                selected =
+                    Text.Search.Option.selected difficulty_search_option
+
+                value =
+                    Text.Search.Option.value difficulty_search_option
+
+                label =
+                    Text.Search.Option.label difficulty_search_option
+            in
+            div
+                [ classList [ ( "difficulty_option", True ), ( "difficulty_option_selected", selected ) ]
+                , onClick (AddDifficulty value (not selected))
+                ]
+                [ Html.text label
+                ]
+    in
+    List.map view_difficulty difficulties
+
+
+view_statuses : TextReadStatusSearch -> List (Html Msg)
+view_statuses status_search =
+    let
+        statuses =
+            Text.Search.ReadingStatus.options status_search
+
+        view_status ( value, status_option ) =
+            let
+                selected =
+                    Text.Search.Option.selected status_option
+
+                label =
+                    Text.Search.Option.label status_option
+
+                status =
+                    Text.Search.ReadingStatus.valueToStatus value
+            in
+            div
+                [ classList [ ( "text_status", True ), ( "text_status_option_selected", selected ) ]
+                , onClick (SelectStatus status (not selected))
+                ]
+                [ Html.text label
+                ]
+    in
+    List.map view_status <| List.map (\option -> ( Text.Search.Option.value option, option )) statuses
+
+
+
+-- HINTS
+
+
+view_topic_filter_hint : SafeModel -> List (Html Msg)
+view_topic_filter_hint (SafeModel model) =
+    let
+        topic_filter_help =
+            TextSearch.Help.topic_filter_help
+
+        hint_attributes =
+            { id = TextSearch.Help.popupToID topic_filter_help
+            , visible = TextSearch.Help.isVisible model.help topic_filter_help
+            , text = TextSearch.Help.helpMsg topic_filter_help
+            , cancel_event = onClick (CloseHelp topic_filter_help)
+            , next_event = onClick NextHelp
+            , prev_event = onClick PrevHelp
+            , addl_attributes = [ class "difficulty_filter_hint" ]
+            , arrow_placement = ArrowUp ArrowLeft
+            }
+    in
+    if model.welcome then
+        [ Help.View.view_hint_overlay hint_attributes
+        ]
+
+    else
+        []
+
+
+view_difficulty_filter_hint : SafeModel -> List (Html Msg)
+view_difficulty_filter_hint (SafeModel model) =
+    let
+        difficulty_filter_help =
+            TextSearch.Help.difficulty_filter_help
+
+        hint_attributes =
+            { id = TextSearch.Help.popupToID difficulty_filter_help
+            , visible = TextSearch.Help.isVisible model.help difficulty_filter_help
+            , text = TextSearch.Help.helpMsg difficulty_filter_help
+            , cancel_event = onClick (CloseHelp difficulty_filter_help)
+            , next_event = onClick NextHelp
+            , prev_event = onClick PrevHelp
+            , addl_attributes = [ class "difficulty_filter_hint" ]
+            , arrow_placement = ArrowUp ArrowLeft
+            }
+    in
+    if model.welcome then
+        [ Help.View.view_hint_overlay hint_attributes
+        ]
+
+    else
+        []
+
+
+view_status_filter_hint : SafeModel -> List (Html Msg)
+view_status_filter_hint (SafeModel model) =
+    let
+        status_filter_help =
+            TextSearch.Help.status_filter_help
+
+        hint_attributes =
+            { id = TextSearch.Help.popupToID status_filter_help
+            , visible = TextSearch.Help.isVisible model.help status_filter_help
+            , text = TextSearch.Help.helpMsg status_filter_help
+            , cancel_event = onClick (CloseHelp status_filter_help)
+            , next_event = onClick NextHelp
+            , prev_event = onClick PrevHelp
+            , addl_attributes = [ class "status_filter_hint" ]
+            , arrow_placement = ArrowUp ArrowLeft
+            }
+    in
+    if model.welcome then
+        [ Help.View.view_hint_overlay hint_attributes
+        ]
+
+    else
+        []
+
+
+
+-- SHARED
+
+
+save : SafeModel -> Shared.Model -> Shared.Model
+save model shared =
+    shared
+
+
+load : Shared.Model -> SafeModel -> ( SafeModel, Cmd Msg )
+load shared safeModel =
+    ( safeModel, Cmd.none )
+
+
+subscriptions : SafeModel -> Sub Msg
+subscriptions (SafeModel model) =
+    Sub.none

--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -4,7 +4,9 @@ module Shared exposing
     , Msg
     , difficulties
     , init
+    , statuses
     , subscriptions
+    , tags
     , update
     , view
     )
@@ -173,4 +175,36 @@ difficulties =
     , ( "intermediate_high", "Intermediate-High" )
     , ( "advanced_low", "Advanced-Low" )
     , ( "advanced_mid", "Advanced-Mid" )
+    ]
+
+
+tags : List String
+tags =
+    [ "Culture"
+    , "Music"
+    , "Film"
+    , "Literary Arts"
+    , "Visual Arts"
+    , "Sports"
+    , "Internal Affairs"
+    , "History"
+    , "Biography"
+    , "News Briefs"
+    , "Economics/Business"
+    , "Medicine/Health Care"
+    , "Science/Technology"
+    , "Human Interest"
+    , "Society and Societal Trends"
+    , "International Relations"
+    , "Public Policy"
+    , "Other"
+    , "Kazakhstan"
+    ]
+
+
+statuses : List ( String, String )
+statuses =
+    [ ( "unread", "Unread" )
+    , ( "in_progress", "In Progress" )
+    , ( "read", "Read" )
     ]

--- a/web/src/Text/Decode.elm
+++ b/web/src/Text/Decode.elm
@@ -22,7 +22,7 @@ import Json.Decode.Pipeline exposing (required)
 import Text.Model exposing (Text, TextDifficulty, TextListItem)
 import Text.Section.Decode
 import Text.Translations.Decode
-import Util
+import Utils
 
 
 type alias TextCreateResp =
@@ -91,7 +91,7 @@ textListItemDecoder =
         |> required "last_read_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
         |> required "text_section_count" Json.Decode.int
         |> required "text_sections_complete" (Json.Decode.nullable Json.Decode.int)
-        |> required "questions_correct" (Json.Decode.nullable Util.intTupleDecoder)
+        |> required "questions_correct" (Json.Decode.nullable Utils.intTupleDecoder)
         |> required "uri" Json.Decode.string
         |> required "write_locker" (Json.Decode.nullable Json.Decode.string)
 
@@ -136,7 +136,7 @@ textDifficultiesDecoder =
 
 textDifficultyDecoder : Json.Decode.Decoder TextDifficulty
 textDifficultyDecoder =
-    Util.stringTupleDecoder
+    Utils.stringTupleDecoder
 
 
 decodeRespErrors : String -> Result Json.Decode.Error TextsRespError

--- a/web/src/Text/Decode.elm
+++ b/web/src/Text/Decode.elm
@@ -16,6 +16,7 @@ module Text.Decode exposing
 import Array
 import DateTime
 import Dict exposing (Dict)
+import Iso8601
 import Json.Decode
 import Json.Decode.Extra exposing (posix)
 import Json.Decode.Pipeline exposing (required)
@@ -69,8 +70,10 @@ textDecoder =
         |> required "created_by" (Json.Decode.nullable Json.Decode.string)
         |> required "last_modified_by" (Json.Decode.nullable Json.Decode.string)
         |> required "tags" (Json.Decode.nullable (Json.Decode.list Json.Decode.string))
-        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
-        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        -- |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        -- |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
+        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
         |> required "text_sections" (Json.Decode.map Array.fromList Text.Section.Decode.textSectionsDecoder)
         |> required "write_locker" (Json.Decode.nullable Json.Decode.string)
         |> required "words" Text.Translations.Decode.wordsDecoder
@@ -86,9 +89,12 @@ textListItemDecoder =
         |> required "created_by" Json.Decode.string
         |> required "last_modified_by" (Json.Decode.nullable Json.Decode.string)
         |> required "tags" (Json.Decode.nullable (Json.Decode.list Json.Decode.string))
-        |> required "created_dt" (Json.Decode.map DateTime.fromPosix posix)
-        |> required "modified_dt" (Json.Decode.map DateTime.fromPosix posix)
-        |> required "last_read_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        -- |> required "created_dt" (Json.Decode.map DateTime.fromPosix posix)
+        -- |> required "modified_dt" (Json.Decode.map DateTime.fromPosix posix)
+        -- |> required "last_read_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        |> required "created_dt" (Json.Decode.map DateTime.fromPosix Iso8601.decoder)
+        |> required "modified_dt" (Json.Decode.map DateTime.fromPosix Iso8601.decoder)
+        |> required "last_read_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
         |> required "text_section_count" Json.Decode.int
         |> required "text_sections_complete" (Json.Decode.nullable Json.Decode.int)
         |> required "questions_correct" (Json.Decode.nullable Utils.intTupleDecoder)

--- a/web/src/Text/Search.elm
+++ b/web/src/Text/Search.elm
@@ -10,8 +10,8 @@ module Text.Search exposing
     , tagSearch
     )
 
-import Admin.Text
 import Dict exposing (Dict)
+import InstructorAdmin.Admin.Text as AdminText
 import Text.Search.Difficulty exposing (DifficultySearch)
 import Text.Search.Option exposing (SearchOption)
 import Text.Search.ReadingStatus exposing (TextReadStatusSearch)
@@ -19,10 +19,10 @@ import Text.Search.Tag exposing (TagSearch)
 
 
 type TextSearch
-    = TextSearch Admin.Text.TextAPIEndpoint TagSearch DifficultySearch TextReadStatusSearch
+    = TextSearch AdminText.TextAPIEndpoint TagSearch DifficultySearch TextReadStatusSearch
 
 
-new : Admin.Text.TextAPIEndpoint -> TagSearch -> DifficultySearch -> TextReadStatusSearch -> TextSearch
+new : AdminText.TextAPIEndpoint -> TagSearch -> DifficultySearch -> TextReadStatusSearch -> TextSearch
 new endpoint tag_search difficulty_search status_search =
     TextSearch endpoint tag_search difficulty_search status_search
 

--- a/web/src/Utils/Date.elm
+++ b/web/src/Utils/Date.elm
@@ -4,62 +4,14 @@ import DateTime
 import Time
 
 
-padZero : Int -> Int -> String
-padZero zeros num =
-    case String.toInt <| "1" ++ String.repeat (zeros - 1) "0" of
-        Just places ->
-            if num > places then
-                String.fromInt num
-
-            else
-                String.repeat zeros "0" ++ String.fromInt num
-
-        _ ->
-            String.fromInt num
-
-
-hourMinSecFmt : DateTime.DateTime -> String
-hourMinSecFmt date =
-    String.join " "
-        [ String.join ":"
-            [ padZero 1 (DateTime.getHours date)
-            , padZero 1 (DateTime.getMinutes date)
-            , padZero 1 (DateTime.getSeconds date)
-            ]
-        , amPMFormat date
-        ]
-
-
-amPMFormat : DateTime.DateTime -> String
-amPMFormat date =
-    if DateTime.getHours date < 12 then
-        "AM"
-
-    else
-        "PM"
-
-
-
--- monthDayYearFormat : DateTime.DateTime -> String
--- monthDayYearFormat date =
---     List.foldr (++) "" <|
---         List.map (\s -> s ++ "  ")
---             [ String.fromInt <| Calendar.monthToInt <| DateTime.getMonth date
---             , (String.fromInt <| DateTime.getDay date) ++ ","
---             , hourMinSecFmt date
---             , String.fromInt <| DateTime.getYear date
---             ]
-
-
 monthDayYearFormat : DateTime.DateTime -> String
 monthDayYearFormat date =
-    List.foldr (++) "" <|
-        List.map (\s -> s ++ "  ")
-            [ toMonthString <| DateTime.getMonth date
-            , (String.fromInt <| DateTime.getDay date) ++ ","
-            , hourMinSecFmt date
-            , String.fromInt <| DateTime.getYear date
-            ]
+    String.join " "
+        [ toMonthString <| DateTime.getMonth date
+        , (String.fromInt <| DateTime.getDay date) ++ ","
+        , hourMinSecFormat date
+        , String.fromInt <| DateTime.getYear date
+        ]
 
 
 toMonthString : Time.Month -> String
@@ -100,3 +52,38 @@ toMonthString month =
 
         Time.Dec ->
             "Dec"
+
+
+hourMinSecFormat : DateTime.DateTime -> String
+hourMinSecFormat date =
+    String.join " "
+        [ String.join ":"
+            [ String.fromInt (toTwelveHourClock (DateTime.getHours date))
+            , padZero (DateTime.getMinutes date)
+            , padZero (DateTime.getSeconds date)
+            ]
+        , amPMFormat date
+        ]
+
+
+padZero : Int -> String
+padZero num =
+    if num < 10 then
+        "0" ++ String.fromInt num
+
+    else
+        String.fromInt num
+
+
+toTwelveHourClock : Int -> Int
+toTwelveHourClock hour =
+    modBy 12 (hour + 11) + 1
+
+
+amPMFormat : DateTime.DateTime -> String
+amPMFormat date =
+    if DateTime.getHours date < 12 then
+        "AM"
+
+    else
+        "PM"

--- a/web/src/Utils/Date.elm
+++ b/web/src/Utils/Date.elm
@@ -1,7 +1,7 @@
 module Utils.Date exposing (monthDayYearFormat)
 
-import Calendar
 import DateTime
+import Time
 
 
 padZero : Int -> Int -> String
@@ -18,11 +18,11 @@ padZero zeros num =
             String.fromInt num
 
 
-hour_min_sec_fmt : DateTime.DateTime -> String
-hour_min_sec_fmt date =
+hourMinSecFmt : DateTime.DateTime -> String
+hourMinSecFmt date =
     String.join " "
         [ String.join ":"
-            [ padZero 1 (DateTime.getHours date - 12)
+            [ padZero 1 (DateTime.getHours date)
             , padZero 1 (DateTime.getMinutes date)
             , padZero 1 (DateTime.getSeconds date)
             ]
@@ -39,12 +39,64 @@ amPMFormat date =
         "PM"
 
 
+
+-- monthDayYearFormat : DateTime.DateTime -> String
+-- monthDayYearFormat date =
+--     List.foldr (++) "" <|
+--         List.map (\s -> s ++ "  ")
+--             [ String.fromInt <| Calendar.monthToInt <| DateTime.getMonth date
+--             , (String.fromInt <| DateTime.getDay date) ++ ","
+--             , hourMinSecFmt date
+--             , String.fromInt <| DateTime.getYear date
+--             ]
+
+
 monthDayYearFormat : DateTime.DateTime -> String
 monthDayYearFormat date =
     List.foldr (++) "" <|
         List.map (\s -> s ++ "  ")
-            [ String.fromInt <| Calendar.monthToInt <| DateTime.getMonth date
+            [ toMonthString <| DateTime.getMonth date
             , (String.fromInt <| DateTime.getDay date) ++ ","
-            , hour_min_sec_fmt date
+            , hourMinSecFmt date
             , String.fromInt <| DateTime.getYear date
             ]
+
+
+toMonthString : Time.Month -> String
+toMonthString month =
+    case month of
+        Time.Jan ->
+            "Jan"
+
+        Time.Feb ->
+            "Feb"
+
+        Time.Mar ->
+            "Mar"
+
+        Time.Apr ->
+            "Apr"
+
+        Time.May ->
+            "May"
+
+        Time.Jun ->
+            "Jun"
+
+        Time.Jul ->
+            "Jul"
+
+        Time.Aug ->
+            "Aug"
+
+        Time.Sep ->
+            "Sep"
+
+        Time.Oct ->
+            "Oct"
+
+        Time.Nov ->
+            "Nov"
+
+        Time.Dec ->
+            "Dec"

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -21,5 +21,7 @@
     <link rel="stylesheet" href="../public/css/user.css">
     <link rel="stylesheet" href="../public/css/user_profile.css">
     <link rel="stylesheet" href="../public/css/user_reset_pass.css">
+    <link rel="stylesheet" href="../public/css/text.css">
+    <link rel="stylesheet" href="../public/css/text_search.css">
   </body>
 </html>

--- a/web/tests/Tests/Date.elm
+++ b/web/tests/Tests/Date.elm
@@ -1,0 +1,77 @@
+module Tests.Date exposing (..)
+
+import DateTime
+import Expect
+import Test exposing (..)
+import Time
+import Utils.Date exposing (monthDayYearFormat)
+
+
+suite : Test
+suite =
+    describe "The Utils.Date module"
+        [ test "Start of POSIX time" <|
+            \_ ->
+                let
+                    startPosix =
+                        DateTime.fromPosix (Time.millisToPosix 0)
+                in
+                monthDayYearFormat startPosix
+                    |> Expect.equal "Jan 1, 12:00:00 AM 1970"
+        , test "High noon on longest day of 2020" <|
+            \_ ->
+                let
+                    startPosix =
+                        DateTime.fromPosix (Time.millisToPosix 1592654400000)
+                in
+                monthDayYearFormat startPosix
+                    |> Expect.equal "Jun 20, 12:00:00 PM 2020"
+        , test "A morning time with a single digit hour" <|
+            \_ ->
+                let
+                    startPosix =
+                        DateTime.fromPosix (Time.millisToPosix 1573546352000)
+                in
+                monthDayYearFormat startPosix
+                    |> Expect.equal "Nov 12, 8:12:32 AM 2019"
+        , test "An afternoon time with a single digit hour" <|
+            \_ ->
+                let
+                    startPosix =
+                        DateTime.fromPosix (Time.millisToPosix 1236007965000)
+                in
+                monthDayYearFormat startPosix
+                    |> Expect.equal "Mar 2, 3:32:45 PM 2009"
+        , test "A morning time with a double digit hour" <|
+            \_ ->
+                let
+                    startPosix =
+                        DateTime.fromPosix (Time.millisToPosix 990963165000)
+                in
+                monthDayYearFormat startPosix
+                    |> Expect.equal "May 27, 11:32:45 AM 2001"
+        , test "A afternoon time with a double digit hour" <|
+            \_ ->
+                let
+                    startPosix =
+                        DateTime.fromPosix (Time.millisToPosix 1070319839000)
+                in
+                monthDayYearFormat startPosix
+                    |> Expect.equal "Dec 1, 11:03:59 PM 2003"
+        , test "Minutes and seconds are padded with zeros, but not hours" <|
+            \_ ->
+                let
+                    startPosix =
+                        DateTime.fromPosix (Time.millisToPosix 1373900582000)
+                in
+                monthDayYearFormat startPosix
+                    |> Expect.equal "Jul 15, 3:03:02 PM 2013"
+        , test "Leap day 2020" <|
+            \_ ->
+                let
+                    startPosix =
+                        DateTime.fromPosix (Time.millisToPosix 1582990200000)
+                in
+                monthDayYearFormat startPosix
+                    |> Expect.equal "Feb 29, 3:30:00 PM 2020"
+        ]


### PR DESCRIPTION
Adds text search page to the elm-spa implementation. The page uses a fake student profile for the moment.

Datetimes that come from the server are ISO8601, and we convert to POSIX time in the text and text list decoders.

The `Utils.Date` module has been refactored to fix a couple of bugs. The implementation does not localize, and we should open an issue to do that. A test suite to check string representations of datetimes has been added. 

The difficulties and reading statuses have been added to the `Shared` module. We may want to configure the app with these at app initialization.

The construction of `QueryParameter`s is not great in this implementation, but it will take a bit of refactoring to change the way this works. An issue should be opened on it.
