### PR TITLE
Move navbar to Shared module

### DIFF
--- a/web/src/Api.elm
+++ b/web/src/Api.elm
@@ -7,7 +7,6 @@ port module Api exposing
     , authResult
     , authSuccessMessage
     , delete
-    , exposeToken
     , get
     , login
     , logout
@@ -50,22 +49,6 @@ credDecoder : Decoder Cred
 credDecoder =
     Decode.succeed Cred
         |> required "token" Decode.string
-
-
-{-| Exposes the token outside this module
-
-TODO: remove this. This should be considered a temporary measure for use while transitioning the
-backend communication layer.
-
--}
-exposeToken : Maybe Cred -> String
-exposeToken maybeCred =
-    case maybeCred of
-        Just (Cred val) ->
-            val
-
-        Nothing ->
-            ""
 
 
 

--- a/web/src/Pages/Login/Instructor.elm
+++ b/web/src/Pages/Login/Instructor.elm
@@ -109,8 +109,7 @@ view model =
     { title = "Instructor Login"
     , body =
         [ div []
-            [ Views.view_unauthed_header
-            , viewContent model
+            [ viewContent model
             , Views.view_footer
             ]
         ]
@@ -124,7 +123,7 @@ viewContent model =
             { onEmailUpdate = UpdateEmail
             , onPasswordUpdate = UpdatePassword
             , onSubmittedForm = SubmittedLogin
-            , signUpRoute = Route.Signup__Student
+            , signUpRoute = Route.Signup__Instructor
             , otherLoginRole = "student"
             , otherLoginRoute = Route.Top
             , maybeHelpMessage = Nothing

--- a/web/src/Pages/Profile/Instructor.elm
+++ b/web/src/Pages/Profile/Instructor.elm
@@ -177,11 +177,10 @@ newInviteResponseDecoder =
 
 view : SafeModel -> Document Msg
 view (SafeModel model) =
-    { title = "ProtectedApplicationTemplate"
+    { title = "Instructor Profile"
     , body =
         [ div []
-            [ viewHeader (SafeModel model)
-            , viewContent (SafeModel model)
+            [ viewContent (SafeModel model)
             , Views.view_footer
             ]
         ]
@@ -315,58 +314,6 @@ viewInstructorInviteCreate (SafeModel model) =
             [ Html.input [ onClick SubmittedNewInvite, attribute "type" "button", attribute "value" "Submit" ] []
             ]
         ]
-
-
-
--- VIEW: HEADER
-
-
-viewHeader : SafeModel -> Html Msg
-viewHeader safeModel =
-    Views.view_header
-        (viewTopHeader safeModel)
-        (viewLowerMenu safeModel)
-
-
-viewTopHeader : SafeModel -> List (Html Msg)
-viewTopHeader safeModel =
-    [ div [ classList [ ( "menu_item", True ) ] ]
-        [ a
-            [ class "link"
-            , href
-                (Route.toString Route.Profile__Instructor)
-            ]
-            [ text "Profile" ]
-        ]
-    , div [ classList [ ( "menu_item", True ) ] ]
-        [ a [ class "link", onClick Logout ]
-            [ text "Logout" ]
-        ]
-    ]
-
-
-viewLowerMenu : SafeModel -> List (Html Msg)
-viewLowerMenu (SafeModel model) =
-    [ div
-        [ classList [ ( "lower-menu-item", True ) ] ]
-        [ a
-            [ class "link"
-            , href (Route.toString Route.Text__EditorSearch)
-            ]
-            [ text "Find a text to edit" ]
-        ]
-    , div
-        [ classList
-            [ ( "lower-menu-item", True )
-            ]
-        ]
-        [ a
-            [ class "link"
-            , href (Route.toString Route.Text__Search)
-            ]
-            [ text "Find a text to read" ]
-        ]
-    ]
 
 
 

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -411,67 +411,11 @@ view (SafeModel model) =
     { title = "Student Profile"
     , body =
         [ div []
-            [ viewHeader (SafeModel model)
-            , viewContent (SafeModel model)
+            [ viewContent (SafeModel model)
             , Views.view_footer
             ]
         ]
     }
-
-
-viewHeader : SafeModel -> Html Msg
-viewHeader safeModel =
-    Views.view_header
-        (viewTopHeader safeModel)
-        (viewLowerMenu safeModel)
-
-
-viewTopHeader : SafeModel -> List (Html Msg)
-viewTopHeader safeModel =
-    [ div [ classList [ ( "menu_item", True ) ] ]
-        [ a
-            [ class "link"
-            , href
-                (Route.toString Route.Profile__Student)
-            ]
-            [ text "Profile" ]
-        ]
-    , div [ classList [ ( "menu_item", True ) ] ]
-        [ a [ class "link", onClick Logout ]
-            [ text "Logout" ]
-        ]
-
-    -- , div [] [ viewProfileHint safeModel ]
-    ]
-
-
-viewLowerMenu : SafeModel -> List (Html Msg)
-viewLowerMenu (SafeModel model) =
-    [ div
-        [ classList
-            [ ( "lower-menu-item", True )
-
-            -- , ( "lower-menu-item-selected", Menu.Item.selected menu_item )
-            ]
-        ]
-      <|
-        viewSearchTextsHint
-            (SafeModel model)
-            ++ [ a
-                    [ class "link"
-                    , href (Route.toString Route.Text__Search)
-                    ]
-                    [ text "Find a text to read" ]
-               ]
-    , div
-        [ classList [ ( "lower-menu-item", True ) ] ]
-        [ a
-            [ class "link"
-            , href (Route.toString Route.NotFound)
-            ]
-            [ text "Practice Flashcards" ]
-        ]
-    ]
 
 
 viewContent : SafeModel -> Html Msg

--- a/web/src/Pages/Signup/Instructor.elm
+++ b/web/src/Pages/Signup/Instructor.elm
@@ -224,8 +224,7 @@ view model =
     { title = "Instructor Signup"
     , body =
         [ div []
-            [ Views.view_unauthed_header
-            , div [ classList [ ( "signup", True ) ] ]
+            [ div [ classList [ ( "signup", True ) ] ]
                 [ div [ class "signup_title" ] [ Html.text "Instructor Signup" ]
                 , div [ classList [ ( "signup_box", True ) ] ] <|
                     SignUp.view_email_input UpdateEmail model

--- a/web/src/Pages/Signup/Student.elm
+++ b/web/src/Pages/Signup/Student.elm
@@ -196,8 +196,7 @@ view model =
     { title = "Student Signup"
     , body =
         [ div []
-            [ Views.view_unauthed_header
-            , viewContent model
+            [ viewContent model
             , Views.view_footer
             ]
         ]

--- a/web/src/Pages/Text/EditorSearch.elm
+++ b/web/src/Pages/Text/EditorSearch.elm
@@ -112,8 +112,7 @@ view (SafeModel model) =
     { title = "Editor Search"
     , body =
         [ div []
-            [ viewHeader (SafeModel model)
-            , viewTexts (SafeModel model)
+            [ viewTexts (SafeModel model)
             , viewFooter (SafeModel model)
             ]
         ]
@@ -194,58 +193,6 @@ viewFooter (SafeModel model) =
                 Html.text <| "Showing " ++ String.fromInt (List.length model.texts) ++ " entries"
             ]
         ]
-
-
-
--- VIEW: HEADER
-
-
-viewHeader : SafeModel -> Html Msg
-viewHeader safeModel =
-    Views.view_header
-        (viewTopHeader safeModel)
-        (viewLowerMenu safeModel)
-
-
-viewTopHeader : SafeModel -> List (Html Msg)
-viewTopHeader safeModel =
-    [ div [ classList [ ( "menu_item", True ) ] ]
-        [ a
-            [ class "link"
-            , href
-                (Route.toString Route.Profile__Instructor)
-            ]
-            [ text "Profile" ]
-        ]
-    , div [ classList [ ( "menu_item", True ) ] ]
-        [ a [ class "link", onClick Logout ]
-            [ text "Logout" ]
-        ]
-    ]
-
-
-viewLowerMenu : SafeModel -> List (Html Msg)
-viewLowerMenu (SafeModel model) =
-    [ div
-        [ classList [ ( "lower-menu-item", True ) ] ]
-        [ a
-            [ class "link"
-            , href (Route.toString Route.Text__EditorSearch)
-            ]
-            [ text "Find a text to edit" ]
-        ]
-    , div
-        [ classList
-            [ ( "lower-menu-item", True )
-            ]
-        ]
-        [ a
-            [ class "link"
-            , href (Route.toString Route.Text__Search)
-            ]
-            [ text "Find a text to read" ]
-        ]
-    ]
 
 
 

--- a/web/src/Pages/Text/Id_Int.elm
+++ b/web/src/Pages/Text/Id_Int.elm
@@ -411,8 +411,7 @@ view (SafeModel model) =
     { title = "Text"
     , body =
         [ div []
-            [ viewHeader (SafeModel model)
-            , viewContent (SafeModel model)
+            [ viewContent (SafeModel model)
             , Views.view_footer
             ]
         ]
@@ -728,58 +727,7 @@ tagWord (SafeModel model) textReaderSection instance token =
 --             , view_flashcard_options model reader_word
 --             ]
 --         ]
--- VIEW: HEADER
-
-
-viewHeader : SafeModel -> Html Msg
-viewHeader safeModel =
-    Views.view_header
-        (viewTopHeader safeModel)
-        (viewLowerMenu safeModel)
-
-
-viewTopHeader : SafeModel -> List (Html Msg)
-viewTopHeader safeModel =
-    [ div [ classList [ ( "menu_item", True ) ] ]
-        [ a
-            [ class "link"
-            , href
-                (Route.toString Route.Profile__Student)
-            ]
-            [ text "Profile" ]
-        ]
-    , div [ classList [ ( "menu_item", True ) ] ]
-        [ a [ class "link", onClick Logout ]
-            [ text "Logout" ]
-        ]
-    ]
-
-
-viewLowerMenu : SafeModel -> List (Html Msg)
-viewLowerMenu (SafeModel model) =
-    [ div
-        [ classList
-            [ ( "lower-menu-item", True )
-            ]
-        ]
-        [ a
-            [ class "link"
-            , href (Route.toString Route.Text__Search)
-            ]
-            [ text "Find a text to read" ]
-        ]
-    , div
-        [ classList [ ( "lower-menu-item", True ) ] ]
-        [ a
-            [ class "link"
-            , href (Route.toString Route.NotFound)
-            ]
-            [ text "Practice Flashcards" ]
-        ]
-    ]
-
-
-
+--
 -- SHARED
 
 

--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -257,60 +257,11 @@ view (SafeModel model) =
     { title = "Search Texts"
     , body =
         [ div []
-            [ viewHeader (SafeModel model)
-            , viewContent (SafeModel model)
+            [ viewContent (SafeModel model)
             , Views.view_footer
             ]
         ]
     }
-
-
-viewHeader : SafeModel -> Html Msg
-viewHeader safeModel =
-    Views.view_header
-        (viewTopHeader safeModel)
-        (viewLowerMenu safeModel)
-
-
-viewTopHeader : SafeModel -> List (Html Msg)
-viewTopHeader safeModel =
-    [ div [ classList [ ( "menu_item", True ) ] ]
-        [ a
-            [ class "link"
-            , href
-                (Route.toString Route.Profile__Student)
-            ]
-            [ text "Profile" ]
-        ]
-    , div [ classList [ ( "menu_item", True ) ] ]
-        [ a [ class "link", onClick Logout ]
-            [ text "Logout" ]
-        ]
-    ]
-
-
-viewLowerMenu : SafeModel -> List (Html Msg)
-viewLowerMenu safeModel =
-    [ div
-        [ classList
-            [ ( "lower-menu-item", True )
-            ]
-        ]
-        [ a
-            [ class "link"
-            , href (Route.toString Route.Text__Search)
-            ]
-            [ text "Find a text to read" ]
-        ]
-    , div
-        [ classList [ ( "lower-menu-item", True ) ] ]
-        [ a
-            [ class "link"
-            , href (Route.toString Route.NotFound)
-            ]
-            [ text "Practice Flashcards" ]
-        ]
-    ]
 
 
 viewContent : SafeModel -> Html Msg

--- a/web/src/Pages/Top.elm
+++ b/web/src/Pages/Top.elm
@@ -109,8 +109,7 @@ view model =
     { title = "Student Login"
     , body =
         [ div []
-            [ Views.view_unauthed_header
-            , viewContent model
+            [ viewContent model
             , Views.view_footer
             ]
         ]

--- a/web/src/Pages/User/ForgotPassword.elm
+++ b/web/src/Pages/User/ForgotPassword.elm
@@ -151,8 +151,7 @@ view model =
     { title = "Forgot Password"
     , body =
         [ div []
-            [ Views.view_unauthed_header
-            , viewContent model
+            [ viewContent model
             , Views.view_footer
             ]
         ]

--- a/web/src/Pages/User/ResetPassword/Uidb64_String/Token_String.elm
+++ b/web/src/Pages/User/ResetPassword/Uidb64_String/Token_String.elm
@@ -192,8 +192,7 @@ view model =
     { title = "Reset Password"
     , body =
         [ div []
-            [ Views.view_unauthed_header
-            , viewContent model
+            [ viewContent model
             , Views.view_footer
             ]
         ]

--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -238,7 +238,7 @@ viewHeader model toMsg =
         case Session.viewer model.session of
             Just viewer ->
                 [ div [ id "header" ]
-                    [ viewLogo
+                    [ viewLogo model.session
                     , div [ class "menu" ] <|
                         viewTopHeader (Viewer.role viewer) toMsg
                     ]
@@ -250,19 +250,34 @@ viewHeader model toMsg =
 
             Nothing ->
                 [ div [ id "header" ]
-                    [ viewLogo ]
+                    [ viewLogo model.session ]
                 , div [ id "lower-menu" ] []
                 ]
 
 
-viewLogo : Html msg
-viewLogo =
-    Html.img
-        [ attribute "src" "/public/img/star_logo.png"
-        , id "logo"
-        , attribute "alt" "Steps To Advanced Reading Logo"
+viewLogo : Session -> Html msg
+viewLogo session =
+    a
+        [ href <|
+            case Session.viewer session of
+                Just viewer ->
+                    case Viewer.role viewer of
+                        Student ->
+                            Route.toString Route.Profile__Student
+
+                        Instructor ->
+                            Route.toString Route.Profile__Instructor
+
+                Nothing ->
+                    Route.toString Route.Top
         ]
-        []
+        [ Html.img
+            [ attribute "src" "/public/img/star_logo.png"
+            , id "logo"
+            , attribute "alt" "Steps To Advanced Reading Logo"
+            ]
+            []
+        ]
 
 
 viewTopHeader : Role -> (Msg -> msg) -> List (Html msg)


### PR DESCRIPTION
This PR moves the navbar from each individual page into the Shared module. The shared the implementation displays one of the following:

- An unauthenticated navbar
- A student navbar
- An instructor navbar

All links in each version of the navbar should route the to the appropriate page if implemented or the NotFound page if not.

A link was also added to the STAR logo directing the user to their profile or to the homepage if they are not authenticated. This addresses #46.