### PR TITLE
Add CSRF-exemption to all ReST API endpoints

### DIFF
--- a/ereadingtool/views.py
+++ b/ereadingtool/views.py
@@ -1,7 +1,15 @@
 from typing import Dict
 
 from django.utils.translation import gettext as _
-from django.views.generic import TemplateView
+from django.views.generic import View, TemplateView
+from django.views.decorators.csrf import csrf_exempt
+from django.utils.decorators import method_decorator
+
+
+class APIView(View):
+    @method_decorator(csrf_exempt)
+    def dispatch(self, request, *args, **kwargs):
+        return super(APIView, self).dispatch(request, *args, **kwargs)
 
 
 class AcknowledgementView(TemplateView):

--- a/question/views.py
+++ b/question/views.py
@@ -4,6 +4,7 @@ from django.db.models import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse
 from django.views.generic import View
+from ereadingtool.views import APIView
 
 from text.models import Text
 from question.models import Question
@@ -11,7 +12,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 
 
-class QuestionAPIView(LoginRequiredMixin, View):
+class QuestionAPIView(LoginRequiredMixin, APIView):
     model = Question
     login_url = reverse_lazy('student-login')
 

--- a/text/views/api/lock.py
+++ b/text/views/api/lock.py
@@ -4,12 +4,12 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse, HttpRequest, HttpResponseServerError
 from django.http import HttpResponseNotAllowed
 from django.urls import reverse_lazy
-from django.views.generic import View
+from ereadingtool.views import APIView
 
 from text.models import Text
 
 
-class TextLockAPIView(LoginRequiredMixin, View):
+class TextLockAPIView(LoginRequiredMixin, APIView):
     login_url = reverse_lazy('instructor-login')
 
     model = Text

--- a/text/views/api/tag.py
+++ b/text/views/api/tag.py
@@ -5,12 +5,12 @@ from django.db import IntegrityError
 from django.http import HttpResponse, HttpRequest, HttpResponseServerError
 from django.http import HttpResponseNotAllowed
 from django.urls import reverse_lazy
-from django.views.generic import View
+from ereadingtool.views import APIView
 
 from text.models import Text
 
 
-class TextTagAPIView(LoginRequiredMixin, View):
+class TextTagAPIView(LoginRequiredMixin, APIView):
     login_url = reverse_lazy('instructor-login')
 
     model = Text

--- a/text/views/api/text.py
+++ b/text/views/api/text.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse, HttpRequest, HttpResponseServerError
 from django.http import HttpResponseNotAllowed
 from django.urls import reverse
 from django.urls import reverse_lazy
-from django.views.generic import View
+from ereadingtool.views import APIView
 
 from mixins.model import WriteLocked
 from question.forms import QuestionForm, AnswerForm
@@ -35,7 +35,7 @@ def or_filters(filters):
     return status_filter
 
 
-class TextAPIView(LoginRequiredMixin, View):
+class TextAPIView(LoginRequiredMixin, APIView):
     login_url = reverse_lazy('instructor-login')
     allowed_methods = ['get', 'put', 'post', 'delete']
 

--- a/text/views/api/text_sections.py
+++ b/text/views/api/text_sections.py
@@ -1,8 +1,9 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 from django.views.generic import View
+from ereadingtool.views import APIView
 
 
-class TextSectionDefinitionAPIView(LoginRequiredMixin, View):
+class TextSectionDefinitionAPIView(LoginRequiredMixin, APIView):
     login_url = reverse_lazy('instructor-login')
     allowed_methods = ['get', 'put', 'post', 'delete']

--- a/text/views/api/text_word/group.py
+++ b/text/views/api/text_word/group.py
@@ -5,13 +5,13 @@ from django.db import models
 from django.db import transaction
 from django.http import HttpResponse, HttpRequest, HttpResponseServerError
 from django.urls import reverse_lazy
-from django.views.generic import View
+from ereadingtool.views import APIView
 
 from text.translations.group.models import TextWordGroup, TextGroupWord
 from text.translations.models import TextWord
 
 
-class TextWordGroupAPIView(LoginRequiredMixin, View):
+class TextWordGroupAPIView(LoginRequiredMixin, APIView):
     model = TextWordGroup
 
     login_url = reverse_lazy('instructor-login')

--- a/text/views/api/text_word/word.py
+++ b/text/views/api/text_word/word.py
@@ -6,7 +6,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse, HttpRequest, HttpResponseServerError
 from django.http import HttpResponseNotAllowed
 from django.urls import reverse_lazy
-from django.views.generic import View
+from ereadingtool.views import APIView
 
 from django.db import transaction, DatabaseError
 from django.core.exceptions import ObjectDoesNotExist
@@ -18,7 +18,7 @@ from text.translations.models import TextWord
 from text.phrase.models import TextPhrase, TextPhraseTranslation
 
 
-class TextWordAPIView(LoginRequiredMixin, View):
+class TextWordAPIView(LoginRequiredMixin, APIView):
     login_url = reverse_lazy('instructor-login')
     allowed_methods = ['post', 'put', 'delete']
 
@@ -83,7 +83,7 @@ class TextWordAPIView(LoginRequiredMixin, View):
             return HttpResponseServerError(json.dumps({'errors': 'something went wrong'}))
 
 
-class TextWordTranslationsAPIView(LoginRequiredMixin, View):
+class TextWordTranslationsAPIView(LoginRequiredMixin, APIView):
     login_url = reverse_lazy('instructor-login')
     allowed_methods = ['put', 'post', 'delete']
 

--- a/text/views/api/translations.py
+++ b/text/views/api/translations.py
@@ -5,7 +5,7 @@ import jsonschema
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse, HttpRequest, HttpResponseServerError
 from django.urls import reverse_lazy
-from django.views.generic import View
+from ereadingtool.views import APIView
 
 from django.db import transaction, DatabaseError
 from django.core.exceptions import ObjectDoesNotExist
@@ -13,7 +13,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from text.phrase.models import TextPhrase, TextPhraseTranslation
 
 
-class TextTranslationMatchAPIView(LoginRequiredMixin, View):
+class TextTranslationMatchAPIView(LoginRequiredMixin, APIView):
     login_url = reverse_lazy('instructor-login')
     allowed_methods = ['put']
 

--- a/user/views/api.py
+++ b/user/views/api.py
@@ -4,12 +4,12 @@ from django import forms
 from django.http import JsonResponse, HttpRequest
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.debug import sensitive_post_parameters
-from django.views.generic import View
+
+from ereadingtool.views import APIView as EreadingToolAPIView
 
 
-class APIView(View):
+class APIView(EreadingToolAPIView):
     def form(self, request: HttpRequest, params: dict) -> 'forms.Form':
         raise NotImplementedError
 
@@ -17,7 +17,6 @@ class APIView(View):
         raise NotImplementedError
 
     @method_decorator(sensitive_post_parameters())
-    @method_decorator(csrf_exempt)
     @method_decorator(never_cache)
     def dispatch(self, request, *args, **kwargs):
         return super(APIView, self).dispatch(request, *args, **kwargs)
@@ -32,7 +31,7 @@ class APIView(View):
         return errors
 
     def post_json_error(self, error: json.JSONDecodeError) -> JsonResponse:
-        return JsonResponse(errors={"errors": {'json': str(error)}}, status=400)
+        return JsonResponse({"errors": {'json': str(error)}}, status=400)
 
     def post_error(self, errors: dict) -> JsonResponse:
         if not errors:

--- a/user/views/instructor.py
+++ b/user/views/instructor.py
@@ -143,7 +143,7 @@ class InstructorLoginAPIView(APIView):
         return JsonResponse(jwt_payload)
 
 
-class InstructorLogoutAPIView(LoginRequiredMixin, View):
+class InstructorLogoutAPIView(LoginRequiredMixin, APIView):
     def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         logout(request)
 

--- a/user/views/student.py
+++ b/user/views/student.py
@@ -191,7 +191,7 @@ class StudentAPIConsentToResearchView(LoginRequiredMixin, APIView):
         try:
             params = json.loads(request.body.decode('utf8'))
         except json.JSONDecodeError as e:
-            return self.put_json_error(e)
+            return self.post_json_error(e)
 
         if 'difficulty_preference' in params:
             try:
@@ -211,7 +211,6 @@ class StudentAPIConsentToResearchView(LoginRequiredMixin, APIView):
 
 
 class StudentAPIView(LoginRequiredMixin, APIView):
-
     def form(self, request: HttpRequest, params: Dict, **kwargs) -> forms.ModelForm:
         return StudentForm(params, **kwargs)
 
@@ -226,11 +225,11 @@ class StudentAPIView(LoginRequiredMixin, APIView):
 
         student_dict = student.to_dict()
 
-
         # TODO: Hot patch
         # student_dict.pop('flashcards')
 
-        student_performance_report = None # student_dict.pop('performance_report')
+        # student_dict.pop('performance_report')
+        student_performance_report = None
 
         return HttpResponse(json.dumps({
             'profile': student_dict,
@@ -262,7 +261,7 @@ class StudentAPIView(LoginRequiredMixin, APIView):
         try:
             params = json.loads(request.body.decode('utf8'))
         except json.JSONDecodeError as e:
-            return self.put_json_error(e)
+            return self.post_json_error(e)
 
         if 'difficulty_preference' in params:
             try:
@@ -296,7 +295,7 @@ class StudentSignupAPIView(APIView):
         return HttpResponse(json.dumps({'id': student.pk, 'redirect': reverse('student-login')}))
 
 
-class StudentLogoutAPIView(LoginRequiredMixin, View):
+class StudentLogoutAPIView(LoginRequiredMixin, APIView):
     def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         logout(request)
 


### PR DESCRIPTION
Previously CSRF-exemption was only added to certain login-related and user-related endpoints.  This extends the same exemption to the rest of the site's endpoints.

 - Adds a base view for all API views
 - Adds aforementioned base view as a base class for all class-based API views
 
I confirmed derived classes hit the `csrf_exempt` decorator but it is unclear whether the Django testing framework is able to test this properly with `Client(enforce_csrf_checks=True)`.   Closes #173.