### PR TITLE
Add profiles and show help persistence

### DIFF
--- a/user/views/student.py
+++ b/user/views/student.py
@@ -229,9 +229,11 @@ class StudentAPIView(LoginRequiredMixin, APIView):
 
         student_dict = student.to_dict()
 
-        student_dict.pop('flashcards')
 
-        student_performance_report = student_dict.pop('performance_report')
+        # TODO: Hot patch
+        # student_dict.pop('flashcards')
+
+        student_performance_report = None # student_dict.pop('performance_report')
 
         return HttpResponse(json.dumps({
             'profile': student_dict,

--- a/web/public/css/user_profile.css
+++ b/web/public/css/user_profile.css
@@ -1,284 +1,310 @@
 table {
-    border: 1px solid darkgrey;
-    border-collapse: collapse;
+  border: 1px solid darkgrey;
+  border-collapse: collapse;
 }
 
 table th {
-    padding: 5px;
+  padding: 5px;
 }
 
 table td {
-    padding: 5px;
-    text-align: center;
+  padding: 5px;
+  text-align: center;
 }
 
 .profile {
-    display: grid;
+  display: grid;
 
-    grid-template-columns: 4% 10% [content] auto 15% 4%;
+  grid-template-columns: 4% 10% [content] auto 15% 4%;
 }
 
 .profile_items {
-    display: grid;
-    grid-column: content;
+  display: grid;
+  grid-column: content;
 
-    padding: 25px;
-    margin-top: 100px;
+  padding: 25px;
+  margin-top: 100px;
 
-    grid-template-columns: 35% 35% 25%;
+  grid-template-columns: 35% 35% 25%;
 
-    border: solid 0.5px lightgrey;
+  border: solid 0.5px lightgrey;
 
-    grid-row-gap: 25px;
-    grid-column-gap: 10px;
+  grid-row-gap: 25px;
+  grid-column-gap: 10px;
 }
 
 .text_readings {
-    display: grid;
+  display: grid;
 
-    margin-top: 15px;
+  margin-top: 15px;
 
-    grid-column: 1 / 4;
-    grid-row: 2;
+  grid-column: 1 / 4;
+  grid-row: 2;
 
-    grid-template-rows: 25px auto;
+  grid-template-rows: 25px auto;
 }
 
 .performance {
-    display: grid;
+  display: grid;
 
-    grid-column: 1 / 4;
-    grid-row: 4;
+  grid-column: 1 / 4;
+  grid-row: 4;
 
-    margin-top: 10px;
+  margin-top: 10px;
 
-    grid-template-rows: 25px auto;
+  grid-template-rows: 25px auto;
 }
 
 .preferred_difficulty {
-    display: grid;
-    grid-column: 1 / 4;
-    grid-row: 2;
+  display: grid;
+  grid-column: 1 / 4;
+  grid-row: 2;
 
-    margin-top: 10px;
+  margin-top: 10px;
 
-    grid-template-rows: 25px auto;
+  grid-template-rows: 25px auto;
 }
 
 .difficulty_desc {
-    margin-top: 10px;
+  margin-top: 10px;
 }
 
 .feedback {
-    display: grid;
-    grid-row: 5;
+  display: grid;
+  grid-row: 5;
 
-    font-size: larger;
+  font-size: larger;
 
-    grid-template-columns: auto;
-    grid-template-rows: 25px 35px;
+  grid-template-columns: auto;
+  grid-template-rows: 25px 35px;
 }
 
 #flashcards {
-    display: grid;
-    grid-template-columns: auto;
-    grid-template-rows: 25px 150px;
-    margin-bottom: 15px;
+  display: grid;
+  grid-template-columns: auto;
+  grid-template-rows: 25px 150px;
+  margin-bottom: 15px;
 }
 
 #flashcards > .profile_item_value {
-    overflow: scroll;
+  overflow: scroll;
 }
 
 #research_consent {
-    display: grid;
-    grid-column: 1 / 4;
-    grid-template-columns: auto;
-    grid-template-rows: auto 35px 35px;
-    grid-row-gap: 10px;
-    margin-bottom: 15px;
+  display: grid;
+  grid-row: 3;
+  grid-column: 1 / 3;
+  grid-template-columns: auto;
+  grid-template-rows: auto 35px 35px;
+  grid-row-gap: 10px;
+  margin-bottom: 15px;
 }
 
 #research_consent > .value > .check-box {
-    display: inline-block;
-    cursor: pointer;
-    border: solid black 0.5px;
-    width: 25px;
-    height: 25px;
-    margin-right: 0.5em;
+  display: inline-block;
+  cursor: pointer;
+  border: solid black 0.5px;
+  width: 25px;
+  height: 25px;
+  margin-right: 0.5em;
 }
 
 #research_consent > .value > .check-box-text {
-    display: inline-block;
-    vertical-align: top;
-    font-size: larger;
+  display: inline-block;
+  vertical-align: top;
+  font-size: larger;
+}
+
+#show-help {
+  display: grid;
+  grid-row: 3;
+  grid-column: 3 / 4;
+  grid-template-columns: auto;
+  grid-template-rows: auto 35px 60px;
+  grid-row-gap: 10px;
+  margin-bottom: 15px;
+}
+
+#show-help > .value > .check-box {
+  display: inline-block;
+  cursor: pointer;
+  border: solid black 0.5px;
+  width: 25px;
+  height: 25px;
+  margin-right: 0.5em;
+}
+
+#show-help > .value > .check-box-text {
+  display: inline-block;
+  vertical-align: top;
+  font-size: larger;
 }
 
 .check-box-selected {
-    background: darkgrey;
+  background: darkgrey;
 }
 
 .performance_report {
-    margin-top: 10px;
+  margin-top: 10px;
 }
 
 .performance_download_link {
-    margin-top: 10px;
+  margin-top: 10px;
 }
 
 .text_readings_values {
-    display: grid;
+  display: grid;
 
-    margin-top: 10px;
-    grid-template-columns: repeat(5, auto);
+  margin-top: 10px;
+  grid-template-columns: repeat(5, auto);
 
-    grid-row-gap: 15px;
-    row-gap: 15px;
+  grid-row-gap: 15px;
+  row-gap: 15px;
 }
 
 .text_reading_actions {
-    grid-template-columns: auto;
-    margin-top: 10px;
+  grid-template-columns: auto;
+  margin-top: 10px;
 }
 
 .text_reading_item {
-    margin-bottom: 5px;
+  margin-bottom: 5px;
 }
 
 .profile_item {
-    display: grid;
+  display: grid;
 
-    grid-template-columns: auto;
-    grid-template-rows: 25px 35px;
-    margin-bottom: 15px;
+  grid-template-columns: auto;
+  grid-template-rows: 25px 35px;
+  margin-bottom: 15px;
 }
 
 .profile_item_title {
-    border-bottom: solid 0.5px grey;
+  height: 16px;
+  border-bottom: solid 0.5px grey;
 }
 
 .profile_item_value {
-    margin-top: 15px;
+  margin-top: 15px;
 }
 
 .update_username {
-    margin-top: 10px;
-    font-size: smaller;
+  margin-top: 10px;
+  font-size: smaller;
 }
 
 .valid_username:after {
-    content: '✓';
-    color: #26b72b;
-    padding-left: 5px;
+  content: '✓';
+  color: #26b72b;
+  padding-left: 5px;
 }
 
 .invalid_username:after {
-    content: '✖';
-    color: #f00;
-    padding-left: 5px;
+  content: '✖';
+  color: #f00;
+  padding-left: 5px;
 }
 
 .difficulty {
-    margin-bottom: 15px;
+  margin-bottom: 15px;
 }
 
 .difficulty > .title {
-    font-size: larger;
+  font-size: larger;
 }
 
 .category {
-    margin-top: 5px;
+  margin-top: 5px;
 }
 
 .category > .title {
-    font-style: italic;
+  font-style: italic;
 }
 
 .metric {
-    margin-top: 5px;
+  margin-top: 5px;
 }
 
 .metric > .title {
-    font-size: smaller;
+  font-size: smaller;
 }
 
 .username_msg {
-    margin-top: 5px;
+  margin-top: 5px;
 }
 
 .username_submit {
-    margin-top: 5px;
+  margin-top: 5px;
 }
 
 .username_submit > span {
-    margin-left: 5px;
-    text-decoration: underline;
+  margin-left: 5px;
+  text-decoration: underline;
 }
 
 #username_hint {
-    bottom: 200px;
+  bottom: 200px;
 }
 
 #my_performance_hint {
-    bottom: 220px;
+  bottom: 220px;
 }
 
 #preferred_difficulty_hint {
-    bottom: 280px;
+  bottom: 280px;
 }
 
 #username_menu_item_hint {
-    left: 200px;
-    top: 130px;
+  left: 200px;
+  top: 130px;
 }
 
 #search_text_menu_item_hint {
-    top: 50px;
+  top: 50px;
 }
 
 .input_error {
-    border: 1px solid #ff0000;
-    background-color: #ffeeee;
+  border: 1px solid #ff0000;
+  background-color: #ffeeee;
 }
 
 @media only screen and (min-device-width: 320px) and (max-device-width: 768px) {
-    #header {
-        padding-left: 10px;
-    }
+  #header {
+    padding-left: 10px;
+  }
 
-    #lower-menu {
-        margin-top: 15px;
-    }
+  #lower-menu {
+    margin-top: 15px;
+  }
 
-    .profile {
-        display: flex;
-        font-size: 11px;
-    }
+  .profile {
+    display: flex;
+    font-size: 11px;
+  }
 
-    .footer_items {
-        margin-top: 0;
-    }
+  .footer_items {
+    margin-top: 0;
+  }
 
-    .profile_items {
-        display: flex;
-        flex-direction: column;
+  .profile_items {
+    display: flex;
+    flex-direction: column;
 
-        margin-top: 15px;
-        grid-template-columns: 50% 50%;
-    }
+    margin-top: 15px;
+    grid-template-columns: 50% 50%;
+  }
 
-    .menu {
-        display: flex;
-        flex-wrap: wrap;
-    }
+  .menu {
+    display: flex;
+    flex-wrap: wrap;
+  }
 
-    .menu > .menu_item {
-        padding-left: 5px;
-        padding-right: 5px;
-    }
+  .menu > .menu_item {
+    padding-left: 5px;
+    padding-right: 5px;
+  }
 
-    .filter {
-        display: none;
-    }
-
+  .filter {
+    display: none;
+  }
 }

--- a/web/src/Api.elm
+++ b/web/src/Api.elm
@@ -13,6 +13,7 @@ port module Api exposing
     , logout
     , post
     , put
+    , toggleShowHelp
     , viewerChanges
     , websocketConnect
     , websocketReceive
@@ -65,6 +66,13 @@ exposeToken maybeCred =
 
         Nothing ->
             ""
+
+
+
+-- HELP
+
+
+port toggleShowHelp : Value -> Cmd msg
 
 
 

--- a/web/src/Api.elm
+++ b/web/src/Api.elm
@@ -25,8 +25,10 @@ import Api.WebSocket as WebSocket exposing (WebSocketCmd, WebSocketMsg)
 import Browser
 import Browser.Navigation as Nav
 import Http
+import Id exposing (Id)
 import Json.Decode as Decode exposing (Decoder, Value, field, string)
 import Json.Decode.Pipeline exposing (required)
+import Role exposing (Role)
 import Url exposing (Url)
 
 
@@ -150,27 +152,31 @@ Otherwise, we have a guest.
 port onAuthStoreChange : (Value -> msg) -> Sub msg
 
 
-viewerChanges : (Maybe viewer -> msg) -> Decoder (Cred -> viewer) -> Sub msg
+viewerChanges : (Maybe viewer -> msg) -> Decoder (Cred -> Id -> Role -> viewer) -> Sub msg
 viewerChanges toMsg decoder =
     onAuthStoreChange (\val -> toMsg (decodeFromChange decoder val))
 
 
-decodeFromChange : Decoder (Cred -> viewer) -> Value -> Maybe viewer
+decodeFromChange : Decoder (Cred -> Id -> Role -> viewer) -> Value -> Maybe viewer
 decodeFromChange viewerDecoder val =
     Decode.decodeValue (storageDecoder viewerDecoder) val
         |> Result.toMaybe
 
 
-storageDecoder : Decoder (Cred -> viewer) -> Decoder viewer
+storageDecoder : Decoder (Cred -> Id -> Role -> viewer) -> Decoder viewer
 storageDecoder viewerDecoder =
     Decode.field "user" (decoderFromCred viewerDecoder)
 
 
-decoderFromCred : Decoder (Cred -> a) -> Decoder a
+decoderFromCred : Decoder (Cred -> Id -> Role -> a) -> Decoder a
 decoderFromCred decoder =
-    Decode.map2 (\fromCred cred -> fromCred cred)
+    Decode.map4 (\fromCred cred -> fromCred cred)
         decoder
         credDecoder
+        (Decode.field "id" Id.decoder)
+        (Decode.field "role" Decode.string
+            |> Decode.andThen Role.decoder
+        )
 
 
 
@@ -184,7 +190,7 @@ access to the token to this module.
 
 -}
 application :
-    Decoder (Cred -> viewer)
+    Decoder (Cred -> Id -> Role -> viewer)
     ->
         { init : { maybeConfig : Maybe Config, maybeViewer : Maybe viewer } -> Url -> Nav.Key -> ( model, Cmd msg )
         , onUrlChange : Url -> msg

--- a/web/src/Api/Config.elm
+++ b/web/src/Api/Config.elm
@@ -1,13 +1,17 @@
 module Api.Config exposing
     ( Config
     , configDecoder
+    , encodeShowHelp
     , init
+    , mapShowHelp
     , restApiUrl
+    , showHelp
     , websocketBaseUrl
     )
 
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline exposing (custom, required)
+import Json.Encode as Encode exposing (Value)
 
 
 type Config
@@ -17,6 +21,7 @@ type Config
 type alias Internals =
     { restApiUrl : String
     , websocketBaseUrl : String
+    , showHelp : Bool
     }
 
 
@@ -30,6 +35,7 @@ init maybeConfig =
             Config
                 { restApiUrl = "https://api.stepstoadvancedreading.org"
                 , websocketBaseUrl = "wss://api.stepstoadvancedreading.org"
+                , showHelp = True
                 }
 
 
@@ -41,6 +47,16 @@ restApiUrl (Config internals) =
 websocketBaseUrl : Config -> String
 websocketBaseUrl (Config internals) =
     internals.websocketBaseUrl
+
+
+showHelp : Config -> Bool
+showHelp (Config internals) =
+    internals.showHelp
+
+
+mapShowHelp : (Bool -> Bool) -> Config -> Config
+mapShowHelp transform (Config internals) =
+    Config { internals | showHelp = transform internals.showHelp }
 
 
 
@@ -58,3 +74,10 @@ internalsDecoder =
     Decode.succeed Internals
         |> required "restApiUrl" Decode.string
         |> required "websocketBaseUrl" Decode.string
+        |> required "showHelp" Decode.bool
+
+
+encodeShowHelp : Bool -> Value
+encodeShowHelp show =
+    Encode.object
+        [ ( "showHelp", Encode.bool show ) ]

--- a/web/src/Api/Endpoint.elm
+++ b/web/src/Api/Endpoint.elm
@@ -95,7 +95,7 @@ studentSignup baseUrl =
 
 studentProfile : String -> Int -> Endpoint
 studentProfile baseUrl id =
-    url baseUrl [ "api", "student", String.fromInt id ] []
+    url baseUrl [ "api", "student", String.fromInt id ++ "/" ] []
 
 
 consentToResearch : String -> Int -> Endpoint

--- a/web/src/Id.elm
+++ b/web/src/Id.elm
@@ -1,0 +1,17 @@
+module Id exposing (Id, decoder, id)
+
+import Json.Decode as Decode exposing (Decoder)
+
+
+type Id
+    = Id Int
+
+
+id : Id -> Int
+id (Id val) =
+    val
+
+
+decoder : Decoder Id
+decoder =
+    Decode.map Id Decode.int

--- a/web/src/Pages/Login/Instructor.elm
+++ b/web/src/Pages/Login/Instructor.elm
@@ -139,7 +139,7 @@ viewContent model =
 
 save : Model -> Shared.Model -> Shared.Model
 save model shared =
-    { shared | role = model.role }
+    shared
 
 
 load : Shared.Model -> Model -> ( Model, Cmd Msg )

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -40,7 +40,7 @@ import Views
 
 page : Page Params Model Msg
 page =
-    Page.protectedApplication
+    Page.protectedStudentApplication
         { init = init
         , update = update
         , subscriptions = subscriptions

--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -67,7 +67,8 @@ type SafeModel
         , textApiEndpoint : AdminText.TextAPIEndpoint
         , help : TextSearch.Help.TextSearchHelp
         , errorMessage : Maybe String
-        , welcome : Bool
+
+        -- , welcome : Bool
         }
 
 
@@ -122,7 +123,8 @@ init shared { params } =
         , textApiEndpoint = textApiEndpoint
         , help = textSearchHelp
         , errorMessage = Nothing
-        , welcome = True
+
+        -- , welcome = Config.showHelp shared.config
         }
     , updateResults shared.session shared.config textSearch
     )
@@ -314,7 +316,7 @@ viewLowerMenu safeModel =
 viewContent : SafeModel -> Html Msg
 viewContent (SafeModel model) =
     div [ id "text_search" ] <|
-        (if model.welcome then
+        (if Config.showHelp model.config then
             [ viewHelpMessage ]
 
          else
@@ -577,7 +579,7 @@ viewTopicFilterHint (SafeModel model) =
             , arrow_placement = ArrowUp ArrowLeft
             }
     in
-    if model.welcome then
+    if Config.showHelp model.config then
         [ Help.View.view_hint_overlay hintAttributes
         ]
 
@@ -602,7 +604,7 @@ viewDifficultyFilterHint (SafeModel model) =
             , arrow_placement = ArrowUp ArrowLeft
             }
     in
-    if model.welcome then
+    if Config.showHelp model.config then
         [ Help.View.view_hint_overlay hintAttributes
         ]
 
@@ -627,7 +629,7 @@ viewStatusFilterHint (SafeModel model) =
             , arrow_placement = ArrowUp ArrowLeft
             }
     in
-    if model.welcome then
+    if Config.showHelp model.config then
         [ Help.View.view_hint_overlay hintAttributes
         ]
 

--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -26,12 +26,8 @@ import Text.Search.Option
 import Text.Search.ReadingStatus exposing (TextReadStatus, TextReadStatusSearch)
 import Text.Search.Tag exposing (TagSearch)
 import TextSearch.Help
-import User.Profile exposing (Profile)
+import User.Profile
 import User.Student.Profile as StudentProfile
-    exposing
-        ( StudentProfile(..)
-        , StudentURIs(..)
-        )
 import Utils.Date
 import Views
 
@@ -75,25 +71,6 @@ type SafeModel
         }
 
 
-fakeProfile : Profile
-fakeProfile =
-    User.Profile.initProfile <|
-        { student_profile =
-            Just
-                { id = Just 0
-                , username = Just "fake name"
-                , email = "test@email.com"
-                , difficulty_preference = Just ( "intermediate_mid", "Intermediate-Mid" )
-                , difficulties = Shared.difficulties
-                , uris =
-                    { logout_uri = "logout"
-                    , profile_uri = "profile"
-                    }
-                }
-        , instructor_profile = Nothing
-        }
-
-
 init : Shared.Model -> Url Params -> ( SafeModel, Cmd Msg )
 init shared { params } =
     let
@@ -119,11 +96,8 @@ init shared { params } =
         defaultSearch =
             Text.Search.new textApiEndpoint tagSearch difficultySearch statusSearch
 
-        profile =
-            fakeProfile
-
         textSearch =
-            case profile of
+            case shared.profile of
                 User.Profile.Student student_profile ->
                     case StudentProfile.studentDifficultyPreference student_profile of
                         Just difficulty ->
@@ -143,7 +117,7 @@ init shared { params } =
         , config = shared.config
         , navKey = shared.key
         , results = []
-        , profile = fakeProfile
+        , profile = shared.profile
         , textSearch = textSearch
         , textApiEndpoint = textApiEndpoint
         , help = textSearchHelp

--- a/web/src/Pages/Top.elm
+++ b/web/src/Pages/Top.elm
@@ -142,7 +142,7 @@ viewContent model =
 
 save : Model -> Shared.Model -> Shared.Model
 save model shared =
-    { shared | role = model.role }
+    shared
 
 
 load : Shared.Model -> Model -> ( Model, Cmd Msg )

--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -140,26 +140,9 @@ update msg model =
             )
 
         GotStudentProfile (Err err) ->
-            ( { model | profile = Profile.fromStudentProfile fakeStudentProfile }
-              -- ( model
+            ( model
             , Cmd.none
             )
-
-
-{-| TODO: remove this placeholder when integration with backend is complete
--}
-fakeStudentProfile : StudentProfile
-fakeStudentProfile =
-    StudentProfile
-        (Just 0)
-        (Just (StudentResource.toStudentUsername "someuser"))
-        (StudentResource.toStudentEmail "user@email.com")
-        (Just ( "intermediate_mid", "Intermediate-Mid" ))
-        difficulties
-        (StudentURIs
-            (StudentResource.toStudentLogoutURI "")
-            (StudentResource.toStudentProfileURI "")
-        )
 
 
 requestStudentProfile : Session -> Config -> Id -> Cmd Msg

--- a/web/src/Spa/Page.elm
+++ b/web/src/Spa/Page.elm
@@ -136,7 +136,14 @@ protectedApplication page =
 
                 Nothing ->
                     Sub.none
-    , save = \_ shared -> shared
+    , save =
+        \maybeModel shared ->
+            case maybeModel of
+                Just model ->
+                    page.save model shared
+
+                Nothing ->
+                    shared
     , load =
         \shared maybeModel ->
             case Session.viewer shared.session of
@@ -207,7 +214,14 @@ protectedStudentApplication page =
 
                 Nothing ->
                     Sub.none
-    , save = \_ shared -> shared
+    , save =
+        \maybeModel shared ->
+            case maybeModel of
+                Just model ->
+                    page.save model shared
+
+                Nothing ->
+                    shared
     , load =
         \shared maybeModel ->
             case Session.viewer shared.session of
@@ -278,7 +292,14 @@ protectedInstructorApplication page =
 
                 Nothing ->
                     Sub.none
-    , save = \_ shared -> shared
+    , save =
+        \maybeModel shared ->
+            case maybeModel of
+                Just model ->
+                    page.save model shared
+
+                Nothing ->
+                    shared
     , load =
         \shared maybeModel ->
             case Session.viewer shared.session of

--- a/web/src/Spa/Page.elm
+++ b/web/src/Spa/Page.elm
@@ -136,10 +136,16 @@ protectedApplication page =
                     Sub.none
     , save = \_ shared -> shared
     , load =
-        \shared model ->
+        \shared maybeModel ->
             case Session.viewer shared.session of
                 Just viewer ->
-                    ( model, Cmd.none )
+                    case maybeModel of
+                        Just model ->
+                            page.load shared model
+                                |> Tuple.mapFirst Just
+
+                        Nothing ->
+                            ( Nothing, Cmd.none )
 
                 Nothing ->
                     ( Nothing

--- a/web/src/Spa/Page.elm
+++ b/web/src/Spa/Page.elm
@@ -1,7 +1,7 @@
 module Spa.Page exposing
     ( Page
     , static, sandbox, element, application
-    , protectedApplication
+    , protectedApplication, protectedInstructorApplication, protectedStudentApplication
     )
 
 {-|
@@ -13,11 +13,13 @@ module Spa.Page exposing
 -}
 
 import Browser.Navigation as Nav
+import Role exposing (Role(..))
 import Session
 import Shared
 import Spa.Document exposing (Document)
 import Spa.Generated.Route as Route
 import Spa.Url exposing (Url)
+import Viewer
 
 
 type alias Page params model msg =
@@ -105,6 +107,148 @@ protectedApplication page =
             case Session.viewer shared.session of
                 Just viewer ->
                     page.init shared url |> Tuple.mapFirst Just
+
+                Nothing ->
+                    ( Nothing
+                    , Nav.pushUrl url.key (Route.toString Route.Top)
+                    )
+    , update =
+        \msg maybeModel ->
+            case maybeModel of
+                Just model ->
+                    page.update msg model |> Tuple.mapFirst Just
+
+                Nothing ->
+                    ( Nothing, Cmd.none )
+    , view =
+        \maybeModel ->
+            case maybeModel of
+                Just model ->
+                    page.view model
+
+                Nothing ->
+                    { title = "Redirecting to login page", body = [] }
+    , subscriptions =
+        \maybeModel ->
+            case maybeModel of
+                Just model ->
+                    page.subscriptions model
+
+                Nothing ->
+                    Sub.none
+    , save = \_ shared -> shared
+    , load =
+        \shared maybeModel ->
+            case Session.viewer shared.session of
+                Just viewer ->
+                    case maybeModel of
+                        Just model ->
+                            page.load shared model
+                                |> Tuple.mapFirst Just
+
+                        Nothing ->
+                            ( Nothing, Cmd.none )
+
+                Nothing ->
+                    ( Nothing
+                    , Nav.pushUrl shared.key (Route.toString Route.Top)
+                    )
+    }
+
+
+protectedStudentApplication :
+    { init : Shared.Model -> Url params -> ( model, Cmd msg )
+    , update : msg -> model -> ( model, Cmd msg )
+    , view : model -> Document msg
+    , subscriptions : model -> Sub msg
+    , save : model -> Shared.Model -> Shared.Model
+    , load : Shared.Model -> model -> ( model, Cmd msg )
+    }
+    -> Page params (Maybe model) msg
+protectedStudentApplication page =
+    { init =
+        \shared url ->
+            case Session.viewer shared.session of
+                Just viewer ->
+                    case Viewer.role viewer of
+                        Student ->
+                            page.init shared url |> Tuple.mapFirst Just
+
+                        Instructor ->
+                            ( Nothing
+                            , Nav.pushUrl url.key (Route.toString Route.Login__Instructor)
+                            )
+
+                Nothing ->
+                    ( Nothing
+                    , Nav.pushUrl url.key (Route.toString Route.Top)
+                    )
+    , update =
+        \msg maybeModel ->
+            case maybeModel of
+                Just model ->
+                    page.update msg model |> Tuple.mapFirst Just
+
+                Nothing ->
+                    ( Nothing, Cmd.none )
+    , view =
+        \maybeModel ->
+            case maybeModel of
+                Just model ->
+                    page.view model
+
+                Nothing ->
+                    { title = "Redirecting to login page", body = [] }
+    , subscriptions =
+        \maybeModel ->
+            case maybeModel of
+                Just model ->
+                    page.subscriptions model
+
+                Nothing ->
+                    Sub.none
+    , save = \_ shared -> shared
+    , load =
+        \shared maybeModel ->
+            case Session.viewer shared.session of
+                Just viewer ->
+                    case maybeModel of
+                        Just model ->
+                            page.load shared model
+                                |> Tuple.mapFirst Just
+
+                        Nothing ->
+                            ( Nothing, Cmd.none )
+
+                Nothing ->
+                    ( Nothing
+                    , Nav.pushUrl shared.key (Route.toString Route.Top)
+                    )
+    }
+
+
+protectedInstructorApplication :
+    { init : Shared.Model -> Url params -> ( model, Cmd msg )
+    , update : msg -> model -> ( model, Cmd msg )
+    , view : model -> Document msg
+    , subscriptions : model -> Sub msg
+    , save : model -> Shared.Model -> Shared.Model
+    , load : Shared.Model -> model -> ( model, Cmd msg )
+    }
+    -> Page params (Maybe model) msg
+protectedInstructorApplication page =
+    { init =
+        \shared url ->
+            case Session.viewer shared.session of
+                Just viewer ->
+                    case Viewer.role viewer of
+                        Student ->
+                            ( Nothing
+                            , Nav.pushUrl url.key (Route.toString Route.Profile__Student)
+                            )
+
+                        Instructor ->
+                            page.init shared url |> Tuple.mapFirst Just
 
                 Nothing ->
                     ( Nothing

--- a/web/src/User/Profile.elm
+++ b/web/src/User/Profile.elm
@@ -9,6 +9,10 @@ import Profile exposing (..)
 import User.Instructor.Profile
 import User.Instructor.View
 import User.Student.Profile
+    exposing
+        ( StudentProfile(..)
+        , StudentURIs(..)
+        )
 import User.Student.Profile.Decode
 import User.Student.Profile.Resource
 import User.Student.Resource
@@ -49,6 +53,40 @@ initProfile flags =
 
                 Nothing ->
                     EmptyProfile
+
+
+{-| TODO: probably best to get rid of this empty default student profile
+somehow. This may take a fundamental restructuring of the way that
+the Profile type works. Some pages require a StudentProfile or
+InstructorProfile and it may be better to have them take a Profile and
+act accordingly.
+-}
+toStudentProfile : Profile -> User.Student.Profile.StudentProfile
+toStudentProfile profile =
+    case profile of
+        Student studentProfile ->
+            studentProfile
+
+        _ ->
+            StudentProfile
+                (Just 0)
+                (Just (User.Student.Resource.toStudentUsername ""))
+                (User.Student.Resource.toStudentEmail "")
+                Nothing
+                difficulties
+                (StudentURIs
+                    (User.Student.Resource.toStudentLogoutURI "")
+                    (User.Student.Resource.toStudentProfileURI "")
+                )
+
+
+difficulties : List ( String, String )
+difficulties =
+    [ ( "intermediate_mid", "Intermediate-Mid" )
+    , ( "intermediate_high", "Intermediate-High" )
+    , ( "advanced_low", "Advanced-Low" )
+    , ( "advanced_mid", "Advanced-Mid" )
+    ]
 
 
 emptyProfile : Profile

--- a/web/src/User/Student/Profile.elm
+++ b/web/src/User/Student/Profile.elm
@@ -3,6 +3,7 @@ module User.Student.Profile exposing
     , StudentProfileParams
     , StudentURIParams
     , StudentURIs(..)
+    , decoder
     , initProfile
     , profileUriToString
     , setStudentDifficultyPreference
@@ -16,8 +17,11 @@ module User.Student.Profile exposing
     , studentUserNameToString
     )
 
+import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Pipeline exposing (required)
 import Text.Model as Text
 import User.Student.Resource as StudentResource
+import Utils
 
 
 type alias StudentURIParams =
@@ -127,3 +131,30 @@ initProfile params =
             (StudentResource.toStudentLogoutURI params.uris.logout_uri)
             (StudentResource.toStudentProfileURI params.uris.profile_uri)
         )
+
+
+
+-- DECODE
+
+
+uriParamsDecoder : Decoder StudentURIParams
+uriParamsDecoder =
+    Decode.succeed StudentURIParams
+        |> required "logout_uri" Decode.string
+        |> required "profile_uri" Decode.string
+
+
+paramsDecoder : Decoder StudentProfileParams
+paramsDecoder =
+    Decode.succeed StudentProfileParams
+        |> required "id" (Decode.nullable Decode.int)
+        |> required "username" (Decode.nullable Decode.string)
+        |> required "email" Decode.string
+        |> required "difficulty_preference" (Decode.nullable Utils.stringTupleDecoder)
+        |> required "difficulties" (Decode.list Utils.stringTupleDecoder)
+        |> required "uris" uriParamsDecoder
+
+
+decoder : Decoder StudentProfile
+decoder =
+    Decode.map initProfile paramsDecoder

--- a/web/src/User/Student/Profile.elm
+++ b/web/src/User/Student/Profile.elm
@@ -157,4 +157,5 @@ paramsDecoder =
 
 decoder : Decoder StudentProfile
 decoder =
-    Decode.map initProfile paramsDecoder
+    Decode.field "profile" paramsDecoder
+        |> Decode.map initProfile

--- a/web/src/User/Student/Profile/Decode.elm
+++ b/web/src/User/Student/Profile/Decode.elm
@@ -1,13 +1,13 @@
 module User.Student.Profile.Decode exposing
     ( studentConsentRespDecoder
     , studentProfileDecoder
-    , username_valid_decoder
+    , usernameValidationDecoder
     )
 
 import InstructorAdmin.Text.Translations exposing (Phrase)
-import Text.Translations.Decode as TextTranslationsDecode
 import Json.Decode
 import Json.Decode.Pipeline exposing (required)
+import Text.Translations.Decode as TextTranslationsDecode
 import TextReader.Section.Decode
 import TextReader.TextWord
 import User.Student.Performance.Report exposing (PerformanceReport)
@@ -17,8 +17,8 @@ import User.Student.Resource as StudentResource
 import Utils exposing (stringTupleDecoder)
 
 
-username_valid_decoder : Json.Decode.Decoder StudentProfileModel.UsernameUpdate
-username_valid_decoder =
+usernameValidationDecoder : Json.Decode.Decoder StudentProfileModel.UsernameUpdate
+usernameValidationDecoder =
     Json.Decode.succeed StudentProfileModel.UsernameUpdate
         |> required "username" (Json.Decode.map (StudentResource.toStudentUsername >> Just) Json.Decode.string)
         |> required "valid" (Json.Decode.nullable Json.Decode.bool)

--- a/web/src/User/Student/Profile/Help.elm
+++ b/web/src/User/Student/Profile/Help.elm
@@ -10,21 +10,23 @@ module User.Student.Profile.Help exposing
     , popupToOverlayID
     , preferredDifficultyHelp
     , prev
-    , profileHelp
     , scrollToFirstMsg
     , scrollToNextMsg
     , scrollToPrevMsg
     , searchTextsHelp
     , setVisible
+    , showHintsHelp
     , usernameHelp
     )
 
+import Api.Config exposing (showHelp)
 import Help exposing (HelpMsgID, HelpMsgOverlayID, HelpMsgStr, HelpMsgVisible)
 import Help.PopUp exposing (Help)
 
 
 type StudentHelp
-    = UsernameHelp HelpMsgStr
+    = ShowHintsHelp HelpMsgStr
+    | UsernameHelp HelpMsgStr
     | MyPerformanceHelp HelpMsgStr
     | PreferredDifficultyHelp HelpMsgStr
     | UsernameMenuItemHelp HelpMsgStr
@@ -40,6 +42,13 @@ usernameHelp =
     UsernameHelp
         """You can create a new username that is distinct from your email address if you choose.
      Your username will be visible to instructors and other students if you comment on any texts."""
+
+
+showHintsHelp : StudentHelp
+showHintsHelp =
+    ShowHintsHelp
+        """Welcome to the Steps to Advanced Reading! The following tutorial will walk you through
+        using this app. You can turn off the tutorial here and come back to turn it on at any time."""
 
 
 myPerformanceHelp : StudentHelp
@@ -58,13 +67,6 @@ preferredDifficultyHelp =
      then you can use these brief descriptions to pick the level that is closest to your current abilities."""
 
 
-profileHelp : StudentHelp
-profileHelp =
-    UsernameMenuItemHelp
-        """You can return to this profile page at any time, by clicking on your username in the top right corner of the
-    screen. Hovering over your username, you can see the option to log out."""
-
-
 searchTextsHelp : StudentHelp
 searchTextsHelp =
     SearchTextsMenuItemHelp
@@ -73,10 +75,10 @@ searchTextsHelp =
 
 help_msgs : List StudentHelp
 help_msgs =
-    [ usernameHelp
+    [ showHintsHelp
+    , usernameHelp
     , myPerformanceHelp
     , preferredDifficultyHelp
-    , profileHelp
     , searchTextsHelp
     ]
 
@@ -135,6 +137,9 @@ scrollToFirstMsg student_profile_help =
 helpMsg : StudentHelp -> HelpMsgStr
 helpMsg help_msg =
     case help_msg of
+        ShowHintsHelp hintsHelp ->
+            hintsHelp
+
         UsernameHelp unameHelp ->
             unameHelp
 
@@ -154,6 +159,9 @@ helpMsg help_msg =
 popupToID : StudentHelp -> HelpMsgID
 popupToID studentHelp =
     case studentHelp of
+        ShowHintsHelp _ ->
+            "help_hints"
+
         UsernameHelp _ ->
             "username_hint"
 

--- a/web/src/Viewer.elm
+++ b/web/src/Viewer.elm
@@ -1,18 +1,30 @@
-module Viewer exposing (Viewer, cred, decoder)
+module Viewer exposing (Viewer, cred, decoder, id, role)
 
 import Api exposing (Cred)
+import Id exposing (Id)
 import Json.Decode as Decode exposing (Decoder)
+import Role exposing (Role)
 
 
 type Viewer
-    = Viewer Cred
+    = Viewer Cred Id Role
 
 
-decoder : Decoder (Cred -> Viewer)
+decoder : Decoder (Cred -> Id -> Role -> Viewer)
 decoder =
     Decode.succeed Viewer
 
 
 cred : Viewer -> Cred
-cred (Viewer val) =
+cred (Viewer val _ _) =
+    val
+
+
+id : Viewer -> Id
+id (Viewer _ val _) =
+    val
+
+
+role : Viewer -> Role
+role (Viewer _ _ val) =
     val

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error
 import { Elm } from './Main.elm';
 
-type User = { user: { token: string } };
+type User = { user: { id: number; token: string; role: string } };
 type Creds = { email: string; password: string; role: string };
 
 const restApiUrl: string = process.env.RESTAPIURL;
@@ -44,7 +44,9 @@ app.ports.login.subscribe(async (creds: Creds) => {
   const jsonResponse = await response.json(); // { token: "JWTToken"}
 
   if (response.ok) {
-    const user: User = { user: { token: jsonResponse.token } };
+    const user: User = {
+      user: { id: jsonResponse.id, token: jsonResponse.token, role: creds.role }
+    };
     localStorage.setItem(authStoreKey, JSON.stringify(user));
     app.ports.onAuthStoreChange.send(user);
   } else {

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -2,6 +2,7 @@
 import { Elm } from './Main.elm';
 
 type User = { user: { id: number; token: string; role: string } };
+type ShowHelp = { showHelp: boolean };
 type Creds = { email: string; password: string; role: string };
 
 const restApiUrl: string = process.env.RESTAPIURL;
@@ -12,10 +13,22 @@ let mySockets = {};
 // INIT
 
 const user: User = JSON.parse(localStorage.getItem(authStoreKey));
+let showHelp: ShowHelp = JSON.parse(localStorage.getItem('showHelp'));
+
+if (showHelp === null) {
+  showHelp = { showHelp: true };
+  localStorage.setItem('showHelp', JSON.stringify(showHelp));
+}
 
 const app = Elm.Main.init({
   node: document.getElementById('main'),
-  flags: { restApiUrl, websocketBaseUrl, ...user }
+  flags: { restApiUrl, websocketBaseUrl, ...showHelp, ...user }
+});
+
+// HELP
+
+app.ports.toggleShowHelp.subscribe(showHelp => {
+  localStorage.setItem('showHelp', JSON.stringify(showHelp));
 });
 
 // LOGIN


### PR DESCRIPTION
This PR adds localstorage persistence for roles, ids, and a show help flag. It also includes a hot patch to get the backend serving partial student profiles.

The following should work now:
- When a student logs in, they are redirected to the profile page and parts of their profile will load (see #159 regarding some missing parts)
- If a student closes the browser and re-opens the app or opens the app in a new tab, they are redirected to their profile page and their profile loads (the persistence piece)
- A new show help button toggles help messages on and off and the student's preference is persisted across sessions
- A student is always shown help messages the first time they use the app