### PR TITLE
These changes will divide instructors and students

### DIFF
--- a/ereadingtool/test/user.py
+++ b/ereadingtool/test/user.py
@@ -37,8 +37,8 @@ class TestUser(TestCase):
 
         self.fake.seed_locale('en_US', random.randint(0, 100))
 
-    def new_user(self, password: AnyStr = None, username: AnyStr = None) -> (ReaderUser, AnyStr):
-        user = ReaderUser(is_active=True, username=username or ''.join(random.choices(
+    def new_user(self, password: AnyStr = None, username: AnyStr = None, is_staff: AnyStr = False) -> (ReaderUser, AnyStr):
+        user = ReaderUser(is_active=True, is_staff=is_staff, username=username or ''.join(random.choices(
             string.ascii_uppercase + string.digits + string.ascii_lowercase, k=8)))
 
         user.email = self.fake['en-US'].email()
@@ -66,7 +66,7 @@ class TestUser(TestCase):
         return instructor
 
     def new_instructor(self) -> (ReaderUser, AnyStr, Instructor):
-        user, user_passwd = self.new_user()
+        user, user_passwd = self.new_user(is_staff=True)
 
         instructor = self.new_instructor_with_user(user)
 

--- a/user/forms.py
+++ b/user/forms.py
@@ -155,16 +155,6 @@ class AuthenticationForm(BaseAuthenticationForm):
         return username
 
 
-class InstructorLoginForm(AuthenticationForm):
-    pass
-
-
-# TODO: StudentLoginAPIView `post_success()` contains code to confirm that the person
-# attempting to login isn't an instructor. Instead this method should be dispatched...
-class StudentLoginForm(AuthenticationForm):
-    pass
-
-
 class StudentConsentForm(forms.ModelForm):
     class Meta:
         model = Student

--- a/user/test/instructor.py
+++ b/user/test/instructor.py
@@ -52,7 +52,8 @@ class TestInstructorUser(TestUserBase, TestCase):
     def setup_admin_instructor(self):
         self.instructor_admin_user, self.instructor_admin_password = self.new_user(
             username='ereader@pdx.edu',
-            password='test-p4ssw0rd!'
+            password='test-p4ssw0rd!',
+            is_staff=True
         )
 
         admin_instructor = self.new_instructor_with_user(self.instructor_admin_user, admin=True)

--- a/user/views/api.py
+++ b/user/views/api.py
@@ -4,12 +4,13 @@ from django import forms
 from django.http import JsonResponse, HttpRequest
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.debug import sensitive_post_parameters
+from django.views.generic import View
+from user.forms import AuthenticationForm
 
-from ereadingtool.views import APIView as EreadingToolAPIView
 
-
-class APIView(EreadingToolAPIView):
+class APIView(View):
     def form(self, request: HttpRequest, params: dict) -> 'forms.Form':
         raise NotImplementedError
 
@@ -17,6 +18,7 @@ class APIView(EreadingToolAPIView):
         raise NotImplementedError
 
     @method_decorator(sensitive_post_parameters())
+    @method_decorator(csrf_exempt)
     @method_decorator(never_cache)
     def dispatch(self, request, *args, **kwargs):
         # entry point for requests and utlimately sends out the response. Dispatches to the appropriate view?
@@ -61,10 +63,18 @@ class APIView(EreadingToolAPIView):
         # `is_valid()` has the ability to determine if a user enters invalid creds
         form_is_valid = form.is_valid()
 
-        if not form_is_valid:
-            errors = self.format_form_errors(form)
-
-        if form_is_valid:
+        if form_is_valid and form.__class__ == AuthenticationForm:
+            # hit the DB to verify the user.
+            user = form.get_user()
+            if "instructor" in request.path and not user.is_staff:
+                # fail with a generic error
+                return self.post_error({'all': 'Please enter a correct username and password. Note that both fields may be case-sensitive.'})
+            elif "student" in request.path and user.is_staff:
+                return self.post_error({'all': 'Please enter a correct username and password. Note that both fields may be case-sensitive.'})
+                
             return self.post_success(request, form)
-        else:
+        elif form_is_valid:
+            return self.post_success(request, form)
+        else: 
+            errors = self.format_form_errors(form)
             return self.post_error(errors)

--- a/user/views/instructor.py
+++ b/user/views/instructor.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from django.views.generic import TemplateView, View
 from django.http import JsonResponse
 
-from user.forms import InstructorSignUpForm, InstructorLoginForm, InstructorInviteForm
+from user.forms import AuthenticationForm, InstructorSignUpForm, InstructorInviteForm
 
 from user.instructor.models import Instructor
 
@@ -124,7 +124,7 @@ class InstructorLoginAPIView(APIView):
     http_method_names = ['post']
 
     def form(self, request: HttpRequest, params: Dict) -> Form:
-        return InstructorLoginForm(request, params)
+        return AuthenticationForm(request, params)
 
     def post_success(self, request: HttpRequest, instructor_login_form: Form) -> JsonResponse:
 
@@ -136,9 +136,6 @@ class InstructorLoginAPIView(APIView):
             # orig_iat means "original issued at" https://tools.ietf.org/html/rfc7519
             reader_user, instructor_login_form.cleaned_data.get('orig_iat')
         )
-        # not sure if this is the best way to go about failing out if you're a student...
-        if hasattr(reader_user, 'student'):
-            return self.post_error({'all': 'Something went wrong.  Please try a different username and password.'})
 
         # payload now contains string 'Bearer', the token, and the expiration time JWT_EXPIRATION_DELTA (in seconds)
         jwt_payload = jwt_get_json_with_token(token)

--- a/user/views/student.py
+++ b/user/views/student.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from django.views.generic import TemplateView, View
 
 from text.models import TextDifficulty
-from user.forms import StudentSignUpForm, StudentLoginForm, StudentForm, StudentConsentForm
+from user.forms import AuthenticationForm, StudentSignUpForm, StudentForm, StudentConsentForm
 from user.student.models import Student
 from user.views.api import APIView
 from user.views.mixin import ProfileView
@@ -308,7 +308,7 @@ class StudentLoginAPIView(APIView):
     """
     def form(self, request: HttpRequest, params: Dict) -> Form:
         # This class appears to just be an `AuthenticationForm` since it simply passes
-        return StudentLoginForm(request, params)
+        return AuthenticationForm(request, params)
 
     def post_success(self, request: HttpRequest, student_login_form: Form) -> JsonResponse:
         """
@@ -325,12 +325,6 @@ class StudentLoginAPIView(APIView):
             # orig_iat means "original issued at" https://tools.ietf.org/html/rfc7519
             reader_user, student_login_form.cleaned_data.get('orig_iat') 
         )
-
-        # not sure if this is the best way to go about failing out if you're an instructor...
-        # TODO: Move this logic into the form validator
-        if hasattr(reader_user, 'instructor'):
-            return self.post_error({'all': 'Something went wrong.  Please try a different username and password.'})
-
 
         # payload now contains string 'Bearer', the token, and the expiration time JWT_EXPIRATION_DELTA (in seconds)
         jwt_payload = jwt_get_json_with_token(token)

--- a/web/src/Api/Endpoint.elm
+++ b/web/src/Api/Endpoint.elm
@@ -103,7 +103,8 @@ studentProfile baseUrl id =
 
 instructorProfile : String -> Int -> Endpoint
 instructorProfile baseUrl id =
-    url baseUrl [ "api", "instructor", String.fromInt id ++ "/" ] []
+    -- url baseUrl [ "api", "instructor", String.fromInt id ++ "/" ] []
+    url baseUrl [ "api", "instructor", String.fromInt id ] []
 
 
 consentToResearch : String -> Int -> Endpoint


### PR DESCRIPTION
It'll be done earlier on in the application logic for allowing or denying a student access to the webapp. Students and instructors were previously allowed through `post_success` and then reverted to a `post_error` if it turned out they have a particular administrative attribute. Now the request path is checked against the user's DB entry to see if the `is_staff` flag is set.

Tests needed to be updated so that they'd work. Specifically, if an instructor is created by way of `new_user` (as they always are) the kwarg `is_staff=True` will be passed along.

Along with this change comes the resolution of issue #172, at least partially. Inheriting from `View` as opposed to `EreadingToolAPIView` gives us the ability to inherit the `method_decorator(csrf_exempt)` which will allow prevent CSRF token errors we were previously dealing with.