### PR TITLE
Upgrade/instructor profile api endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,7 @@ Generated/
 
 #node
 node_modules/
+
+# Docker
+secrets.env
+ereadingtool.com

--- a/user/urls/instructor.py
+++ b/user/urls/instructor.py
@@ -1,8 +1,8 @@
 from django.urls import path
-from user.views.instructor import (InstructorSignupAPIView, InstructorLoginAPIView, InstructorLogoutAPIView,
-                                   InstructorSignUpView, InstructorLoginView, InstructorProfileView,
-                                   InstructorInviteAPIView, ElmLoadJsInstructorProfileView,
-                                   ElmLoadJsInstructorNoAuthView)
+from user.views.instructor import (InstructorAPIView, InstructorSignupAPIView, InstructorLoginAPIView, 
+                                   InstructorLogoutAPIView, InstructorSignUpView, InstructorLoginView,
+                                   InstructorProfileView, InstructorInviteAPIView, 
+                                   ElmLoadJsInstructorProfileView, ElmLoadJsInstructorNoAuthView)
 
 
 api_urlpatterns = [
@@ -10,6 +10,7 @@ api_urlpatterns = [
     path('api/instructor/signup/', InstructorSignupAPIView.as_view(), name='api-instructor-signup'),
     path('api/instructor/login/', InstructorLoginAPIView.as_view(), name='api-instructor-login'),
     path('api/instructor/logout/', InstructorLogoutAPIView.as_view(), name='api-instructor-logout'),
+    path('api/instructor/<int:pk>/', InstructorAPIView.as_view(), name='api-instructor')
 ]
 
 elm_load_urlpatterns = [

--- a/user/views/instructor.py
+++ b/user/views/instructor.py
@@ -76,6 +76,9 @@ class InstructorView(ProfileView):
     login_url = Instructor.login_url
 
 
+class InstructorAPIView(LoginRequiredMixin, APIView):
+    pass
+
 class InstructorInviteAPIView(LoginRequiredMixin, APIView):
     login_url = Instructor.login_url
 

--- a/user/views/instructor.py
+++ b/user/views/instructor.py
@@ -77,7 +77,10 @@ class InstructorView(ProfileView):
 
 
 class InstructorAPIView(LoginRequiredMixin, APIView):
-    pass
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        if not Instructor.objects.get(pk=kwargs['pk']):
+            return HttpResponse(status=400)
+        
 
 class InstructorInviteAPIView(LoginRequiredMixin, APIView):
     login_url = Instructor.login_url

--- a/user/views/instructor.py
+++ b/user/views/instructor.py
@@ -80,7 +80,15 @@ class InstructorAPIView(LoginRequiredMixin, APIView):
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         if not Instructor.objects.get(pk=kwargs['pk']):
             return HttpResponse(status=400)
-        
+
+        instructor = Instructor.objects.get(pk=kwargs['pk'])
+
+        instructor_dict = instructor.to_dict()
+
+        return HttpResponse(json.dumps({
+            'profile': instructor_dict,
+        }))
+
 
 class InstructorInviteAPIView(LoginRequiredMixin, APIView):
     login_url = Instructor.login_url

--- a/user/views/student.py
+++ b/user/views/student.py
@@ -165,7 +165,6 @@ class StudentView(ProfileView):
 
 class StudentAPIConsentToResearchView(LoginRequiredMixin, APIView):
     # returns permission denied HTTP message rather than redirect to login
-    raise_exception = True
 
     def form(self, request: HttpRequest, params: Dict, **kwargs) -> forms.ModelForm:
         return StudentConsentForm(params, **kwargs)

--- a/user/views/student.py
+++ b/user/views/student.py
@@ -212,8 +212,6 @@ class StudentAPIConsentToResearchView(LoginRequiredMixin, APIView):
 
 
 class StudentAPIView(LoginRequiredMixin, APIView):
-    # returns permission denied HTTP message rather than redirect to login
-    raise_exception = True
 
     def form(self, request: HttpRequest, params: Dict, **kwargs) -> forms.ModelForm:
         return StudentForm(params, **kwargs)

--- a/user/views/student_performance.py
+++ b/user/views/student_performance.py
@@ -10,8 +10,6 @@ from user.student.models import Student
 
 
 class StudentPerformancePDFView(LoginRequiredMixin, View):
-    # returns permission denied HTTP message rather than redirect to login
-    raise_exception = True
 
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         if not Student.objects.filter(pk=kwargs['pk']).exists():


### PR DESCRIPTION
This pull request brings in a rudimentary instructor profile. Details of the response object (when a request is sent to `api/instructor/<id:pk>` can be found at this [gh issue](https://github.com/ereadingtool/ereadingtool/issues/165). 