### PR TITLE
Add create and edit text pages

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/ckeditor": {
+      "version": "4.9.10",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor/-/ckeditor-4.9.10.tgz",
+      "integrity": "sha512-dcOPCXM0Cr5Z0i6eF/aW5LvECrS+cdl2Gi7lU+rEUNWby0w9Yl6mBubjrs29OVAducpuZjB4mfDayE+o4/gGdQ==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/ckeditor": "^4.9.10",
     "@types/node": "^12.12.50",
     "chokidar-cli": "2.1.0",
     "cssnano": "^4.1.10",

--- a/web/public/css/create_text.css
+++ b/web/public/css/create_text.css
@@ -1,0 +1,766 @@
+body {
+    background: #FFFFFF;
+    margin-top: 0;
+    margin-right: 0;
+    margin-left: 0;
+}
+
+.preview {
+    display: grid;
+    grid-template-rows: 67px;
+
+    margin-top: 3%;
+    margin-bottom: 4%;
+
+    background: #f9f9f9;
+
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 18px;
+
+    align-items: right;
+    justify-items: right;
+
+    border: solid 0.5px lightgrey;
+}
+
+.preview_menu {
+    grid-column: 5 / 6;
+    display: grid;
+
+    grid-template-rows: 35px;
+    grid-template-columns: 200px;
+}
+
+.filter {
+    grid-column: 2 / 2;
+}
+
+.filter_items {
+    display: grid;
+    margin-top: 50px;
+    margin-bottom: 0;
+    grid-template-columns: 4% auto 4%;
+
+    align-items: right;
+    justify-items: right;
+
+    grid-auto-rows: 50px;
+
+    grid-row-gap: 5%;
+    row-gap: 5%;
+}
+
+.item_property {
+    display: grid;
+
+    align-items: center;
+    justify-items: center;
+
+    font-size: 23px;
+    font-weight: 300;
+}
+
+.sub_description {
+    color: #a4a4a4;
+    font-size: 14px;
+    font-weight: 300;
+
+    display: block;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.message {
+    margin: 8px;
+    color: #737373;
+}
+
+.body {
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 17px;
+}
+
+.body > textarea {
+    width: 100%;
+    height: 100%;
+}
+
+.body > div:nth-child(1) {
+    font-weight: 300;
+    margin-bottom: 10px;
+}
+
+.body > div:nth-child(2) {
+    padding: 15px;
+    background-color: white;
+}
+
+#text_attributes {
+    grid-column: 2;
+    display: grid;
+
+    padding: 15px 20px 15px 20px;
+
+    background: #f9f9f9;
+
+    font-size: 23px;
+    font-weight: 300;
+
+    grid-template-columns: 100%;
+}
+
+#text_introduction {
+    display: grid;
+
+    grid-column: 1;
+
+    grid-template-columns: 100%;
+    grid-template-rows: 25px minmax(130px, auto);
+    grid-row-gap: 10px;
+
+    border-bottom: solid 2px white;
+    margin-bottom: 15px;
+}
+
+#text_introduction div:nth-child(2) {
+    background: white;
+}
+
+#text_conclusion {
+    display: grid;
+
+    grid-column: 1;
+
+    grid-template-columns: 100%;
+    grid-template-rows: 25px minmax(130px, auto);
+    grid-row-gap: 10px;
+
+    border-bottom: solid 2px white;
+    margin-bottom: 15px;
+}
+
+#text_conclusion div:nth-child(2) {
+    background: white;
+}
+
+#text_author_view {
+    display: grid;
+    grid-column: 1;
+}
+
+#text_attributes > div > div:nth-child(1) {
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 17px;
+    color: #000e2d;
+}
+
+
+.text_introduction {
+    padding: 15px;
+}
+
+#text_lock {
+    display: grid;
+
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 17px;
+
+    grid-column: 1;
+
+    margin-bottom: 15px;
+}
+
+#lock_box {
+    cursor: pointer;
+    margin-top: 15px;
+    border: 1px solid black;
+    border-radius: 25px;
+    width: 35px;
+}
+
+#lock_left {
+    position: relative;
+    float: left;
+
+    width: 15px;
+    height: 15px;
+
+    transition-property: float;
+    transition-duration: 2s;
+
+    border-radius: 50%;
+
+    background: black;
+}
+
+
+#lock_right {
+    position: relative;
+    float: right;
+
+    width: 15px;
+    height: 15px;
+
+    transition-property: float;
+    transition-duration: 7s;
+
+    border-radius: 50%;
+
+    background: black;
+}
+
+#tabs {
+    display: grid;
+
+    grid-template-columns: 10% auto 10%;
+
+    row-gap: 0;
+
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 18px;
+    font-weight: 200;
+
+    margin-top: 25px;
+    margin-bottom: 15px;
+}
+
+#tabs_menu {
+    grid-column: 2;
+    display: grid;
+
+    grid-template-columns: 6% 12% auto;
+    text-align: center;
+}
+
+#tabs_menu > div {
+    cursor: pointer;
+    border-top: solid 1px #a4a4a4;
+    border-left: solid 1px #a4a4a4;
+    border-right: solid 1px #a4a4a4;
+    border-radius: 10px 10px 0 0;
+}
+
+#tabs_menu > .selected {
+    background: #f9f9f9;
+    font-weight: bold;
+}
+
+#tabs_contents {
+    grid-column: 2;
+    border: solid 1px #a4a4a4;
+}
+
+#text_tags > div {
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 18px;
+    color: #000e2d;
+}
+
+.text_sections {
+    grid-column: 2;
+    display: grid;
+}
+
+#text_title {
+    display: grid;
+    grid-column: 1;
+
+    grid-template-columns: 100%;
+    grid-template-rows: 25px 30px;
+
+    grid-row-gap: 2px;
+    row-gap: 2px;
+
+    margin-bottom: 10px;
+}
+
+.text {
+    display: grid;
+
+    background: #f9f9f9;
+    padding: 10px 20px 15px 20px;
+    margin-top: 25px;
+}
+
+.text > .cursor {
+    margin-top: 10px;
+}
+
+.text_content {
+    grid-column: 2;
+}
+
+.text_properties {
+    display: grid;
+    grid-row-gap: 5%;
+    row-gap: 5%;
+
+    margin-bottom: 15px;
+}
+
+.editable:hover {
+    background-color: #d1e1ed;
+}
+
+.text_property_items {
+    display: grid;
+
+    font-size: 23px;
+    font-weight: 300;
+    grid-row-gap: 10px;
+    row-gap: 10px;
+}
+
+.text_property {
+    display: grid;
+
+    grid-template-columns: 100%;
+    grid-template-rows: 25px 30px;
+
+    grid-row-gap: 5px;
+
+    padding-left: 5px;
+    padding-bottom: 5px;
+}
+
+.text_property > div:nth-child(1) {
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 17px;
+    color: #000e2d;
+}
+
+.text_property > select {
+    width: 150px;
+}
+
+#letter_menu {
+    padding-bottom: 10px;
+}
+
+#letter_menu > span {
+    margin-right: 10px;
+}
+
+.underline {
+    border-bottom: 0.5px solid grey;
+}
+
+@media screen and (min-width:300px) and (max-width: 568px) {
+    .text_items {
+        margin-top: 2%;
+        display: grid;
+        grid-row-gap: 5%;
+        row-gap: 5%;
+
+        grid-template-columns: 4% auto 4%;
+        grid-auto-rows: 110px;
+    }
+
+    .item_property {
+        display: grid;
+
+        align-items: center;
+        justify-items: center;
+
+        font-size: 9px;
+    }
+
+    .sub_description {
+        color: #a4a4a4;
+        font-size: 9px;
+
+        display: block;
+
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+}
+
+.footer_items {
+    margin-top: 50px;
+    margin-bottom: 0;
+
+    display: grid;
+    grid-template-columns: 4% auto 4%;
+
+    align-items: center;
+    justify-items: center;
+}
+
+.footer {
+    grid-column: 2 / 2;
+}
+
+.question_section {
+    display: grid;
+
+    padding-top: 5%;
+
+    grid-row-gap: 50px;
+    row-gap: 50px;
+
+    grid-template-columns: 0% auto 0%;
+}
+
+.question_parts {
+    display: grid;
+    background: #FFFFFF;
+
+    border: solid 1px lightgrey;
+
+    grid-column: 2;
+
+    grid-template-columns: 3% auto 2%;
+    grid-row-gap: 15px;
+    row-gap: 15px;
+}
+
+.question {
+    padding: 5px 20px 20px 0px;
+    display: grid;
+    grid-row-gap: 15px;
+    row-gap: 15px;
+
+    grid-template-columns: 0 auto 10%;
+}
+
+.question_item {
+    grid-column: 2;
+    word-wrap: break-word;
+}
+
+.question_menu {
+    position: relative;
+    cursor: pointer;
+}
+
+.question_menu_overlay {
+    display: grid;
+    position: absolute;
+
+    z-index: 2;
+    right: 0;
+
+    background: #FFFFFF;
+
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+
+    border: solid 0.5px lightgrey;
+    border-radius: 2px;
+    box-shadow: 0 1px 16px rgba(0,0,0,.1);
+
+    grid-template-columns: 20% 200px 20%;
+
+    cursor: pointer;
+}
+
+.question_menu_item {
+    margin: 5px 5px 5px 5px;
+    grid-column: 2;
+}
+
+.answer_item {
+    grid-column: 2;
+    display: grid;
+    grid-template-columns: 22px auto 20px;
+    color: #a4a4a4;
+}
+
+.answer_delete {
+    visibility: hidden;
+}
+
+.answer_item:hover > .answer_delete {
+    visibility: visible;
+}
+
+.answer_add {
+    visibility: hidden;
+}
+
+.answer_item:hover > .answer_add {
+    visibility: visible;
+}
+
+.answer_feedback {
+    margin: 10px 10px 10px 10px;
+    padding: 20px 20px 20px 20px;
+    word-wrap: break-word;
+    color: #000000;
+}
+
+.grey_bg {
+    background: #F7F7F7;
+}
+
+.dimgray_bg {
+    background: dimgray;
+}
+
+.question_buttons {
+    display: grid;
+    cursor: pointer;
+    margin-top: 20px;
+
+    grid-template-columns: 300px;
+}
+
+.delete {
+    align-items: right;
+    justify-items: right;
+}
+
+.submit_section {
+    display: grid;
+    grid-template-columns: 160px 160px auto 120px;
+    grid-column-gap: 10px;
+    grid-column: 2;
+    margin-top: 10px;
+
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 18px;
+}
+
+.submit > img {
+    margin-left: 10px;
+}
+
+/* TODO(andrew): cleanup */
+.submit {
+    cursor: pointer;
+}
+
+.tag_delete_btn {
+    cursor: pointer;
+}
+
+.input_error {
+    border: 1px solid #ff0000;
+    background-color: #ffeeee;
+}
+
+.error {
+    background-color: #ffeeee;
+    font-size: 15px;
+    font-style: italic;
+    font-weight: 300;
+}
+
+.chars_remaining {
+    margin-top: 10px;
+    font-size: 15px;
+    font-style: italic;
+}
+
+.text_dates {
+    display: grid;
+    grid-column: 1;
+    grid-template-columns: auto;
+
+    font-size: 13px;
+
+    margin-top: 25px;
+}
+
+.answer_note {
+    font-style: italic;
+    font-size: 14px;
+}
+
+.word_instance  {
+    grid-row: 2;
+    grid-column: 2;
+
+    display: grid;
+
+    margin: 5px;
+}
+
+.word_instance > .word {
+    margin: 5px 0 25px 0;
+    font-size: larger;
+}
+
+.translations {
+    display: grid;
+
+    grid-template-columns: auto;
+}
+
+.translation {
+    display: grid;
+
+    grid-template-columns: 1fr min-content;
+
+    margin-top: 5px;
+    cursor: pointer;
+}
+
+.correct_checkmark {
+    margin-left: 5px;
+}
+
+.grammemes {
+    margin-top: 15px;
+}
+
+.word_phrase {
+    display: inline-block;
+    font-weight: bolder;
+    margin-bottom: 5px;
+}
+
+.word > .grammemes {
+    display: grid;
+    font-size: smaller;
+}
+
+.grammemes > .add {
+    display: grid;
+
+    grid-template-columns: 70px 1fr 1fr;
+    grid-column-gap: 2px;
+
+    margin-top: 15px;
+}
+
+#translations_tab {
+    background: #f9f9f9;
+    padding: 15px 15px 15px 15px;
+
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+}
+
+.add_translation {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    margin-top: 5px;
+}
+
+.add_as_text_word {
+    display: grid;
+    grid-template-columns: 1fr 10%;
+
+    margin-top: 5px;
+    font-size: large;
+}
+
+.translation_delete {
+    visibility: hidden;
+}
+
+.translation .icons {
+    display: grid;
+
+    grid-template-columns: 1fr 1fr;
+    grid-column-gap: 5px;
+
+    align-items: center;
+}
+
+.translation:hover > div > .translation_delete {
+    visibility: visible;
+}
+
+.text_section {
+    grid-column: 2;
+}
+
+.edit_overlay {
+    display: inline-block;
+    position: relative;
+}
+
+.edit_menu {
+    display: grid;
+    position: absolute;
+    top: 17px;
+    left: -145px;
+
+    grid-template-columns: 10px auto 10px;
+    grid-template-rows: 10px auto auto;
+
+    margin-top: 5px;
+
+    z-index: 1;
+    min-width: 250px;
+
+    background: #FFFFFF;
+
+    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+
+    padding: 5px;
+
+    border: solid 0.5px lightgrey;
+    border-radius: 2px;
+    box-shadow: 0 1px 16px rgba(0,0,0,.1);
+
+    cursor: unset;
+}
+
+.edit_overlay:after {
+    position: absolute;
+    content: '';
+    left: -30px;
+    top: 11.5px;
+    width: 20px;
+    height: 20px;
+    background-color: #FFFFFF;
+    z-index: 1;
+    transform: rotate(45deg);
+    border-top: solid 0.5px lightgrey;
+    border-left: solid 0.5px lightgrey;
+}
+
+.edit_overlay_close_btn {
+    grid-row: 1;
+    grid-column: 3;
+}
+
+.text_word_options {
+    grid-column: 2;
+    grid-row: 3;
+
+    display: grid;
+
+    grid-template-columns: auto auto auto;
+    grid-template-rows: min-content;
+
+    grid-column-gap: 5px;
+
+    margin-bottom: 10px;
+    margin-top: 10px;
+}
+
+.text-word-option {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-rows: 1fr 1fr 1fr;
+
+    max-height: 20px;
+    font-weight: 400;
+    white-space: nowrap;
+}
+
+.text-word-option > div {
+    grid-column: 2;
+    grid-row: 2;
+
+    border: solid 1px black;
+    padding: 5px;
+}
+
+.merge_words {
+    font-weight: 400;
+}
+
+.merge-highlight {
+    background: lightblue;
+}

--- a/web/src/Answer/View.elm
+++ b/web/src/Answer/View.elm
@@ -157,7 +157,7 @@ view_editable_answer params num_of_answers answer_field =
                             [ Html.img
                                 [ attribute "title" title_text_add
                                 , attribute "alt" title_text_add
-                                , attribute "src" "/static/img/add.svg"
+                                , attribute "src" "/public/img/add.svg"
                                 , attribute "height" "18px"
                                 , attribute "width" "18px"
                                 ]
@@ -173,7 +173,7 @@ view_editable_answer params num_of_answers answer_field =
                             [ Html.img
                                 [ attribute "title" title_text_delete
                                 , attribute "alt" title_text_delete
-                                , attribute "src" "/static/img/delete.svg"
+                                , attribute "src" "/public/img/delete.svg"
                                 , attribute "height" "18px"
                                 , attribute "width" "18px"
                                 ]

--- a/web/src/Api/Endpoint.elm
+++ b/web/src/Api/Endpoint.elm
@@ -2,11 +2,14 @@ module Api.Endpoint exposing
     ( Endpoint
     , consentToResearch
     , createText
+    , createTranslation
     , filterToStringQueryParam
     , forgotPassword
     , instructorProfile
     , instructorSignup
     , inviteInstructor
+    , matchTranslation
+    , mergeWords
     , request
     , resetPassword
     , studentProfile
@@ -14,7 +17,9 @@ module Api.Endpoint exposing
     , text
     , textLock
     , textSearch
+    , translation
     , validateUsername
+    , word
     )
 
 import Http
@@ -130,19 +135,67 @@ createText baseUrl =
     url baseUrl [ "api", "text/" ] []
 
 
-text : String -> Int -> Maybe (List QueryParameter) -> Endpoint
-text baseUrl id maybeQueryParameters =
-    case maybeQueryParameters of
-        Just queryParameters ->
-            url baseUrl [ "api", "text", String.fromInt id ++ "/" ] queryParameters
-
-        Nothing ->
-            url baseUrl [ "api", "text", String.fromInt id ++ "/" ] []
+text : String -> Int -> List ( String, String ) -> Endpoint
+text baseUrl id queryParameters =
+    url baseUrl
+        [ "api", "text", String.fromInt id ++ "/" ]
+        (List.map
+            (\qp ->
+                Url.Builder.string
+                    (Tuple.first qp)
+                    (Tuple.second qp)
+            )
+            queryParameters
+        )
 
 
 textLock : String -> Int -> Endpoint
 textLock baseUrl id =
     url baseUrl [ "api", "text", String.fromInt id, "lock/" ] []
+
+
+
+-- WORDS AND TRANSLATIONS
+
+
+word : String -> Int -> Endpoint
+word baseUrl id =
+    url baseUrl [ "api", "text", "word", String.fromInt id ] []
+
+
+mergeWords : String -> Endpoint
+mergeWords baseUrl =
+    url baseUrl [ "api", "text", "word", "compound" ] []
+
+
+createTranslation : String -> Int -> Endpoint
+createTranslation baseUrl wordId =
+    url baseUrl
+        [ "api"
+        , "text"
+        , "word"
+        , String.fromInt wordId
+        , "translation"
+        ]
+        []
+
+
+translation : String -> Int -> Int -> Endpoint
+translation baseUrl wordId translationId =
+    url baseUrl
+        [ "api"
+        , "text"
+        , "word"
+        , String.fromInt wordId
+        , "translation"
+        , String.fromInt translationId
+        ]
+        []
+
+
+matchTranslation : String -> Endpoint
+matchTranslation baseUrl =
+    url baseUrl [ "api", "text", "translations", "match" ] []
 
 
 

--- a/web/src/Api/Endpoint.elm
+++ b/web/src/Api/Endpoint.elm
@@ -3,6 +3,7 @@ module Api.Endpoint exposing
     , consentToResearch
     , createText
     , createTranslation
+    , createWord
     , filterToStringQueryParam
     , forgotPassword
     , instructorProfile
@@ -155,7 +156,12 @@ textLock baseUrl id =
 
 
 
--- WORDS AND TRANSLATIONS
+-- WORDS
+
+
+createWord : String -> Endpoint
+createWord baseUrl =
+    url baseUrl [ "api", "text", "word" ] []
 
 
 word : String -> Int -> Endpoint
@@ -166,6 +172,10 @@ word baseUrl id =
 mergeWords : String -> Endpoint
 mergeWords baseUrl =
     url baseUrl [ "api", "text", "word", "compound" ] []
+
+
+
+-- TRANSLATIONS
 
 
 createTranslation : String -> Int -> Endpoint

--- a/web/src/Api/Endpoint.elm
+++ b/web/src/Api/Endpoint.elm
@@ -100,13 +100,11 @@ studentSignup baseUrl =
 
 studentProfile : String -> Int -> Endpoint
 studentProfile baseUrl id =
-    -- url baseUrl [ "api", "student", String.fromInt id ++ "/" ] []
     url baseUrl [ "api", "student", String.fromInt id ] []
 
 
 instructorProfile : String -> Int -> Endpoint
 instructorProfile baseUrl id =
-    -- url baseUrl [ "api", "instructor", String.fromInt id ++ "/" ] []
     url baseUrl [ "api", "instructor", String.fromInt id ] []
 
 
@@ -135,13 +133,13 @@ textSearch baseUrl queryParameters =
 
 createText : String -> Endpoint
 createText baseUrl =
-    url baseUrl [ "api", "text/" ] []
+    url baseUrl [ "api", "text" ] []
 
 
 text : String -> Int -> List ( String, String ) -> Endpoint
 text baseUrl id queryParameters =
     url baseUrl
-        [ "api", "text", String.fromInt id ++ "/" ]
+        [ "api", "text", String.fromInt id ]
         (List.map
             (\qp ->
                 Url.Builder.string
@@ -154,7 +152,7 @@ text baseUrl id queryParameters =
 
 textLock : String -> Int -> Endpoint
 textLock baseUrl id =
-    url baseUrl [ "api", "text", String.fromInt id, "lock/" ] []
+    url baseUrl [ "api", "text", String.fromInt id, "lock" ] []
 
 
 

--- a/web/src/Api/Endpoint.elm
+++ b/web/src/Api/Endpoint.elm
@@ -1,6 +1,7 @@
 module Api.Endpoint exposing
     ( Endpoint
     , consentToResearch
+    , createText
     , filterToStringQueryParam
     , forgotPassword
     , instructorProfile
@@ -10,7 +11,8 @@ module Api.Endpoint exposing
     , resetPassword
     , studentProfile
     , studentSignup
-    , test
+    , text
+    , textLock
     , textSearch
     , validateUsername
     )
@@ -66,11 +68,6 @@ request config =
 -- ENDPOINTS
 
 
-test : String -> Endpoint
-test baseUrl =
-    url baseUrl [ "test" ] []
-
-
 forgotPassword : String -> Endpoint
 forgotPassword baseUrl =
     url baseUrl [ "password", "reset" ] []
@@ -122,6 +119,30 @@ validateUsername baseUrl =
 textSearch : String -> List QueryParameter -> Endpoint
 textSearch baseUrl queryParameters =
     url baseUrl [ "api", "text/" ] queryParameters
+
+
+
+-- TEXT CREATE AND EDIT
+
+
+createText : String -> Endpoint
+createText baseUrl =
+    url baseUrl [ "api", "text/" ] []
+
+
+text : String -> Int -> Maybe (List QueryParameter) -> Endpoint
+text baseUrl id maybeQueryParameters =
+    case maybeQueryParameters of
+        Just queryParameters ->
+            url baseUrl [ "api", "text", String.fromInt id ++ "/" ] queryParameters
+
+        Nothing ->
+            url baseUrl [ "api", "text", String.fromInt id ++ "/" ] []
+
+
+textLock : String -> Int -> Endpoint
+textLock baseUrl id =
+    url baseUrl [ "api", "text", String.fromInt id, "lock/" ] []
 
 
 

--- a/web/src/InstructorAdmin/Text/Create.elm
+++ b/web/src/InstructorAdmin/Text/Create.elm
@@ -1,13 +1,23 @@
-module InstructorAdmin.Text.Create exposing (Flags, Mode(..), Model, Msg(..), Tab(..), TextField(..), TextViewParams)
+module InstructorAdmin.Text.Create exposing
+    ( Flags
+    , Mode(..)
+    , Model
+    , Msg(..)
+    , Tab(..)
+    , TextField(..)
+    , TextViewParams
+    )
+
+{-| TODO: The contents of this module have been moved to TextEdit.elm
+or lifted into individual pages. It should be safe to remove it on clean
+up.
+-}
 
 import Dict exposing (Dict)
 import Flags
 import Http
-import User.Instructor.Profile
 import InstructorAdmin.Admin.Text
 import InstructorAdmin.Text.Translations as Translations
-import Text.Translations.Model as TranslationsModel
-import Text.Translations.Msg as TranslationsMsg
 import Json.Encode
 import Menu.Items
 import Menu.Logout
@@ -16,8 +26,11 @@ import Text.Component exposing (TextComponent)
 import Text.Decode
 import Text.Field exposing (TextAuthor, TextDifficulty, TextIntro, TextSource, TextTags, TextTitle)
 import Text.Model exposing (Text, TextDifficulty)
+import Text.Translations.Model as TranslationsModel
+import Text.Translations.Msg as TranslationsMsg
 import Text.Update
 import Time
+import User.Instructor.Profile
 
 
 type alias Flags =

--- a/web/src/InstructorAdmin/Text/Translations.elm
+++ b/web/src/InstructorAdmin/Text/Translations.elm
@@ -26,8 +26,10 @@ module InstructorAdmin.Text.Translations exposing
     , textWordIdToInt
     )
 
+import Api.Config exposing (Config)
 import Dict exposing (Dict)
 import Flags
+import Session exposing (Session)
 import Set exposing (Set)
 
 
@@ -117,7 +119,9 @@ type MergeState
 
 
 type alias Flags =
-    { add_as_text_word_endpoint_url : String
+    { session : Session
+    , config : Config
+    , add_as_text_word_endpoint_url : String
     , merge_textword_endpoint_url : String
     , text_translation_match_endpoint : String
     , csrftoken : Flags.CSRFToken

--- a/web/src/Pages/Text/Create.elm
+++ b/web/src/Pages/Text/Create.elm
@@ -1,0 +1,882 @@
+module Pages.Text.Create exposing (..)
+
+-- import HttpHelpers exposing (delete_with_headers, post_with_headers, put_with_headers)
+
+import Api
+import Api.Config as Config exposing (Config)
+import Api.Endpoint as Endpoint
+import Array
+import Browser.Navigation
+import DateTime
+import Debug
+import Dict exposing (Dict)
+import Flags
+import Html exposing (..)
+import Html.Attributes exposing (attribute, class, classList)
+import Html.Events exposing (onBlur, onClick, onInput)
+import Http
+import InstructorAdmin.Admin.Text as AdminText
+import InstructorAdmin.Text.Translations as Translations
+import Iso8601
+import Json.Decode as Decode
+import Json.Decode.Extra exposing (posix)
+import Json.Decode.Pipeline exposing (required)
+import Json.Encode
+import Ports exposing (ckEditorUpdate, clearInputText, confirm, confirmation)
+import Session exposing (Session)
+import Shared
+import Spa.Document exposing (Document)
+import Spa.Generated.Route as Route
+import Spa.Page as Page exposing (Page)
+import Spa.Url as Url exposing (Url)
+import Task
+import Text.Component exposing (TextComponent)
+import Text.Decode
+import Text.Encode
+import Text.Field
+    exposing
+        ( TextAuthor
+        , TextConclusion
+        , TextDifficulty
+        , TextField(..)
+        , TextIntro
+        , TextSource
+        , TextTags
+        , TextTitle
+        )
+import Text.Model exposing (Text, TextDifficulty, TextListItem)
+import Text.Section.Decode
+import Text.Section.View
+import Text.Subscriptions
+import Text.Tags.View
+import Text.Translations.Decode
+import Text.Translations.Model as TranslationsModel
+import Text.Translations.Msg as TranslationsMsg
+import Text.Translations.Subscriptions
+import Text.Translations.Update
+import Text.Translations.View
+import Text.Update
+import Text.View
+import TextEdit exposing (Mode(..), Tab(..))
+import Time
+import User.Instructor.Profile as InstructorProfile exposing (InstructorProfile)
+import User.Profile as Profile
+import Utils
+import Utils.Date
+import Views
+
+
+page : Page Params Model Msg
+page =
+    Page.protectedInstructorApplication
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        , save = save
+        , load = load
+        }
+
+
+type alias TextsResponseError =
+    Dict String String
+
+
+
+-- INIT
+
+
+type alias Params =
+    ()
+
+
+type alias Model =
+    Maybe SafeModel
+
+
+type SafeModel
+    = SafeModel
+        { session : Session
+        , config : Config
+        , mode : Mode
+        , profile : InstructorProfile
+        , successMessage : Maybe String
+        , errorMessage : Maybe String
+        , text_component : TextComponent
+        , textDifficulties : List Text.Model.TextDifficulty
+        , textTranslationsModel : Maybe TranslationsModel.Model
+        , tags : Dict String String
+        , writeLocked : Bool
+        , selectedTab : Tab
+        }
+
+
+
+-- type alias Flags =
+--     Flags.AuthedFlags
+--         { instructor_profile : User.Instructor.Profile.InstructorProfileParams
+--         , text : Maybe Json.Encode.Value
+--         , answer_feedback_limit : Int
+--         , text_endpoint_url : String
+--         , translation_flags : Translations.Flags
+--         , tags : List String
+--         }
+
+
+{-| TODO: replace this with Endpoints or a new API endpoint to get what
+we need.
+-}
+fakeTranslationFlags : Translations.Flags
+fakeTranslationFlags =
+    { add_as_text_word_endpoint_url = "placeholder"
+    , merge_textword_endpoint_url = "placeholder"
+    , text_translation_match_endpoint = "placeholder"
+    , csrftoken = "placeholder"
+    }
+
+
+init : Shared.Model -> Url Params -> ( SafeModel, Cmd Msg )
+init shared { params } =
+    -- let
+    --     textApiEndpoint =
+    --         Admin.Text.toTextAPIEndpoint flags.text_endpoint_url
+    -- in
+    ( SafeModel
+        { session = shared.session
+        , config = shared.config
+        , mode = CreateMode
+        , successMessage = Nothing
+        , errorMessage = Nothing
+        , profile = Profile.toInstructorProfile shared.profile
+        , text_component = Text.Component.emptyTextComponent
+        , textDifficulties = Shared.difficulties
+        , textTranslationsModel = Nothing
+        , tags = Dict.fromList []
+        , selectedTab = TextTab
+        , writeLocked = False
+        }
+      -- , Cmd.batch
+      --     [ retrieveTextDifficultyOptions textApiEndpoint
+      --     , textJSONtoComponent flags.text
+      --     , tagsToDict flags.tags
+      --     ]
+    , Cmd.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = SubmittedText
+    | GotText (Result Http.Error Text)
+    | GotTextCreated (Result Http.Error Text.Decode.TextCreateResp)
+    | GotTextUpdated (Result Http.Error Text.Decode.TextUpdateResp)
+    | SubmittedTextDelete
+    | ConfirmedTextDelete Bool
+    | GotTextDeleted (Result Http.Error Text.Decode.TextDeleteResp)
+    | ToggleEditable TextField Bool
+    | UpdateTextAttributes String String
+    | UpdateTextCkEditors ( String, String )
+    | ClearMessages Time.Posix
+    | AddTagInput String String
+    | DeleteTag String
+    | ToggleLock
+    | TextLocked (Result Http.Error Text.Decode.TextLockResp)
+    | TextUnlocked (Result Http.Error Text.Decode.TextLockResp)
+    | InitTextFieldEditors
+    | ToggleTab Tab
+    | TextJSONDecode (Result String TextComponent)
+    | TextTagsDecode (Result String (Dict String String))
+    | TextTranslationMsg TranslationsMsg.Msg
+    | TextComponentMsg Text.Update.Msg
+
+
+update : Msg -> SafeModel -> ( SafeModel, Cmd Msg )
+update msg (SafeModel model) =
+    case msg of
+        SubmittedText ->
+            let
+                text =
+                    Text.Component.text model.text_component
+            in
+            case model.mode of
+                ReadOnlyMode writeLocker ->
+                    ( SafeModel { model | successMessage = Just <| "Text is locked by " ++ writeLocker }, Cmd.none )
+
+                EditMode ->
+                    ( SafeModel { model | errorMessage = Nothing, successMessage = Nothing }
+                    , updateText model.session model.config text
+                    )
+
+                CreateMode ->
+                    ( SafeModel { model | errorMessage = Nothing, successMessage = Nothing }
+                    , postText model.session model.config text
+                    )
+
+        GotText (Ok text) ->
+            ( SafeModel { model | text_component = Text.Component.init text }
+            , Cmd.none
+            )
+
+        GotText (Err err) ->
+            ( SafeModel model
+            , Cmd.none
+            )
+
+        GotTextCreated (Ok textCreateResp) ->
+            let
+                text =
+                    Text.Component.text model.text_component
+            in
+            ( SafeModel
+                { model
+                    | successMessage = Just <| String.join " " [ " created '" ++ text.title ++ "'" ]
+                    , mode = EditMode
+                }
+            , Browser.Navigation.load textCreateResp.redirect
+            )
+
+        GotTextCreated (Err err) ->
+            case err of
+                Http.BadStatus resp ->
+                    -- case Text.Decode.decodeRespErrors resp.body of
+                    --     Ok errors ->
+                    --         ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+                    --     _ ->
+                    ( SafeModel model, Cmd.none )
+
+                Http.BadBody resp ->
+                    let
+                        _ =
+                            Debug.log "submit text bad payload error" resp
+                    in
+                    ( SafeModel model, Cmd.none )
+
+                _ ->
+                    ( SafeModel model, Cmd.none )
+
+        GotTextUpdated (Ok textUpdateResp) ->
+            let
+                text =
+                    Text.Component.text model.text_component
+            in
+            ( SafeModel
+                { model
+                    | successMessage =
+                        Just <|
+                            String.join " " [ " saved '" ++ text.title ++ "'" ]
+                }
+            , Cmd.none
+            )
+
+        GotTextUpdated (Err err) ->
+            case err of
+                Http.BadStatus resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad status" resp
+                    in
+                    -- case Text.Decode.decodeRespErrors resp.body of
+                    --     Ok errors ->
+                    --         ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+                    --     _ ->
+                    ( SafeModel model, Cmd.none )
+
+                Http.BadBody resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad payload" resp
+                    in
+                    ( SafeModel model, Cmd.none )
+
+                _ ->
+                    ( SafeModel model, Cmd.none )
+
+        SubmittedTextDelete ->
+            ( SafeModel model
+            , confirm "Are you sure you want to delete this text?"
+            )
+
+        GotTextDeleted (Ok textDelete) ->
+            let
+                _ =
+                    Debug.log "text delete" textDelete
+            in
+            ( SafeModel model, Browser.Navigation.load textDelete.redirect )
+
+        GotTextDeleted (Err httpError) ->
+            case httpError of
+                Http.BadStatus resp ->
+                    let
+                        _ =
+                            Debug.log "delete text error bad status" resp
+                    in
+                    -- case Text.Decode.decodeRespErrors resp.body of
+                    --     Ok errors ->
+                    --         let
+                    --             errorsStr =
+                    --                 String.join " and " (Dict.values errors)
+                    --         in
+                    --         ( SafeModel { model | success_msg = Just <| "Error trying to delete the text: " ++ errorsStr }, Cmd.none )
+                    --     _ ->
+                    ( SafeModel model, Cmd.none )
+
+                Http.BadBody resp ->
+                    let
+                        _ =
+                            Debug.log "delete text error bad payload" resp
+                    in
+                    ( SafeModel model, Cmd.none )
+
+                _ ->
+                    let
+                        _ =
+                            Debug.log "delete text error bad payload" httpError
+                    in
+                    ( SafeModel model, Cmd.none )
+
+        ConfirmedTextDelete confirm ->
+            if confirm then
+                let
+                    text =
+                        Text.Component.text model.text_component
+                in
+                ( SafeModel model
+                , deleteText model.session model.config text
+                )
+
+            else
+                ( SafeModel model, Cmd.none )
+
+        InitTextFieldEditors ->
+            ( SafeModel model
+            , Text.Component.initialize_text_field_ck_editors model.text_component
+            )
+
+        ClearMessages _ ->
+            ( SafeModel { model | successMessage = Nothing }, Cmd.none )
+
+        ToggleEditable textField editable ->
+            let
+                ( textComponent, postToggleCmds ) =
+                    case textField of
+                        Title _ ->
+                            ( Text.Component.set_title_editable model.text_component editable
+                            , Text.Component.post_toggle_title
+                            )
+
+                        Author _ ->
+                            ( Text.Component.set_author_editable model.text_component editable
+                            , Text.Component.post_toggle_author
+                            )
+
+                        Source _ ->
+                            ( Text.Component.set_source_editable model.text_component editable
+                            , Text.Component.post_toggle_source
+                            )
+
+                        _ ->
+                            ( model.text_component, \_ -> Cmd.none )
+            in
+            ( SafeModel { model | text_component = textComponent }
+            , postToggleCmds textComponent
+            )
+
+        ToggleLock ->
+            let
+                text =
+                    Text.Component.text model.text_component
+            in
+            ( SafeModel model
+            , if not model.writeLocked then
+                postLock model.session model.config text
+
+              else
+                deleteLock model.session model.config text
+            )
+
+        TextLocked (Ok textLockedResp) ->
+            ( SafeModel
+                { model
+                    | writeLocked = textLockedResp.locked
+
+                    -- if textLockedResp.locked then
+                    --     True
+                    -- else
+                    --     False
+                    , successMessage =
+                        Just "text is locked for editing, other instructors can only view the text while it is locked."
+                }
+            , Cmd.none
+            )
+
+        TextUnlocked (Ok textUnlockedResp) ->
+            ( SafeModel
+                { model
+                    | writeLocked = textUnlockedResp.locked
+
+                    -- if textUnlockedResp.locked then
+                    --     True
+                    -- else
+                    --     False
+                    , successMessage =
+                        Just "text is unlocked for editing, other instructors can now edit the text."
+                }
+            , Cmd.none
+            )
+
+        TextUnlocked (Err err) ->
+            case err of
+                Http.BadStatus resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad status" resp
+                    in
+                    -- case Text.Decode.decodeRespErrors resp.body of
+                    --     Ok errors ->
+                    --         let
+                    --             errors_str =
+                    --                 String.join " and " (Dict.values errors)
+                    --         in
+                    --         ( SafeModel { model | success_msg = Just <| "Error trying to unlock the text: " ++ errors_str }, Cmd.none )
+                    --     _ ->
+                    ( SafeModel model, Cmd.none )
+
+                Http.BadBody resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad payload" resp
+                    in
+                    ( SafeModel model, Cmd.none )
+
+                _ ->
+                    ( SafeModel model, Cmd.none )
+
+        TextLocked (Err err) ->
+            case err of
+                Http.BadStatus resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad status" resp
+                    in
+                    -- case Text.Decode.decodeRespErrors resp.body of
+                    --     Ok errors ->
+                    --         let
+                    --             errors_str =
+                    --                 String.join " and " (Dict.values errors)
+                    --         in
+                    --         ( SafeModel { model | success_msg = Just <| "Error trying to lock the text: " ++ errors_str }, Cmd.none )
+                    --     _ ->
+                    ( SafeModel model, Cmd.none )
+
+                Http.BadBody resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad payload" resp
+                    in
+                    ( SafeModel model, Cmd.none )
+
+                _ ->
+                    ( SafeModel model, Cmd.none )
+
+        UpdateTextAttributes attrName attrValue ->
+            ( SafeModel { model | text_component = Text.Component.set_text_attribute model.text_component attrName attrValue }
+            , Cmd.none
+            )
+
+        UpdateTextCkEditors ( ckId, ckText ) ->
+            let
+                textIntroInputId =
+                    (Text.Field.text_intro_attrs
+                        (Text.Field.intro (Text.Component.text_fields model.text_component))
+                    ).input_id
+
+                textConclusionInputId =
+                    (Text.Field.text_conclusion_attrs
+                        (Text.Field.conclusion (Text.Component.text_fields model.text_component))
+                    ).input_id
+            in
+            if ckId == textIntroInputId then
+                ( SafeModel { model | text_component = Text.Component.set_text_attribute model.text_component "introduction" ckText }
+                , Cmd.none
+                )
+
+            else if ckId == textConclusionInputId then
+                ( SafeModel { model | text_component = Text.Component.set_text_attribute model.text_component "conclusion" ckText }
+                , Cmd.none
+                )
+
+            else
+                ( SafeModel model, Cmd.none )
+
+        AddTagInput inputId input ->
+            if Dict.member input model.tags then
+                ( SafeModel { model | text_component = Text.Component.add_tag model.text_component input }
+                , clearInputText inputId
+                )
+
+            else
+                ( SafeModel model, Cmd.none )
+
+        DeleteTag tag ->
+            ( SafeModel { model | text_component = Text.Component.remove_tag model.text_component tag }, Cmd.none )
+
+        ToggleTab tab ->
+            let
+                postToggleCmd =
+                    if tab == TextTab then
+                        Text.Component.reinitialize_ck_editors model.text_component
+
+                    else
+                        Cmd.none
+            in
+            ( SafeModel { model | selectedTab = tab }, postToggleCmd )
+
+        TextJSONDecode result ->
+            case result of
+                Ok textComponent ->
+                    let
+                        text =
+                            Text.Component.text textComponent
+                    in
+                    case text.write_locker of
+                        Just writeLocker ->
+                            if writeLocker /= InstructorProfile.usernameToString (InstructorProfile.username model.profile) then
+                                ( SafeModel
+                                    { model
+                                        | text_component = textComponent
+                                        , mode = ReadOnlyMode writeLocker
+                                        , errorMessage = Just <| "READONLY: text is currently being edited by " ++ writeLocker
+                                        , writeLocked = True
+                                    }
+                                , Text.Component.reinitialize_ck_editors textComponent
+                                )
+
+                            else
+                                ( SafeModel
+                                    { model
+                                        | text_component = textComponent
+                                        , mode = EditMode
+                                        , successMessage = Just <| "editing '" ++ text.title ++ "' text"
+                                        , writeLocked = True
+                                    }
+                                , Cmd.batch
+                                    [ Text.Component.reinitialize_ck_editors textComponent
+
+                                    -- , Text.Translations.Update.retrieveTextWords TextTranslationMsg model.text_api_endpoint text.id
+                                    , Cmd.none
+                                    ]
+                                )
+
+                        Nothing ->
+                            case text.id of
+                                Just id ->
+                                    ( SafeModel
+                                        { model
+                                            | text_component = textComponent
+                                            , mode = EditMode
+                                            , textTranslationsModel =
+                                                -- Just (TranslationsModel.init model.flags.translation_flags id text)
+                                                Just (TranslationsModel.init fakeTranslationFlags id text)
+                                            , successMessage = Just <| "editing '" ++ text.title ++ "' text"
+                                        }
+                                    , Cmd.batch
+                                        [ Text.Component.reinitialize_ck_editors textComponent
+
+                                        -- , Text.Translations.Update.retrieveTextWords TextTranslationMsg model.text_api_endpoint text.id
+                                        , Cmd.none
+                                        ]
+                                    )
+
+                                Nothing ->
+                                    ( SafeModel
+                                        { model
+                                            | text_component = textComponent
+                                            , mode = EditMode
+                                            , errorMessage = Just <| "Something went wrong: no valid text id"
+                                        }
+                                    , Text.Component.reinitialize_ck_editors textComponent
+                                    )
+
+                Err err ->
+                    let
+                        _ =
+                            Debug.log "text decode error" err
+                    in
+                    ( SafeModel
+                        { model
+                            | errorMessage = Just <| "Something went wrong loading the text from the server."
+                            , successMessage = Just <| "Editing a new text"
+                        }
+                    , Cmd.none
+                    )
+
+        TextTagsDecode result ->
+            case result of
+                Ok tagDict ->
+                    ( SafeModel { model | tags = tagDict }, Cmd.none )
+
+                _ ->
+                    ( SafeModel model, Cmd.none )
+
+        TextComponentMsg textComponentMsg ->
+            Text.Update.update textComponentMsg model
+                |> Tuple.mapFirst SafeModel
+
+        TextTranslationMsg textTransMsg ->
+            case model.textTranslationsModel of
+                Just translationModel ->
+                    let
+                        ( textTranslationsModel, textTranslationCmd ) =
+                            Text.Translations.Update.update TextTranslationMsg textTransMsg translationModel
+                    in
+                    ( SafeModel { model | textTranslationsModel = Just textTranslationsModel }, textTranslationCmd )
+
+                Nothing ->
+                    ( SafeModel model, Cmd.none )
+
+
+getText :
+    Session
+    -> Config
+    -> Int
+    -> Cmd Msg
+getText session config textId =
+    Api.get
+        (Endpoint.text (Config.restApiUrl config) textId Nothing)
+        (Session.cred session)
+        GotText
+        Text.Decode.textDecoder
+
+
+postText :
+    Session
+    -> Config
+    -> Text
+    -> Cmd Msg
+postText session config text =
+    Api.post
+        (Endpoint.createText (Config.restApiUrl config))
+        (Session.cred session)
+        (Http.jsonBody (Text.Encode.textEncoder text))
+        GotTextCreated
+        Text.Decode.textCreateRespDecoder
+
+
+updateText :
+    Session
+    -> Config
+    -> Text
+    -> Cmd Msg
+updateText session config text =
+    case text.id of
+        Just textId ->
+            Api.put
+                (Endpoint.text (Config.restApiUrl config) textId Nothing)
+                (Session.cred session)
+                (Http.jsonBody (Text.Encode.textEncoder text))
+                GotTextUpdated
+                Text.Decode.textUpdateRespDecoder
+
+        _ ->
+            Cmd.none
+
+
+deleteText :
+    Session
+    -> Config
+    -> Text.Model.Text
+    -> Cmd Msg
+deleteText session config text =
+    case text.id of
+        Just textId ->
+            Api.delete
+                (Endpoint.text (Config.restApiUrl config) textId Nothing)
+                (Session.cred session)
+                Http.emptyBody
+                GotTextDeleted
+                Text.Decode.textDeleteRespDecoder
+
+        _ ->
+            Cmd.none
+
+
+postLock :
+    Session
+    -> Config
+    -> Text.Model.Text
+    -> Cmd Msg
+postLock session config text =
+    case text.id of
+        Just textId ->
+            Api.post
+                (Endpoint.textLock (Config.restApiUrl config) textId)
+                (Session.cred session)
+                Http.emptyBody
+                TextLocked
+                Text.Decode.textLockRespDecoder
+
+        _ ->
+            Cmd.none
+
+
+deleteLock :
+    Session
+    -> Config
+    -> Text.Model.Text
+    -> Cmd Msg
+deleteLock session config text =
+    case text.id of
+        Just textId ->
+            Api.delete
+                (Endpoint.textLock (Config.restApiUrl config) textId)
+                (Session.cred session)
+                Http.emptyBody
+                TextUnlocked
+                Text.Decode.textLockRespDecoder
+
+        _ ->
+            Cmd.none
+
+
+
+-- textJSONtoComponent : Maybe Json.Encode.Value -> Cmd Msg
+-- textJSONtoComponent text =
+--     case text of
+--         Just json ->
+--             Task.attempt TextJSONDecode
+--                 (case Decode.decodeValue Text.Decode.textDecoder json of
+--                     Ok decodedText ->
+--                         Task.succeed (Text.Component.init decodedText)
+--                     Err err ->
+--                         Task.fail err
+--                 )
+--         Nothing ->
+--             -- CreateMode, initialize the text field editors
+--             Task.attempt (\_ -> InitTextFieldEditors) (Task.succeed Nothing)
+
+
+tagsToDict : List String -> Cmd Msg
+tagsToDict tagList =
+    Task.attempt TextTagsDecode (Task.succeed <| Dict.fromList (List.map (\tag -> ( tag, tag )) tagList))
+
+
+
+-- DECODE
+
+
+decodeRespErrors : String -> Result Decode.Error TextsResponseError
+decodeRespErrors str =
+    Decode.decodeString (Decode.field "errors" (Decode.dict Decode.string)) str
+
+
+
+-- VIEW
+
+
+view : SafeModel -> Document Msg
+view (SafeModel model) =
+    let
+        textViewParams =
+            { text = Text.Component.text model.text_component
+            , text_component = model.text_component
+            , text_translations_model = model.textTranslationsModel
+            , text_fields = Text.Component.text_fields model.text_component
+            , tags = model.tags
+            , selected_tab = model.selectedTab
+            , profile = model.profile
+            , write_locked = model.writeLocked
+            , mode = model.mode
+            , text_difficulties = model.textDifficulties
+            }
+
+        messages =
+            { onToggleEditable = ToggleEditable
+            , onTextComponentMsg = TextComponentMsg
+            , onDeleteText = SubmittedTextDelete
+            , onSubmitText = SubmittedText
+            , onUpdateTextAttributes = UpdateTextAttributes
+            , onToggleTab = ToggleTab
+            , onToggleLock = ToggleLock
+            , onAddTagInput = AddTagInput
+            , onDeleteTag = DeleteTag
+            , onTextTranslationMsg = TextTranslationMsg
+            }
+    in
+    { title = "Create Text"
+    , body =
+        [ div []
+            [ viewMessages (SafeModel model)
+            , Text.View.view_text
+                textViewParams
+                messages
+                -- TODO: replace this flag somehow
+                -- model.flags.answer_feedback_limit
+                1
+            ]
+        ]
+    }
+
+
+viewMessages : SafeModel -> Html Msg
+viewMessages (SafeModel model) =
+    div [ attribute "class" "msgs" ]
+        [ div [ attribute "class" "error_msg" ] [ viewMessage model.errorMessage ]
+        , div [ attribute "class" "success_msg" ] [ viewMessage model.successMessage ]
+        ]
+
+
+viewMessage : Maybe String -> Html Msg
+viewMessage msg =
+    let
+        msgStr =
+            case msg of
+                Just str ->
+                    String.join " " [ " ", str ]
+
+                _ ->
+                    ""
+    in
+    Html.text msgStr
+
+
+
+-- SHARED
+
+
+save : SafeModel -> Shared.Model -> Shared.Model
+save model shared =
+    shared
+
+
+load : Shared.Model -> SafeModel -> ( SafeModel, Cmd Msg )
+load shared safeModel =
+    ( safeModel, Cmd.none )
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : SafeModel -> Sub Msg
+subscriptions (SafeModel model) =
+    Sub.batch <|
+        [ -- text updates
+          Text.Subscriptions.subscriptions TextComponentMsg model
+
+        -- handle clearing messages
+        , case model.successMessage of
+            Just _ ->
+                Time.every 3.0 ClearMessages
+
+            _ ->
+                Sub.none
+
+        -- text ckeditor updates
+        , ckEditorUpdate UpdateTextCkEditors
+
+        -- handle text delete confirmation
+        , confirmation ConfirmedTextDelete
+        ]

--- a/web/src/Pages/Text/Edit/Id_Int.elm
+++ b/web/src/Pages/Text/Edit/Id_Int.elm
@@ -1,0 +1,802 @@
+module Pages.Text.Edit.Id_Int exposing (..)
+
+import Api
+import Api.Config as Config exposing (Config)
+import Api.Endpoint as Endpoint
+import Browser.Navigation
+import Debug
+import Dict exposing (Dict)
+import Html exposing (..)
+import Html.Attributes exposing (attribute)
+import Http
+import InstructorAdmin.Text.Translations as Translations
+import Json.Decode as Decode
+import Ports exposing (ckEditorUpdate, clearInputText, confirm, confirmation)
+import Session exposing (Session)
+import Shared
+import Spa.Document exposing (Document)
+import Spa.Page as Page exposing (Page)
+import Spa.Url exposing (Url)
+import Task
+import Text.Component exposing (TextComponent)
+import Text.Decode
+import Text.Encode
+import Text.Field exposing (TextField(..))
+import Text.Model exposing (Text)
+import Text.Subscriptions
+import Text.Translations.Model as TranslationsModel
+import Text.Translations.Msg as TranslationsMsg
+import Text.Translations.Update
+import Text.Update
+import Text.View
+import TextEdit exposing (Mode(..), Tab(..))
+import Time
+import User.Instructor.Profile as InstructorProfile exposing (InstructorProfile)
+import User.Profile as Profile
+
+
+page : Page Params Model Msg
+page =
+    Page.protectedInstructorApplication
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        , save = save
+        , load = load
+        }
+
+
+type alias TextsResponseError =
+    Dict String String
+
+
+
+-- INIT
+
+
+type alias Params =
+    { id : Int }
+
+
+type alias Model =
+    Maybe SafeModel
+
+
+type SafeModel
+    = SafeModel
+        { session : Session
+        , config : Config
+        , mode : Mode
+        , profile : InstructorProfile
+        , successMessage : Maybe String
+        , errorMessage : Maybe String
+        , text_component : TextComponent
+        , textDifficulties : List Text.Model.TextDifficulty
+        , translationsInit : Translations.Flags
+        , textTranslationsModel : Maybe TranslationsModel.Model
+        , tags : Dict String String
+        , writeLocked : Bool
+        , selectedTab : Tab
+        }
+
+
+init : Shared.Model -> Url Params -> ( SafeModel, Cmd Msg )
+init shared { params } =
+    ( SafeModel
+        { session = shared.session
+        , config = shared.config
+
+        -- the writeLocker is a instructor username string,
+        -- and we don't know who it is until we retrieve the text
+        , mode = ReadOnlyMode ""
+        , successMessage = Nothing
+        , errorMessage = Nothing
+        , profile = Profile.toInstructorProfile shared.profile
+        , text_component = Text.Component.emptyTextComponent
+        , textDifficulties = Shared.difficulties
+        , translationsInit =
+            { session = shared.session
+            , config = shared.config
+            , add_as_text_word_endpoint_url = "legacyEndpoint"
+            , merge_textword_endpoint_url = "legacyEndpoint"
+            , text_translation_match_endpoint = "legacyEndpoint"
+            , csrftoken = "legacyToken"
+            }
+        , textTranslationsModel = Nothing
+        , tags =
+            Dict.fromList <|
+                List.map (\tag -> ( tag, tag )) Shared.tags
+        , selectedTab = TextTab
+        , writeLocked = False
+        }
+    , Cmd.batch
+        [ Task.perform (\_ -> InitTextFieldEditors) (Task.succeed Nothing)
+        , getText shared.session shared.config params.id
+        ]
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = SubmittedText
+    | GotText (Result Http.Error Text)
+    | GotTextCreated (Result Http.Error Text.Decode.TextCreateResp)
+    | GotTextUpdated (Result Http.Error Text.Decode.TextUpdateResp)
+    | SubmittedTextDelete
+    | ConfirmedTextDelete Bool
+    | GotTextDeleted (Result Http.Error Text.Decode.TextDeleteResp)
+    | InitTextFieldEditors
+    | ToggleEditable TextField Bool
+    | UpdateTextAttributes String String
+    | UpdateTextCkEditors ( String, String )
+    | AddTagInput String String
+    | DeleteTag String
+    | ToggleLock
+    | TextLocked (Result Http.Error Text.Decode.TextLockResp)
+    | TextUnlocked (Result Http.Error Text.Decode.TextLockResp)
+    | ToggleTab Tab
+    | ClearMessages Time.Posix
+    | TextTagsDecode (Result String (Dict String String))
+    | TextTranslationMsg TranslationsMsg.Msg
+    | TextComponentMsg Text.Update.Msg
+
+
+update : Msg -> SafeModel -> ( SafeModel, Cmd Msg )
+update msg (SafeModel model) =
+    case msg of
+        SubmittedText ->
+            let
+                text =
+                    Text.Component.text model.text_component
+            in
+            case model.mode of
+                ReadOnlyMode writeLocker ->
+                    ( SafeModel { model | successMessage = Just <| "Text is locked by " ++ writeLocker }, Cmd.none )
+
+                EditMode ->
+                    ( SafeModel { model | errorMessage = Nothing, successMessage = Nothing }
+                    , updateText model.session model.config text
+                    )
+
+                CreateMode ->
+                    ( SafeModel { model | errorMessage = Nothing, successMessage = Nothing }
+                    , postText model.session model.config text
+                    )
+
+        GotText (Ok text) ->
+            let
+                textComponent =
+                    Text.Component.init text
+            in
+            case text.write_locker of
+                Just writeLocker ->
+                    if writeLocker /= InstructorProfile.usernameToString (InstructorProfile.username model.profile) then
+                        ( SafeModel
+                            { model
+                                | text_component = textComponent
+                                , mode = ReadOnlyMode writeLocker
+                                , errorMessage = Just <| "READONLY: text is currently being edited by " ++ writeLocker
+                                , writeLocked = True
+                            }
+                        , Text.Component.reinitialize_ck_editors textComponent
+                        )
+
+                    else
+                        ( SafeModel
+                            { model
+                                | text_component = textComponent
+                                , mode = EditMode
+                                , successMessage = Just <| "editing '" ++ text.title ++ "' text"
+                                , writeLocked = True
+                            }
+                        , Cmd.batch
+                            [ Text.Component.reinitialize_ck_editors textComponent
+                            , Text.Translations.Update.retrieveTextWords
+                                model.session
+                                model.config
+                                TextTranslationMsg
+                                text.id
+                            ]
+                        )
+
+                Nothing ->
+                    case text.id of
+                        Just id ->
+                            ( SafeModel
+                                { model
+                                    | text_component = textComponent
+                                    , mode = EditMode
+                                    , textTranslationsModel =
+                                        Just (TranslationsModel.init model.translationsInit id text)
+                                    , successMessage = Just <| "editing '" ++ text.title ++ "' text"
+                                }
+                            , Cmd.batch
+                                [ Text.Component.reinitialize_ck_editors textComponent
+                                , Text.Translations.Update.retrieveTextWords
+                                    model.session
+                                    model.config
+                                    TextTranslationMsg
+                                    text.id
+                                ]
+                            )
+
+                        Nothing ->
+                            ( SafeModel
+                                { model
+                                    | text_component = textComponent
+                                    , mode = EditMode
+                                    , errorMessage = Just <| "Something went wrong: no valid text id"
+                                }
+                            , Text.Component.reinitialize_ck_editors textComponent
+                            )
+
+        GotText (Err err) ->
+            ( SafeModel model
+            , Cmd.none
+            )
+
+        GotTextCreated (Ok textCreateResp) ->
+            let
+                text =
+                    Text.Component.text model.text_component
+            in
+            ( SafeModel
+                { model
+                    | successMessage = Just <| String.join " " [ " created '" ++ text.title ++ "'" ]
+                    , mode = EditMode
+                }
+            , Browser.Navigation.load textCreateResp.redirect
+            )
+
+        GotTextCreated (Err err) ->
+            case err of
+                Http.BadStatus resp ->
+                    -- case Text.Decode.decodeRespErrors resp.body of
+                    --     Ok errors ->
+                    --         ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+                    --     _ ->
+                    ( SafeModel model, Cmd.none )
+
+                Http.BadBody resp ->
+                    let
+                        _ =
+                            Debug.log "submit text bad payload error" resp
+                    in
+                    ( SafeModel model, Cmd.none )
+
+                _ ->
+                    ( SafeModel model, Cmd.none )
+
+        GotTextUpdated (Ok textUpdateResp) ->
+            let
+                text =
+                    Text.Component.text model.text_component
+            in
+            ( SafeModel
+                { model
+                    | successMessage =
+                        Just <|
+                            String.join " " [ " saved '" ++ text.title ++ "'" ]
+                }
+            , Cmd.none
+            )
+
+        GotTextUpdated (Err err) ->
+            case err of
+                Http.BadStatus resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad status" resp
+                    in
+                    -- case Text.Decode.decodeRespErrors resp.body of
+                    --     Ok errors ->
+                    --         ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+                    --     _ ->
+                    ( SafeModel model, Cmd.none )
+
+                Http.BadBody resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad payload" resp
+                    in
+                    ( SafeModel model, Cmd.none )
+
+                _ ->
+                    ( SafeModel model, Cmd.none )
+
+        SubmittedTextDelete ->
+            ( SafeModel model
+            , confirm "Are you sure you want to delete this text?"
+            )
+
+        GotTextDeleted (Ok textDelete) ->
+            let
+                _ =
+                    Debug.log "text delete" textDelete
+            in
+            ( SafeModel model, Browser.Navigation.load textDelete.redirect )
+
+        GotTextDeleted (Err httpError) ->
+            case httpError of
+                Http.BadStatus resp ->
+                    let
+                        _ =
+                            Debug.log "delete text error bad status" resp
+                    in
+                    -- case Text.Decode.decodeRespErrors resp.body of
+                    --     Ok errors ->
+                    --         let
+                    --             errorsStr =
+                    --                 String.join " and " (Dict.values errors)
+                    --         in
+                    --         ( SafeModel { model | success_msg = Just <| "Error trying to delete the text: " ++ errorsStr }, Cmd.none )
+                    --     _ ->
+                    ( SafeModel model, Cmd.none )
+
+                Http.BadBody resp ->
+                    let
+                        _ =
+                            Debug.log "delete text error bad payload" resp
+                    in
+                    ( SafeModel model, Cmd.none )
+
+                _ ->
+                    let
+                        _ =
+                            Debug.log "delete text error bad payload" httpError
+                    in
+                    ( SafeModel model, Cmd.none )
+
+        ConfirmedTextDelete confirm ->
+            if confirm then
+                let
+                    text =
+                        Text.Component.text model.text_component
+                in
+                ( SafeModel model
+                , deleteText model.session model.config text
+                )
+
+            else
+                ( SafeModel model, Cmd.none )
+
+        InitTextFieldEditors ->
+            ( SafeModel model
+            , Text.Component.initialize_text_field_ck_editors model.text_component
+            )
+
+        ToggleEditable textField editable ->
+            let
+                ( textComponent, postToggleCmds ) =
+                    case textField of
+                        Title _ ->
+                            ( Text.Component.set_title_editable model.text_component editable
+                            , Text.Component.post_toggle_title
+                            )
+
+                        Author _ ->
+                            ( Text.Component.set_author_editable model.text_component editable
+                            , Text.Component.post_toggle_author
+                            )
+
+                        Source _ ->
+                            ( Text.Component.set_source_editable model.text_component editable
+                            , Text.Component.post_toggle_source
+                            )
+
+                        _ ->
+                            ( model.text_component, \_ -> Cmd.none )
+            in
+            ( SafeModel { model | text_component = textComponent }
+            , postToggleCmds textComponent
+            )
+
+        UpdateTextAttributes attrName attrValue ->
+            ( SafeModel { model | text_component = Text.Component.set_text_attribute model.text_component attrName attrValue }
+            , Cmd.none
+            )
+
+        UpdateTextCkEditors ( ckId, ckText ) ->
+            let
+                textIntroInputId =
+                    (Text.Field.text_intro_attrs
+                        (Text.Field.intro (Text.Component.text_fields model.text_component))
+                    ).input_id
+
+                textConclusionInputId =
+                    (Text.Field.text_conclusion_attrs
+                        (Text.Field.conclusion (Text.Component.text_fields model.text_component))
+                    ).input_id
+            in
+            if ckId == textIntroInputId then
+                ( SafeModel { model | text_component = Text.Component.set_text_attribute model.text_component "introduction" ckText }
+                , Cmd.none
+                )
+
+            else if ckId == textConclusionInputId then
+                ( SafeModel { model | text_component = Text.Component.set_text_attribute model.text_component "conclusion" ckText }
+                , Cmd.none
+                )
+
+            else
+                ( SafeModel model, Cmd.none )
+
+        AddTagInput inputId input ->
+            if Dict.member input model.tags then
+                ( SafeModel
+                    { model
+                        | text_component =
+                            Text.Component.add_tag model.text_component input
+                    }
+                , clearInputText inputId
+                )
+
+            else
+                ( SafeModel model, Cmd.none )
+
+        DeleteTag tag ->
+            ( SafeModel
+                { model
+                    | text_component =
+                        Text.Component.remove_tag model.text_component tag
+                }
+            , Cmd.none
+            )
+
+        ToggleLock ->
+            let
+                text =
+                    Text.Component.text model.text_component
+            in
+            ( SafeModel model
+            , if not model.writeLocked then
+                postLock model.session model.config text
+
+              else
+                deleteLock model.session model.config text
+            )
+
+        TextLocked (Ok textLockedResp) ->
+            ( SafeModel
+                { model
+                    | writeLocked = textLockedResp.locked
+                    , successMessage =
+                        Just "text is locked for editing, other instructors can only view the text while it is locked."
+                }
+            , Cmd.none
+            )
+
+        TextLocked (Err err) ->
+            case err of
+                Http.BadStatus resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad status" resp
+                    in
+                    -- case Text.Decode.decodeRespErrors resp.body of
+                    --     Ok errors ->
+                    --         let
+                    --             errors_str =
+                    --                 String.join " and " (Dict.values errors)
+                    --         in
+                    --         ( SafeModel { model | success_msg = Just <| "Error trying to lock the text: " ++ errors_str }, Cmd.none )
+                    --     _ ->
+                    ( SafeModel model, Cmd.none )
+
+                Http.BadBody resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad payload" resp
+                    in
+                    ( SafeModel model, Cmd.none )
+
+                _ ->
+                    ( SafeModel model, Cmd.none )
+
+        TextUnlocked (Ok textUnlockedResp) ->
+            ( SafeModel
+                { model
+                    | writeLocked = textUnlockedResp.locked
+                    , successMessage =
+                        Just "text is unlocked for editing, other instructors can now edit the text."
+                }
+            , Cmd.none
+            )
+
+        TextUnlocked (Err err) ->
+            case err of
+                Http.BadStatus resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad status" resp
+                    in
+                    -- case Text.Decode.decodeRespErrors resp.body of
+                    --     Ok errors ->
+                    --         let
+                    --             errors_str =
+                    --                 String.join " and " (Dict.values errors)
+                    --         in
+                    --         ( SafeModel { model | success_msg = Just <| "Error trying to unlock the text: " ++ errors_str }, Cmd.none )
+                    --     _ ->
+                    ( SafeModel model, Cmd.none )
+
+                Http.BadBody resp ->
+                    let
+                        _ =
+                            Debug.log "update error bad payload" resp
+                    in
+                    ( SafeModel model, Cmd.none )
+
+                _ ->
+                    ( SafeModel model, Cmd.none )
+
+        ToggleTab tab ->
+            let
+                postToggleCmd =
+                    if tab == TextTab then
+                        Text.Component.reinitialize_ck_editors model.text_component
+
+                    else
+                        Cmd.none
+            in
+            ( SafeModel { model | selectedTab = tab }, postToggleCmd )
+
+        ClearMessages _ ->
+            ( SafeModel { model | successMessage = Nothing }
+            , Cmd.none
+            )
+
+        TextTagsDecode result ->
+            case result of
+                Ok tagDict ->
+                    ( SafeModel { model | tags = tagDict }, Cmd.none )
+
+                _ ->
+                    ( SafeModel model, Cmd.none )
+
+        TextComponentMsg textComponentMsg ->
+            Text.Update.update textComponentMsg model
+                |> Tuple.mapFirst SafeModel
+
+        TextTranslationMsg textTransMsg ->
+            case model.textTranslationsModel of
+                Just translationModel ->
+                    let
+                        ( textTranslationsModel, textTranslationCmd ) =
+                            Text.Translations.Update.update TextTranslationMsg textTransMsg translationModel
+                    in
+                    ( SafeModel { model | textTranslationsModel = Just textTranslationsModel }, textTranslationCmd )
+
+                Nothing ->
+                    ( SafeModel model, Cmd.none )
+
+
+getText :
+    Session
+    -> Config
+    -> Int
+    -> Cmd Msg
+getText session config textId =
+    Api.get
+        (Endpoint.text (Config.restApiUrl config) textId [])
+        (Session.cred session)
+        GotText
+        Text.Decode.textDecoder
+
+
+postText :
+    Session
+    -> Config
+    -> Text
+    -> Cmd Msg
+postText session config text =
+    Api.post
+        (Endpoint.createText (Config.restApiUrl config))
+        (Session.cred session)
+        (Http.jsonBody (Text.Encode.textEncoder text))
+        GotTextCreated
+        Text.Decode.textCreateRespDecoder
+
+
+updateText :
+    Session
+    -> Config
+    -> Text
+    -> Cmd Msg
+updateText session config text =
+    case text.id of
+        Just textId ->
+            Api.put
+                (Endpoint.text (Config.restApiUrl config) textId [])
+                (Session.cred session)
+                (Http.jsonBody (Text.Encode.textEncoder text))
+                GotTextUpdated
+                Text.Decode.textUpdateRespDecoder
+
+        _ ->
+            Cmd.none
+
+
+deleteText :
+    Session
+    -> Config
+    -> Text.Model.Text
+    -> Cmd Msg
+deleteText session config text =
+    case text.id of
+        Just textId ->
+            Api.delete
+                (Endpoint.text (Config.restApiUrl config) textId [])
+                (Session.cred session)
+                Http.emptyBody
+                GotTextDeleted
+                Text.Decode.textDeleteRespDecoder
+
+        _ ->
+            Cmd.none
+
+
+postLock :
+    Session
+    -> Config
+    -> Text.Model.Text
+    -> Cmd Msg
+postLock session config text =
+    case text.id of
+        Just textId ->
+            Api.post
+                (Endpoint.textLock (Config.restApiUrl config) textId)
+                (Session.cred session)
+                Http.emptyBody
+                TextLocked
+                Text.Decode.textLockRespDecoder
+
+        _ ->
+            Cmd.none
+
+
+deleteLock :
+    Session
+    -> Config
+    -> Text.Model.Text
+    -> Cmd Msg
+deleteLock session config text =
+    case text.id of
+        Just textId ->
+            Api.delete
+                (Endpoint.textLock (Config.restApiUrl config) textId)
+                (Session.cred session)
+                Http.emptyBody
+                TextUnlocked
+                Text.Decode.textLockRespDecoder
+
+        _ ->
+            Cmd.none
+
+
+tagsToDict : List String -> Cmd Msg
+tagsToDict tagList =
+    Task.attempt
+        TextTagsDecode
+        (Task.succeed <| Dict.fromList (List.map (\tag -> ( tag, tag )) tagList))
+
+
+
+-- DECODE
+
+
+decodeRespErrors : String -> Result Decode.Error TextsResponseError
+decodeRespErrors str =
+    Decode.decodeString (Decode.field "errors" (Decode.dict Decode.string)) str
+
+
+
+-- VIEW
+
+
+view : SafeModel -> Document Msg
+view (SafeModel model) =
+    let
+        textViewParams =
+            { text = Text.Component.text model.text_component
+            , text_component = model.text_component
+            , text_translations_model = model.textTranslationsModel
+            , text_fields = Text.Component.text_fields model.text_component
+            , tags = model.tags
+            , selected_tab = model.selectedTab
+            , profile = model.profile
+            , write_locked = model.writeLocked
+            , mode = model.mode
+            , text_difficulties = model.textDifficulties
+            }
+
+        messages =
+            { onToggleEditable = ToggleEditable
+            , onTextComponentMsg = TextComponentMsg
+            , onDeleteText = SubmittedTextDelete
+            , onSubmitText = SubmittedText
+            , onUpdateTextAttributes = UpdateTextAttributes
+            , onToggleTab = ToggleTab
+            , onToggleLock = ToggleLock
+            , onAddTagInput = AddTagInput
+            , onDeleteTag = DeleteTag
+            , onTextTranslationMsg = TextTranslationMsg
+            }
+    in
+    { title = "Create Text"
+    , body =
+        [ div []
+            [ viewMessages (SafeModel model)
+            , Text.View.view_text
+                textViewParams
+                messages
+                Shared.answerFeedbackCharacterLimit
+            ]
+        ]
+    }
+
+
+viewMessages : SafeModel -> Html Msg
+viewMessages (SafeModel model) =
+    div [ attribute "class" "msgs" ]
+        [ div [ attribute "class" "error_msg" ] [ viewMessage model.errorMessage ]
+        , div [ attribute "class" "success_msg" ] [ viewMessage model.successMessage ]
+        ]
+
+
+viewMessage : Maybe String -> Html Msg
+viewMessage msg =
+    let
+        msgStr =
+            case msg of
+                Just str ->
+                    String.join " " [ " ", str ]
+
+                _ ->
+                    ""
+    in
+    Html.text msgStr
+
+
+
+-- SHARED
+
+
+save : SafeModel -> Shared.Model -> Shared.Model
+save model shared =
+    shared
+
+
+load : Shared.Model -> SafeModel -> ( SafeModel, Cmd Msg )
+load shared safeModel =
+    ( safeModel, Cmd.none )
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : SafeModel -> Sub Msg
+subscriptions (SafeModel model) =
+    Sub.batch <|
+        [ -- text updates
+          Text.Subscriptions.subscriptions TextComponentMsg model
+
+        -- handle clearing messages
+        , case model.successMessage of
+            Just _ ->
+                Time.every 3.0 ClearMessages
+
+            _ ->
+                Sub.none
+
+        -- text ckeditor updates
+        , ckEditorUpdate UpdateTextCkEditors
+
+        -- handle text delete confirmation
+        , confirmation ConfirmedTextDelete
+        ]

--- a/web/src/Question/Decode.elm
+++ b/web/src/Question/Decode.elm
@@ -2,12 +2,12 @@ module Question.Decode exposing (questionDecoder, questionsDecoder)
 
 import Answer.Decode
 import Array exposing (Array)
+import DateTime
+import Iso8601
 import Json.Decode
 import Json.Decode.Extra exposing (posix)
 import Json.Decode.Pipeline exposing (required)
 import Question.Model exposing (Question)
-
-import DateTime
 
 
 questionDecoder : Json.Decode.Decoder Question
@@ -15,8 +15,10 @@ questionDecoder =
     Json.Decode.succeed Question
         |> required "id" (Json.Decode.nullable Json.Decode.int)
         |> required "text_section_id" (Json.Decode.nullable Json.Decode.int)
-        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
-        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
+        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
+        -- |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        -- |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
         |> required "body" Json.Decode.string
         |> required "order" Json.Decode.int
         |> required "answers" Answer.Decode.answersDecoder

--- a/web/src/Question/Encode.elm
+++ b/web/src/Question/Encode.elm
@@ -18,6 +18,8 @@ questionEncoder question =
 
 questionsEncoder : Array Question -> Encode.Value
 questionsEncoder questions =
-    Encode.list <|
-        Array.toList <|
-            Array.map (\question -> questionEncoder question) questions
+    -- Encode.list <|
+    -- Array.toList <|
+    -- Array.map (\question -> questionEncoder question) questions
+    Encode.list questionEncoder <|
+        Array.toList questions

--- a/web/src/Question/Field.elm
+++ b/web/src/Question/Field.elm
@@ -123,9 +123,9 @@ update_errors question_fields ( field_id, field_error ) =
     case error_key of
         "question" :: questnIdx :: "answer" :: answer_index :: feedback ->
             case String.toInt questnIdx of
-                Ok i ->
+                Just i ->
                     case String.toInt answer_index of
-                        Ok j ->
+                        Just j ->
                             case get_question_field question_fields i of
                                 Just question_field ->
                                     case Answer.Field.get_answer_field (answers question_field) j of
@@ -146,17 +146,17 @@ update_errors question_fields ( field_id, field_error ) =
                                     question_fields
 
                         -- question field does not exist
-                        _ ->
+                        Nothing ->
                             question_fields
 
                 -- not a valid answer index
-                _ ->
+                Nothing ->
                     question_fields
 
         -- not a valid question index
         "question" :: questnIdx :: field :: [] ->
             case String.toInt questnIdx of
-                Ok i ->
+                Just i ->
                     case get_question_field question_fields i of
                         Just question_field ->
                             update_question_field (update_error question_field field_error) question_fields
@@ -165,7 +165,7 @@ update_errors question_fields ( field_id, field_error ) =
                             question_fields
 
                 -- question field not present
-                _ ->
+                Nothing ->
                     question_fields
 
         -- not a valid question index

--- a/web/src/Question/View.elm
+++ b/web/src/Question/View.elm
@@ -125,7 +125,7 @@ view_question_menu params field =
     div [ classList [ ( "question_menu", True ) ] ]
         [ div []
             [ Html.img
-                [ attribute "src" "/static/img/action_arrow.svg"
+                [ attribute "src" "/public/img/action_arrow.svg"
                 , onClick (params.msg (ToggleQuestionMenu params.text_section_component field))
                 ]
                 []
@@ -178,7 +178,7 @@ view_add_question : (Msg -> msg) -> TextSectionComponent -> Html msg
 view_add_question msg text_component =
     div [ classList [ ( "add_question", True ) ], onClick (msg (AddQuestion text_component)) ]
         [ Html.img
-            [ attribute "src" "/static/img/add.svg"
+            [ attribute "src" "/public/img/add.svg"
             , attribute "height" "20px"
             , attribute "width" "20px"
             ]
@@ -199,7 +199,7 @@ view_delete_selected : (Msg -> msg) -> TextSectionComponent -> Html msg
 view_delete_selected msg text_component =
     div [ classList [ ( "delete_question", True ) ], onClick (msg (DeleteSelectedQuestions text_component)) ]
         [ Html.img
-            [ attribute "src" "/static/img/delete_question.svg"
+            [ attribute "src" "/public/img/delete_question.svg"
             , attribute "height" "20px"
             , attribute "width" "20px"
             ]

--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -2,6 +2,7 @@ module Shared exposing
     ( Flags
     , Model
     , Msg
+    , answerFeedbackCharacterLimit
     , difficulties
     , init
     , statuses
@@ -395,3 +396,8 @@ statuses =
     , ( "in_progress", "In Progress" )
     , ( "read", "Read" )
     ]
+
+
+answerFeedbackCharacterLimit : Int
+answerFeedbackCharacterLimit =
+    2048

--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -345,7 +345,7 @@ viewLowerMenu role =
                 [ classList [ ( "lower-menu-item", True ) ] ]
                 [ a
                     [ class "link"
-                    , href (Route.toString Route.NotFound)
+                    , href (Route.toString Route.Text__Create)
                     ]
                     [ text "Create a new text" ]
                 ]

--- a/web/src/Text/Component.elm
+++ b/web/src/Text/Component.elm
@@ -43,89 +43,89 @@ type TextComponent
 
 
 init : Text -> TextComponent
-init text =
+init txt =
     TextComponent
-        text
+        txt
         init_text_fields
-        (tags_to_dict text.tags)
-        (Text.Section.Component.Group.fromTextSections text.sections)
+        (tags_to_dict txt.tags)
+        (Text.Section.Component.Group.fromTextSections txt.sections)
 
 
 text : TextComponent -> Text
-text (TextComponent text _ text_tags component_group) =
+text (TextComponent txt _ text_tags component_group) =
     Text.set_tags
-        (Text.set_sections text (Text.Section.Component.Group.toTextSections component_group))
+        (Text.set_sections txt (Text.Section.Component.Group.toTextSections component_group))
         (Just <| Dict.keys text_tags)
 
 
 text_fields : TextComponent -> TextFields
-text_fields (TextComponent _ text_fields _ _) =
-    text_fields
+text_fields (TextComponent _ textFields _ _) =
+    textFields
 
 
 set_text_fields : TextComponent -> TextFields -> TextComponent
-set_text_fields text_component text_fields =
+set_text_fields text_component _ =
     text_component
 
 
 set_intro_editable : TextComponent -> Bool -> TextComponent
-set_intro_editable (TextComponent text text_fields text_tags component_group) editable =
+set_intro_editable (TextComponent txt textFields text_tags component_group) editable =
     let
         (Text.Field.TextIntro intro_field_attrs) =
-            Text.Field.intro text_fields
+            Text.Field.intro textFields
 
         new_text_fields =
-            Text.Field.set_intro text_fields { intro_field_attrs | error = False, editable = editable }
+            Text.Field.set_intro textFields { intro_field_attrs | error = False, editable = editable }
     in
-    TextComponent text new_text_fields text_tags component_group
+    TextComponent txt new_text_fields text_tags component_group
 
 
 set_conclusion_editable : TextComponent -> Bool -> TextComponent
-set_conclusion_editable (TextComponent text text_fields text_tags component_group) editable =
+set_conclusion_editable (TextComponent txt textFields text_tags component_group) editable =
     let
         (Text.Field.TextConclusion conclusion_field_attrs) =
-            Text.Field.conclusion text_fields
+            Text.Field.conclusion textFields
 
         new_text_fields =
-            Text.Field.set_conclusion text_fields { conclusion_field_attrs | error = False, editable = editable }
+            Text.Field.set_conclusion textFields { conclusion_field_attrs | error = False, editable = editable }
     in
-    TextComponent text new_text_fields text_tags component_group
+    TextComponent txt new_text_fields text_tags component_group
 
 
 set_title_editable : TextComponent -> Bool -> TextComponent
-set_title_editable (TextComponent text text_fields text_tags component_group) editable =
+set_title_editable (TextComponent txt textFields text_tags component_group) editable =
     let
         (Text.Field.TextTitle title_field_attrs) =
-            Text.Field.title text_fields
+            Text.Field.title textFields
 
         new_text_fields =
-            Text.Field.set_title text_fields { title_field_attrs | error = False, editable = editable }
+            Text.Field.set_title textFields { title_field_attrs | error = False, editable = editable }
     in
-    TextComponent text new_text_fields text_tags component_group
+    TextComponent txt new_text_fields text_tags component_group
 
 
 set_author_editable : TextComponent -> Bool -> TextComponent
-set_author_editable (TextComponent text text_fields text_tags component_group) editable =
+set_author_editable (TextComponent txt textFields text_tags component_group) editable =
     let
         (Text.Field.TextAuthor text_author_attrs) =
-            Text.Field.author text_fields
+            Text.Field.author textFields
 
         new_text_fields =
-            Text.Field.set_author text_fields { text_author_attrs | error = False, editable = editable }
+            Text.Field.set_author textFields { text_author_attrs | error = False, editable = editable }
     in
-    TextComponent text new_text_fields text_tags component_group
+    TextComponent txt new_text_fields text_tags component_group
 
 
 set_source_editable : TextComponent -> Bool -> TextComponent
-set_source_editable (TextComponent text text_fields text_tags component_group) editable =
+set_source_editable (TextComponent txt textFields text_tags component_group) editable =
     let
         (Text.Field.TextSource text_source_attrs) =
-            Text.Field.source text_fields
+            Text.Field.source textFields
 
         new_text_fields =
-            Text.Field.set_source text_fields { text_source_attrs | error = False, editable = editable }
+            Text.Field.set_source textFields { text_source_attrs | error = False, editable = editable }
     in
-    TextComponent text new_text_fields text_tags component_group
+    TextComponent txt new_text_fields text_tags component_group
 
 
 text_section_components : TextComponent -> TextSectionComponentGroup
@@ -134,8 +134,8 @@ text_section_components (TextComponent _ _ _ components) =
 
 
 set_text_section_components : TextComponent -> TextSectionComponentGroup -> TextComponent
-set_text_section_components (TextComponent text fields text_tags _) new_components =
-    TextComponent text fields text_tags new_components
+set_text_section_components (TextComponent txt fields text_tags _) new_components =
+    TextComponent txt fields text_tags new_components
 
 
 
@@ -143,25 +143,25 @@ set_text_section_components (TextComponent text fields text_tags _) new_componen
 
 
 set_text_attribute : TextComponent -> TextAttributeName -> String -> TextComponent
-set_text_attribute ((TextComponent text fields text_tags components) as text_component) attr_name value =
+set_text_attribute ((TextComponent txt fields text_tags components) as text_component) attr_name value =
     case attr_name of
         "title" ->
-            TextComponent { text | title = value } fields text_tags components
+            TextComponent { txt | title = value } fields text_tags components
 
         "introduction" ->
-            TextComponent { text | introduction = value } fields text_tags components
+            TextComponent { txt | introduction = value } fields text_tags components
 
         "author" ->
-            TextComponent { text | author = value } fields text_tags components
+            TextComponent { txt | author = value } fields text_tags components
 
         "source" ->
-            TextComponent { text | source = value } fields text_tags components
+            TextComponent { txt | source = value } fields text_tags components
 
         "difficulty" ->
-            TextComponent { text | difficulty = value } fields text_tags components
+            TextComponent { txt | difficulty = value } fields text_tags components
 
         "conclusion" ->
-            TextComponent { text | conclusion = Just value } fields text_tags components
+            TextComponent { txt | conclusion = Just value } fields text_tags components
 
         _ ->
             text_component
@@ -203,14 +203,14 @@ reinitialize_ck_editors text_component =
 
 
 update_text_errors : TextComponent -> Dict String String -> TextComponent
-update_text_errors (TextComponent text fields text_tags components) errors =
+update_text_errors (TextComponent txt fields text_tags components) errors =
     let
         _ =
             Debug.log "text errors" errors
 
         new_text_component =
             TextComponent
-                text
+                txt
                 (Array.foldr Text.Field.update_error fields (Array.fromList <| Dict.toList errors))
                 text_tags
                 components
@@ -222,8 +222,8 @@ update_text_errors (TextComponent text fields text_tags components) errors =
 
 
 tags_to_dict : Maybe (List String) -> Dict String String
-tags_to_dict tags =
-    case tags of
+tags_to_dict tgs =
+    case tgs of
         Just tags_list ->
             Dict.fromList <| List.map (\tag -> ( tag, tag )) tags_list
 
@@ -237,7 +237,7 @@ tags (TextComponent _ _ text_tags _) =
 
 
 add_tag : TextComponent -> String -> TextComponent
-add_tag ((TextComponent text fields text_tags components) as text_component) tag =
+add_tag ((TextComponent txt fields text_tags components) as text_component) tag =
     let
         text_tag_field =
             Text.Field.tags fields
@@ -251,24 +251,24 @@ add_tag ((TextComponent text fields text_tags components) as text_component) tag
         new_text_component_fields =
             Text.Field.set_tags fields new_text_tag_field_attrs
     in
-    TextComponent text new_text_component_fields (Dict.insert tag tag text_tags) components
+    TextComponent txt new_text_component_fields (Dict.insert tag tag text_tags) components
 
 
 remove_tag : TextComponent -> String -> TextComponent
-remove_tag ((TextComponent text fields text_tags components) as text_component) tag =
-    TextComponent text fields (Dict.remove tag text_tags) components
+remove_tag ((TextComponent txt fields text_tags components) as text_component) tag =
+    TextComponent txt fields (Dict.remove tag text_tags) components
 
 
 post_toggle_title : TextComponent -> Cmd msg
-post_toggle_title ((TextComponent text fields text_tags components) as text_component) =
+post_toggle_title ((TextComponent _ fields text_tags components) as text_component) =
     Text.Field.post_toggle_title (Text.Field.title fields)
 
 
 post_toggle_author : TextComponent -> Cmd msg
-post_toggle_author ((TextComponent text fields text_tags components) as text_component) =
+post_toggle_author ((TextComponent _ fields text_tags components) as text_component) =
     Text.Field.post_toggle_author (Text.Field.author fields)
 
 
 post_toggle_source : TextComponent -> Cmd msg
-post_toggle_source ((TextComponent text fields text_tags components) as text_component) =
+post_toggle_source ((TextComponent _ fields text_tags components) as text_component) =
     Text.Field.post_toggle_source (Text.Field.source fields)

--- a/web/src/Text/Encode.elm
+++ b/web/src/Text/Encode.elm
@@ -10,8 +10,8 @@ textEncoder text =
     let
         conclusion =
             case text.conclusion of
-                Just conclusion ->
-                    [ ( "conclusion", Encode.string conclusion ) ]
+                Just concln ->
+                    [ ( "conclusion", Encode.string concln ) ]
 
                 Nothing ->
                     []
@@ -24,14 +24,20 @@ textEncoder text =
         , ( "difficulty", Encode.string text.difficulty )
         , ( "text_sections", textSectionsEncoder text.sections )
         , ( "tags"
-          , Encode.list
-                (case text.tags of
+          , Encode.list Encode.string <|
+                case text.tags of
                     Just tags ->
-                        List.map (\tag -> Encode.string tag) tags
+                        tags
 
-                    _ ->
+                    Nothing ->
                         []
-                )
+            --   , Encode.list
+            --         (case text.tags of
+            --             Just tags ->
+            --                 List.map (\tag -> Encode.string tag) tags
+            --             _ ->
+            --                 []
+            --         )
           )
         ]
             ++ conclusion

--- a/web/src/Text/Field.elm
+++ b/web/src/Text/Field.elm
@@ -2,6 +2,7 @@ module Text.Field exposing
     ( TextAuthor(..)
     , TextConclusion(..)
     , TextDifficulty
+    , TextField(..)
     , TextFieldAttributes
     , TextFields
     , TextIntro(..)
@@ -36,6 +37,16 @@ module Text.Field exposing
 
 import Field
 import Ports exposing (addClassToCKEditor, ckEditor, selectAllInputText)
+
+
+type TextField
+    = Title TextTitle
+    | Intro TextIntro
+    | Tags TextTags
+    | Author TextAuthor
+    | Source TextSource
+    | Difficulty TextDifficulty
+    | Conclusion TextConclusion
 
 
 type alias TextFieldAttributes =

--- a/web/src/Text/Field.elm
+++ b/web/src/Text/Field.elm
@@ -1,13 +1,13 @@
 module Text.Field exposing
-    ( TextAuthor
-    , TextConclusion
+    ( TextAuthor(..)
+    , TextConclusion(..)
     , TextDifficulty
     , TextFieldAttributes
     , TextFields
-    , TextIntro
-    , TextSource
+    , TextIntro(..)
+    , TextSource(..)
     , TextTags
-    , TextTitle
+    , TextTitle(..)
     , author
     , conclusion
     , difficulty

--- a/web/src/Text/Section/Component.elm
+++ b/web/src/Text/Section/Component.elm
@@ -128,7 +128,7 @@ switch_editable text_field =
 
 
 update_errors : TextSectionComponent -> ( String, String ) -> TextSectionComponent
-update_errors ((TextSectionComponent text attr fields question_fields) as text_section) ( field_id, field_error ) =
+update_errors ((TextSectionComponent text attr fields questionFields) as textSection) ( field_id, field_error ) =
     {- error keys could be
           body
        || (question_i_answers)
@@ -145,20 +145,20 @@ update_errors ((TextSectionComponent text attr fields question_fields) as text_s
     case first_key of
         Just fst ->
             if List.member fst [ "body" ] then
-                case get_field text_section fst of
+                case get_field textSection fst of
                     Just field ->
-                        set_field text_section (update_field_error field field_error)
+                        set_field textSection (update_field_error field field_error)
 
                     Nothing ->
-                        text_section
+                        textSection
                 -- no matching field name
 
             else
                 -- update questions/answers errors
-                TextSectionComponent text attr fields (Question.Field.update_errors question_fields ( field_id, field_error ))
+                TextSectionComponent text attr fields (Question.Field.update_errors questionFields ( field_id, field_error ))
 
         _ ->
-            text_section
+            textSection
 
 
 
@@ -195,87 +195,87 @@ body_id text_section_component =
 
 
 body : TextSectionComponent -> TextSectionField
-body (TextSectionComponent text attr fields question_fields) =
+body (TextSectionComponent text attr fields _) =
     fields.body
 
 
 update_body : TextSectionComponent -> String -> TextSectionComponent
-update_body (TextSectionComponent text attr fields question_fields) body =
-    TextSectionComponent { text | body = body } attr fields question_fields
+update_body (TextSectionComponent text attr fields questionFields) bdy =
+    TextSectionComponent { text | body = bdy } attr fields questionFields
 
 
 text_section : TextSectionComponent -> TextSection
-text_section (TextSectionComponent text_section attr fields question_fields) =
-    text_section
+text_section (TextSectionComponent textSection attr fields _) =
+    textSection
 
 
 attributes : TextSectionComponent -> TextSectionComponentAttributes
-attributes (TextSectionComponent text attr fields question_fields) =
+attributes (TextSectionComponent text attr fields _) =
     attr
 
 
 index : TextSectionComponent -> Int
-index text_section =
+index textSection =
     let
         attrs =
-            attributes text_section
+            attributes textSection
     in
     attrs.index
 
 
 set_index : TextSectionComponent -> Int -> TextSectionComponent
-set_index (TextSectionComponent text attr fields question_fields) index =
+set_index (TextSectionComponent text attr fields questionFields) idx =
     let
         body_field =
             fields.body
 
         new_body_field =
-            { body_field | id = generate_text_section_field_id index "body" }
+            { body_field | id = generate_text_section_field_id idx "body" }
     in
     TextSectionComponent
-        { text | order = index }
-        { attr | index = index }
+        { text | order = idx }
+        { attr | index = idx }
         { fields | body = new_body_field }
-        question_fields
+        questionFields
 
 
 set_question : TextSectionComponent -> QuestionField -> TextSectionComponent
-set_question (TextSectionComponent text attr fields question_fields) question_field =
+set_question (TextSectionComponent text attr fields questionFields) question_field =
     let
         question_index =
             Question.Field.index question_field
     in
-    TextSectionComponent text attr fields (Array.set question_index question_field question_fields)
+    TextSectionComponent text attr fields (Array.set question_index question_field questionFields)
 
 
 set_answer : TextSectionComponent -> Answer.Field.AnswerField -> TextSectionComponent
-set_answer (TextSectionComponent text attr fields question_fields) answer_field =
-    TextSectionComponent text attr fields (Question.Field.set_answer_field question_fields answer_field)
+set_answer (TextSectionComponent text attr fields questionFields) answer_field =
+    TextSectionComponent text attr fields (Question.Field.set_answer_field questionFields answer_field)
 
 
 set_answer_text : TextSectionComponent -> Answer.Field.AnswerField -> String -> TextSectionComponent
-set_answer_text text_section answer_field answer_text =
-    set_answer text_section (Answer.Field.set_answer_text answer_field answer_text)
+set_answer_text textSection answer_field answer_text =
+    set_answer textSection (Answer.Field.set_answer_text answer_field answer_text)
 
 
 set_answer_correct : TextSectionComponent -> Answer.Field.AnswerField -> TextSectionComponent
-set_answer_correct text_section answer_field =
-    case Question.Field.question_field_for_answer (question_fields text_section) answer_field of
+set_answer_correct textSection answer_field =
+    case Question.Field.question_field_for_answer (question_fields textSection) answer_field of
         Just question_field ->
-            set_question text_section (Question.Field.set_answer_correct question_field answer_field)
+            set_question textSection (Question.Field.set_answer_correct question_field answer_field)
 
         _ ->
-            text_section
+            textSection
 
 
 set_answer_feedback : TextSectionComponent -> Answer.Field.AnswerField -> String -> TextSectionComponent
-set_answer_feedback text_section answer_field feedback =
-    case Question.Field.question_field_for_answer (question_fields text_section) answer_field of
+set_answer_feedback textSection answer_field feedback =
+    case Question.Field.question_field_for_answer (question_fields textSection) answer_field of
         Just question_field ->
-            set_question text_section (Question.Field.set_answer_feedback question_field answer_field feedback)
+            set_question textSection (Question.Field.set_answer_feedback question_field answer_field feedback)
 
         _ ->
-            text_section
+            textSection
 
 
 
@@ -325,13 +325,13 @@ delete_answer text_section_component answer_field =
 
 
 set_field_value : TextSectionComponent -> FieldName -> String -> TextSectionComponent
-set_field_value (TextSectionComponent text attr fields question_fields) field_name value =
+set_field_value (TextSectionComponent text attr fields questionFields) field_name value =
     case field_name of
         "body" ->
-            TextSectionComponent { text | body = value } attr fields question_fields
+            TextSectionComponent { text | body = value } attr fields questionFields
 
         _ ->
-            TextSectionComponent text attr fields question_fields
+            TextSectionComponent text attr fields questionFields
 
 
 update_field_error : TextSectionField -> String -> TextSectionField
@@ -340,7 +340,7 @@ update_field_error text_field error_string =
 
 
 get_field : TextSectionComponent -> FieldName -> Maybe TextSectionField
-get_field (TextSectionComponent text attr fields question_fields) field_name =
+get_field (TextSectionComponent text attr fields _) field_name =
     case field_name of
         "body" ->
             Just fields.body
@@ -350,42 +350,42 @@ get_field (TextSectionComponent text attr fields question_fields) field_name =
 
 
 set_field : TextSectionComponent -> TextSectionField -> TextSectionComponent
-set_field ((TextSectionComponent text attr fields question_fields) as text_section) new_text_field =
+set_field ((TextSectionComponent text attr fields questionFields) as textSection) new_text_field =
     case new_text_field.name of
         "body" ->
-            TextSectionComponent text attr { fields | body = new_text_field } question_fields
+            TextSectionComponent text attr { fields | body = new_text_field } questionFields
 
         _ ->
-            text_section
+            textSection
 
 
 question_fields : TextSectionComponent -> Array QuestionField
-question_fields (TextSectionComponent text attr fields question_fields) =
-    question_fields
+question_fields (TextSectionComponent text attr fields questionFields) =
+    questionFields
 
 
 update_question_field : TextSectionComponent -> QuestionField -> TextSectionComponent
-update_question_field (TextSectionComponent text attr fields question_fields) question_field =
-    TextSectionComponent text attr fields (Question.Field.update_question_field question_field question_fields)
+update_question_field (TextSectionComponent text attr fields questionFields) question_field =
+    TextSectionComponent text attr fields (Question.Field.update_question_field question_field questionFields)
 
 
 delete_question_field : TextSectionComponent -> QuestionField -> TextSectionComponent
-delete_question_field (TextSectionComponent text attr fields question_fields) question_field =
-    TextSectionComponent text attr fields (Question.Field.delete_question_field question_field question_fields)
+delete_question_field (TextSectionComponent text attr fields questionFields) question_field =
+    TextSectionComponent text attr fields (Question.Field.delete_question_field question_field questionFields)
 
 
 delete_selected_question_fields : TextSectionComponent -> TextSectionComponent
-delete_selected_question_fields (TextSectionComponent text attr fields question_fields) =
-    TextSectionComponent text attr fields (Question.Field.delete_selected question_fields)
+delete_selected_question_fields (TextSectionComponent text attr fields questionFields) =
+    TextSectionComponent text attr fields (Question.Field.delete_selected questionFields)
 
 
 add_new_question : TextSectionComponent -> TextSectionComponent
-add_new_question (TextSectionComponent text attr fields question_fields) =
-    TextSectionComponent text attr fields (Question.Field.add_new_question attr.index question_fields)
+add_new_question (TextSectionComponent text attr fields questionFields) =
+    TextSectionComponent text attr fields (Question.Field.add_new_question attr.index questionFields)
 
 
 toggle_question_menu : TextSectionComponent -> QuestionField -> TextSectionComponent
-toggle_question_menu text_section question_field =
+toggle_question_menu textSection question_field =
     let
         visible =
             if Question.Field.menu_visible question_field then
@@ -394,7 +394,7 @@ toggle_question_menu text_section question_field =
             else
                 True
     in
-    set_question text_section (Question.Field.set_menu_visible question_field visible)
+    set_question textSection (Question.Field.set_menu_visible question_field visible)
 
 
 toTextSection : TextSectionComponent -> TextSection

--- a/web/src/Text/Section/Component/Group.elm
+++ b/web/src/Text/Section/Component/Group.elm
@@ -39,16 +39,16 @@ update_error ( field_id, field_error ) text_section_components =
     case error_key of
         "textsection" :: index :: _ ->
             case String.toInt index of
-                Ok i ->
+                Just i ->
                     case Array.get i text_section_components of
-                        Just text_section_component ->
+                        Just textSectionComponent ->
                             let
                                 -- only pass the relevant part of the error key
                                 text_component_error =
                                     String.join "_" (List.drop 2 error_key)
 
                                 new_text_component_with_errors =
-                                    Text.Section.Component.update_errors text_section_component ( text_component_error, field_error )
+                                    Text.Section.Component.update_errors textSectionComponent ( text_component_error, field_error )
                             in
                             Array.set i new_text_component_with_errors text_section_components
 
@@ -56,7 +56,7 @@ update_error ( field_id, field_error ) text_section_components =
                             text_section_components
 
                 -- section doesn't exist in the group
-                _ ->
+                Nothing ->
                     text_section_components
 
         -- not a valid index string
@@ -95,13 +95,13 @@ add_new_text_section (TextSectionComponentGroup text_components) =
 
 
 delete_text_section : TextSectionComponentGroup -> TextSectionComponent -> TextSectionComponentGroup
-delete_text_section (TextSectionComponentGroup text_components) text_section_component =
+delete_text_section (TextSectionComponentGroup text_components) textSectionComponent =
     let
         index =
             Text.Section.Component.index
 
         component_index =
-            index text_section_component
+            index textSectionComponent
 
         new_sections =
             Array.indexedMap (\i text_component -> Text.Section.Component.set_index text_component i) <|

--- a/web/src/Text/Section/Encode.elm
+++ b/web/src/Text/Section/Encode.elm
@@ -16,6 +16,8 @@ textSectionEncoder text =
 
 textSectionsEncoder : Array TextSection -> Encode.Value
 textSectionsEncoder texts =
-    Encode.list <|
-        Array.toList <|
-            Array.map (\text -> textSectionEncoder text) texts
+    -- Encode.list <|
+    --     Array.toList <|
+    --         Array.map (\text -> textSectionEncoder text) texts
+    Encode.list textSectionEncoder <|
+        Array.toList texts

--- a/web/src/Text/Section/View.elm
+++ b/web/src/Text/Section/View.elm
@@ -106,7 +106,7 @@ view_text_section_component msg text_difficulties answer_feedback_limit text_sec
                , Question.View.view_question_buttons msg text_section_component
                , div [ class "cursor", onClick (msg <| DeleteTextSection text_section_component) ]
                     [ Html.img
-                        [ attribute "src" "/static/img/delete.svg"
+                        [ attribute "src" "/public/img/delete.svg"
                         , attribute "height" "18px"
                         , attribute "width" "18px"
                         ]

--- a/web/src/Text/Subscriptions.elm
+++ b/web/src/Text/Subscriptions.elm
@@ -1,6 +1,7 @@
 module Text.Subscriptions exposing (subscriptions)
 
 import Ports exposing (ckEditorUpdate)
+import Text.Component exposing (TextComponent)
 import Text.Update exposing (Msg)
 
 

--- a/web/src/Text/Tags/View.elm
+++ b/web/src/Text/Tags/View.elm
@@ -19,7 +19,7 @@ view_tag : (String -> msg) -> String -> Html msg
 view_tag delete_msg tag =
     div [ class "text_tag" ]
         [ Html.img
-            [ attribute "src" "/static/img/cancel.svg"
+            [ attribute "src" "/public/img/cancel.svg"
             , attribute "height" "13px"
             , attribute "width" "13px"
             , class "cursor"

--- a/web/src/Text/Translations.elm
+++ b/web/src/Text/Translations.elm
@@ -26,8 +26,10 @@ module Text.Translations exposing
     , textWordIdToInt
     )
 
+import Api.Config exposing (Config)
 import Dict exposing (Dict)
 import Flags
+import Session exposing (Session)
 import Set exposing (Set)
 
 
@@ -117,7 +119,9 @@ type MergeState
 
 
 type alias Flags =
-    { add_as_text_word_endpoint_url : String
+    { session : Session
+    , config : Config
+    , add_as_text_word_endpoint_url : String
     , merge_textword_endpoint_url : String
     , text_translation_match_endpoint : String
     , csrftoken : Flags.CSRFToken

--- a/web/src/Text/Translations/Model.elm
+++ b/web/src/Text/Translations/Model.elm
@@ -33,9 +33,11 @@ module Text.Translations.Model exposing
     , wordInstanceKey
     )
 
+import Api.Config exposing (Config)
 import Array exposing (Array)
 import Dict exposing (Dict)
 import OrderedDict exposing (OrderedDict)
+import Session exposing (Session)
 import Text.Model
 import Text.Translations
 import Text.Translations.TextWord
@@ -58,6 +60,8 @@ type alias Model =
     , text : Text.Model.Text
     , text_id : Int
     , new_translations : Dict String String
+    , session : Session
+    , config : Config
     , add_as_text_word_endpoint : Text.Translations.AddTextWordEndpoint
     , merge_textword_endpoint : Text.Translations.MergeTextWordEndpoint
     , text_translation_match_endpoint : Text.Translations.TextTranslationMatchEndpoint
@@ -78,6 +82,8 @@ init flags text_id text =
     , text_id = text_id
     , new_translations = Dict.empty
     , flags = flags
+    , session = flags.session
+    , config = flags.config
     , add_as_text_word_endpoint = Text.Translations.AddTextWordEndpoint (Text.Translations.URL flags.add_as_text_word_endpoint_url)
     , merge_textword_endpoint = Text.Translations.MergeTextWordEndpoint (Text.Translations.URL flags.merge_textword_endpoint_url)
     , text_translation_match_endpoint =

--- a/web/src/Text/Translations/Model.elm
+++ b/web/src/Text/Translations/Model.elm
@@ -14,6 +14,7 @@ module Text.Translations.Model exposing
     , inputGrammeme
     , instanceCount
     , isMergingWords
+    , isPartOfCompoundWord
     , mergeState
     , mergingWord
     , mergingWordInstances
@@ -29,6 +30,7 @@ module Text.Translations.Model exposing
     , uneditWord
     , updateTextTranslation
     , updateTranslationsForWord
+    , wordInstanceKey
     )
 
 import Array exposing (Array)

--- a/web/src/Text/Translations/Msg.elm
+++ b/web/src/Text/Translations/Msg.elm
@@ -23,7 +23,7 @@ type Msg
     | CloseEditWord WordInstance
     | DeleteTextWord TextWord
       -- translations
-    | MakeCorrectForContext Translation
+    | MakeCorrectForContext TextWord Translation
     | UpdateNewTranslationForTextWord TextWord String
     | SubmitNewTranslationForTextWord TextWord
     | DeleteTranslation TextWord Translation

--- a/web/src/Text/Translations/Update.elm
+++ b/web/src/Text/Translations/Update.elm
@@ -3,12 +3,13 @@ module Text.Translations.Update exposing
     , update
     )
 
-import Admin.Text
+-- import HttpHelpers
+
 import Array
 import Dict exposing (Dict)
 import Flags
 import Http
-import HttpHelpers
+import InstructorAdmin.Admin.Text as AdminText
 import Task
 import Text.Translations exposing (..)
 import Text.Translations.Decode
@@ -226,33 +227,33 @@ handleAddTextWords parentMsg _ result =
 
 attemptToAddTextWords : (Msg -> msg) -> Model -> Flags.CSRFToken -> List WordInstance -> Cmd msg
 attemptToAddTextWords parentMsg model csrftoken wordInstancesWithNoTextWord =
-    Task.attempt (handleAddTextWords parentMsg wordInstancesWithNoTextWord) <|
-        Task.sequence <|
-            List.map Http.toTask <|
-                List.map (addAsTextWordRequest model csrftoken) wordInstancesWithNoTextWord
+    -- Task.attempt (handleAddTextWords parentMsg wordInstancesWithNoTextWord) <|
+    --     Task.sequence <|
+    --         List.map Http.toTask <|
+    --             List.map (addAsTextWordRequest model csrftoken) wordInstancesWithNoTextWord
+    Debug.todo "attempt to add text words"
 
 
-addAsTextWordRequest : Model -> Flags.CSRFToken -> WordInstance -> Http.Request TextWord
-addAsTextWordRequest model csrftoken wordInstance =
-    let
-        endpointUri =
-            Text.Translations.addTextWordEndpointToString model.add_as_text_word_endpoint
 
-        headers =
-            [ Http.header "X-CSRFToken" csrftoken ]
-
-        encodedTextWord =
-            Text.Translations.Word.Instance.Encode.textWordAddEncoder model.text_id wordInstance
-
-        body =
-            Http.jsonBody encodedTextWord
-    in
-    HttpHelpers.post_with_headers endpointUri headers body Text.Translations.Decode.textWordInstanceDecoder
+-- addAsTextWordRequest : Model -> Flags.CSRFToken -> WordInstance -> Http.Request TextWord
+-- addAsTextWordRequest model csrftoken wordInstance =
+--     let
+--         endpointUri =
+--             Text.Translations.addTextWordEndpointToString model.add_as_text_word_endpoint
+--         headers =
+--             [ Http.header "X-CSRFToken" csrftoken ]
+--         encodedTextWord =
+--             Text.Translations.Word.Instance.Encode.textWordAddEncoder model.text_id wordInstance
+--         body =
+--             Http.jsonBody encodedTextWord
+--     in
+--     HttpHelpers.post_with_headers endpointUri headers body Text.Translations.Decode.textWordInstanceDecoder
 
 
 addAsTextWord : (Msg -> msg) -> Model -> Flags.CSRFToken -> WordInstance -> Cmd msg
 addAsTextWord parentMsg model csrftoken wordInstance =
-    Http.send (parentMsg << UpdatedTextWord) (addAsTextWordRequest model csrftoken wordInstance)
+    -- Http.send (parentMsg << UpdatedTextWord) (addAsTextWordRequest model csrftoken wordInstance)
+    Debug.todo "add as text word request"
 
 
 postMergeWords : (Msg -> msg) -> Model -> Flags.CSRFToken -> List WordInstance -> Cmd msg
@@ -273,10 +274,11 @@ postMergeWords parentMsg model csrftoken wordInstances =
         body =
             Http.jsonBody encodedTextWordIds
 
-        request =
-            HttpHelpers.post_with_headers endpointUrl headers body Text.Translations.Decode.textWordMergeDecoder
+        -- request =
+        -- HttpHelpers.post_with_headers endpointUrl headers body Text.Translations.Decode.textWordMergeDecoder
     in
-    Http.send (parentMsg << MergedWords) request
+    -- Http.send (parentMsg << MergedWords) request
+    Debug.todo "POST merge words"
 
 
 matchTranslations : (Msg -> msg) -> Model -> WordInstance -> Cmd msg
@@ -325,14 +327,15 @@ deleteTranslation msg csrftoken _ translation =
         body =
             Http.jsonBody encodedTranslation
 
-        request =
-            HttpHelpers.delete_with_headers
-                translation.endpoint
-                headers
-                body
-                Text.Translations.Decode.textTranslationRemoveRespDecoder
+        -- request =
+        --     HttpHelpers.delete_with_headers
+        --         translation.endpoint
+        --         headers
+        --         body
+        --         Text.Translations.Decode.textTranslationRemoveRespDecoder
     in
-    Http.send (msg << DeletedTranslation) request
+    -- Http.send (msg << DeletedTranslation) request
+    Debug.todo "DELETE translation"
 
 
 putMatchTranslations : (Msg -> msg) -> TextTranslationMatchEndpoint -> Flags.CSRFToken -> List Translation -> List TextWord -> Cmd msg
@@ -350,10 +353,11 @@ putMatchTranslations msg textTranslationApiMatchEndpoint csrftoken translations 
         body =
             Http.jsonBody encodedMergeRequest
 
-        request =
-            HttpHelpers.put_with_headers endpointUri headers body Text.Translations.Decode.textWordInstancesDecoder
+        -- request =
+        --     HttpHelpers.put_with_headers endpointUri headers body Text.Translations.Decode.textWordInstancesDecoder
     in
-    Http.send (msg << UpdatedTextWords) request
+    -- Http.send (msg << UpdatedTextWords) request
+    Debug.todo "PUT match transaltions"
 
 
 updateGrammemes : (Msg -> msg) -> Flags.CSRFToken -> WordInstance -> Dict String String -> Cmd msg
@@ -373,14 +377,15 @@ updateGrammemes msg csrftoken wordInstance grammemes =
                 body =
                     Http.jsonBody encodedGrammemes
 
-                request =
-                    HttpHelpers.put_with_headers
-                        textWordEndpoint
-                        headers
-                        body
-                        Text.Translations.Decode.textWordInstanceDecoder
+                -- request =
+                --     HttpHelpers.put_with_headers
+                --         textWordEndpoint
+                --         headers
+                --         body
+                --         Text.Translations.Decode.textWordInstanceDecoder
             in
-            Http.send (msg << UpdatedTextWord) request
+            -- Http.send (msg << UpdatedTextWord) request
+            Debug.todo "PUT update grammemes"
 
         -- no text word to update
         Nothing ->
@@ -402,10 +407,11 @@ postTranslation msg csrftoken textWord translationText correctForContext =
         body =
             Http.jsonBody encodedTranslation
 
-        request =
-            HttpHelpers.post_with_headers endpointUri headers body Text.Translations.Decode.textTranslationUpdateRespDecoder
+        -- request =
+        -- HttpHelpers.post_with_headers endpointUri headers body Text.Translations.Decode.textTranslationUpdateRespDecoder
     in
-    Http.send (msg << SubmittedTextTranslation) request
+    -- Http.send (msg << SubmittedTextTranslation) request
+    Debug.todo "POST translation"
 
 
 updateTranslationAsCorrect : (Msg -> msg) -> Flags.CSRFToken -> Translation -> Cmd msg
@@ -420,32 +426,34 @@ updateTranslationAsCorrect msg csrftoken translation =
         body =
             Http.jsonBody encodedTranslation
 
-        request =
-            HttpHelpers.put_with_headers
-                translation.endpoint
-                headers
-                body
-                Text.Translations.Decode.textTranslationUpdateRespDecoder
+        -- request =
+        --     HttpHelpers.put_with_headers
+        --         translation.endpoint
+        --         headers
+        --         body
+        --         Text.Translations.Decode.textTranslationUpdateRespDecoder
     in
-    Http.send (msg << UpdateTextTranslation) request
+    -- Http.send (msg << UpdateTextTranslation) request
+    Debug.todo "PUT translation as correct"
 
 
-retrieveTextWords : (Msg -> msg) -> Admin.Text.TextAPIEndpoint -> Maybe Int -> Cmd msg
+retrieveTextWords : (Msg -> msg) -> AdminText.TextAPIEndpoint -> Maybe Int -> Cmd msg
 retrieveTextWords msg textApiEndpoint textId =
     case textId of
         Just id ->
             let
                 textApiEndpointUrl =
-                    Admin.Text.textEndpointToString textApiEndpoint
+                    AdminText.textEndpointToString textApiEndpoint
 
-                request =
-                    Http.get
-                        (String.join "?"
-                            [ String.join "" [ textApiEndpointUrl, String.fromInt id, "/" ], "text_words=list" ]
-                        )
-                        Text.Translations.Decode.textWordDictInstancesDecoder
+                -- request =
+                --     Http.get
+                --         (String.join "?"
+                --             [ String.join "" [ textApiEndpointUrl, String.fromInt id, "/" ], "text_words=list" ]
+                --         )
+                --         Text.Translations.Decode.textWordDictInstancesDecoder
             in
-            Http.send (msg << UpdateTextTranslations) request
+            -- Http.send (msg << UpdateTextTranslations) request
+            Debug.todo "GET retrieve text words"
 
         Nothing ->
             Cmd.none

--- a/web/src/Text/Translations/View.elm
+++ b/web/src/Text/Translations/View.elm
@@ -5,7 +5,7 @@ import Dict
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import HtmlParser
+import Html.Parser as HtmlParser
 import OrderedDict
 import Set
 import Text.Section.Model
@@ -15,7 +15,10 @@ import Text.Translations.Model exposing (..)
 import Text.Translations.Msg exposing (..)
 import Text.Translations.TextWord exposing (TextWord)
 import Text.Translations.Word.Instance exposing (WordInstance)
-import VirtualDom
+
+
+
+-- import VirtualDom
 
 
 wordInstanceOnClick : Model -> (Msg -> msg) -> WordInstance -> Html.Attribute msg
@@ -42,7 +45,8 @@ tagWord model parentMsg sectionNumber instance originalToken =
             String.toLower originalToken
     in
     if token == " " then
-        VirtualDom.text token
+        -- VirtualDom.text token
+        Html.div [] []
 
     else
         let
@@ -70,7 +74,8 @@ tagWord model parentMsg sectionNumber instance originalToken =
                     ]
                 , wordInstanceOnClick model parentMsg wordInstance
                 ]
-                [ VirtualDom.text originalToken
+                -- [ VirtualDom.text originalToken
+                [ Html.div [] []
                 ]
             , view_edit model parentMsg wordInstance
             ]
@@ -83,11 +88,12 @@ tagSection model msg section =
             SectionNumber section.order
     in
     div [ id ("section-" ++ String.fromInt section.order), class "section" ]
-        (Text.Section.Words.Tag.tagWordsAndToVDOM
-            (tagWord model msg section.order)
-            (isPartOfCompoundWord model sectionNumber)
-            (HtmlParser.parse section.body)
-        )
+        -- (Text.Section.Words.Tag.tagWordsAndToVDOM
+        --     (tagWord model msg section.order)
+        --     (isPartOfCompoundWord model sectionNumber)
+        --     (HtmlParser.parse section.body)
+        -- )
+        []
 
 
 view_edit : Model -> (Msg -> msg) -> WordInstance -> Html msg
@@ -194,10 +200,11 @@ view_delete_text_word parentMsg wordInstance =
     in
     div [ class "text-word-option" ]
         (case textWord wordInstance of
-            Just textWord ->
+            -- Just textWord ->
+            Just word ->
                 [ div
                     [ attribute "title" "Delete this word instance from glossing."
-                    , onClick (parentMsg (DeleteTextWord textWord))
+                    , onClick (parentMsg (DeleteTextWord word))
                     ]
                     [ Html.text "Delete"
                     ]
@@ -390,7 +397,7 @@ view_add_grammemes model msg wordInstance =
             Text.Translations.Model.editingGrammemeValue model wordInstance
     in
     div [ class "add" ]
-        [ select [ onInput (SelectGrammemeForEditing wordinstance >> msg) ]
+        [ select [ onInput (SelectGrammemeForEditing wordInstance >> msg) ]
             (List.map (\grammeme -> option [ value grammeme ] [ Html.text grammeme ]) grammemeKeys)
         , div [ onInput (InputGrammeme wordInstance >> msg) ]
             [ Html.input [ placeholder "add/edit a grammeme..", value grammemeValue ] []

--- a/web/src/Text/Translations/View.elm
+++ b/web/src/Text/Translations/View.elm
@@ -294,7 +294,7 @@ view_text_word_translation msg textWord translation =
     div [ classList [ ( "translation", True ) ] ]
         [ div
             [ classList [ ( "editable", True ), ( "phrase", True ) ]
-            , onClick (msg (MakeCorrectForContext translation))
+            , onClick (msg (MakeCorrectForContext textWord translation))
             ]
             [ Html.text translation.text ]
         , div [ class "icons" ] <|

--- a/web/src/Text/Update.elm
+++ b/web/src/Text/Update.elm
@@ -48,7 +48,7 @@ update msg model =
         text_section_group =
             Text.Component.text_section_components model.text_component
 
-        update =
+        updt =
             Text.Section.Component.Group.update_components text_section_group
                 >> Text.Component.set_text_section_components model.text_component
     in
@@ -78,7 +78,7 @@ update msg model =
         UpdateTextValue text_component field_name input ->
             ( { model
                 | text_component =
-                    update
+                    updt
                         (Text.Section.Component.set_field_value text_component field_name input)
               }
             , Cmd.none
@@ -88,16 +88,16 @@ update msg model =
             case String.split "_" ckeditor_id of
                 [ "textsection", i, "body" ] ->
                     case String.toInt i of
-                        Ok i ->
+                        Just i_ ->
                             ( { model
                                 | text_component =
                                     Text.Component.set_text_section_components model.text_component
-                                        (Text.Section.Component.Group.update_body_for_section_index text_section_group i ckeditor_text)
+                                        (Text.Section.Component.Group.update_body_for_section_index text_section_group i_ ckeditor_text)
                               }
                             , Cmd.none
                             )
 
-                        _ ->
+                        Nothing ->
                             ( model, Cmd.none )
 
                 -- not a valid index
@@ -107,17 +107,17 @@ update msg model =
         -- not interested in this update
         -- question msgs
         AddQuestion text_component ->
-            ( { model | text_component = update (Text.Section.Component.add_new_question text_component) }, Cmd.none )
+            ( { model | text_component = updt (Text.Section.Component.add_new_question text_component) }, Cmd.none )
 
         UpdateQuestionField text_component question_field ->
-            ( { model | text_component = update (Text.Section.Component.update_question_field text_component question_field) }
+            ( { model | text_component = updt (Text.Section.Component.update_question_field text_component question_field) }
             , Cmd.none
             )
 
         UpdateQuestionFieldValue text_component question_field value ->
             ( { model
                 | text_component =
-                    update
+                    updt
                         (Text.Section.Component.update_question_field text_component
                             (Question.Field.set_question_body question_field value)
                         )
@@ -128,7 +128,7 @@ update msg model =
         DeleteQuestion text_component question_field ->
             ( { model
                 | text_component =
-                    update
+                    updt
                         (Text.Section.Component.delete_question_field text_component question_field)
               }
             , Cmd.none
@@ -141,7 +141,7 @@ update msg model =
             in
             ( { model
                 | text_component =
-                    update
+                    updt
                         (Text.Section.Component.update_question_field text_component new_question_field)
               }
             , Cmd.none
@@ -150,7 +150,7 @@ update msg model =
         DeleteSelectedQuestions text_component ->
             ( { model
                 | text_component =
-                    update
+                    updt
                         (Text.Section.Component.delete_selected_question_fields text_component)
               }
             , Cmd.none
@@ -159,7 +159,7 @@ update msg model =
         ToggleQuestionMenu text_component question_field ->
             ( { model
                 | text_component =
-                    update
+                    updt
                         (Text.Section.Component.toggle_question_menu text_component question_field)
               }
             , Cmd.none
@@ -167,17 +167,17 @@ update msg model =
 
         -- answer msgs
         UpdateAnswerField text_component answer_field ->
-            ( { model | text_component = update (Text.Section.Component.set_answer text_component answer_field) }, Cmd.none )
+            ( { model | text_component = updt (Text.Section.Component.set_answer text_component answer_field) }, Cmd.none )
 
         UpdateAnswerFieldValue text_component answer_field text ->
-            ( { model | text_component = update (Text.Section.Component.set_answer_text text_component answer_field text) }
+            ( { model | text_component = updt (Text.Section.Component.set_answer_text text_component answer_field text) }
             , Cmd.none
             )
 
         UpdateAnswerFeedbackValue text_component answer_field feedback ->
             ( { model
                 | text_component =
-                    update
+                    updt
                         (Text.Section.Component.set_answer_feedback text_component answer_field feedback)
               }
             , Cmd.none
@@ -186,7 +186,7 @@ update msg model =
         UpdateAnswerFieldCorrect text_component answer_field correct ->
             ( { model
                 | text_component =
-                    update
+                    updt
                         (Text.Section.Component.set_answer_correct text_component answer_field)
               }
             , Cmd.none
@@ -195,7 +195,7 @@ update msg model =
         AddAnswer text_section_component answer_field ->
             ( { model
                 | text_component =
-                    update
+                    updt
                         (Text.Section.Component.add_answer text_section_component answer_field)
               }
             , Cmd.none
@@ -204,7 +204,7 @@ update msg model =
         DeleteAnswer text_section_component answer_field ->
             ( { model
                 | text_component =
-                    update
+                    updt
                         (Text.Section.Component.delete_answer text_section_component answer_field)
               }
             , Cmd.none
@@ -223,16 +223,16 @@ update msg model =
 
                 new_text_component =
                     case field of
-                        Text field ->
-                            Text.Section.Component.set_field text_component (Text.Section.Component.switch_editable field)
+                        Text fld ->
+                            Text.Section.Component.set_field text_component (Text.Section.Component.switch_editable fld)
 
-                        Question field ->
-                            Text.Section.Component.set_question text_component (Question.Field.switch_editable field)
+                        Question fld ->
+                            Text.Section.Component.set_question text_component (Question.Field.switch_editable fld)
 
-                        Answer field ->
-                            Text.Section.Component.set_answer text_component (Answer.Field.switch_editable field)
+                        Answer fld ->
+                            Text.Section.Component.set_answer text_component (Answer.Field.switch_editable fld)
             in
-            ( { model | text_component = update new_text_component }, Cmd.batch <| extra_cmds ++ [ post_toggle_field field ] )
+            ( { model | text_component = updt new_text_component }, Cmd.batch <| extra_cmds ++ [ post_toggle_field field ] )
 
 
 post_toggle_field : Field -> Cmd msg
@@ -240,14 +240,14 @@ post_toggle_field field =
     let
         ( field_editable, field_id ) =
             case field of
-                Text field ->
-                    ( Text.Section.Component.editable field, Text.Section.Component.text_field_id field )
+                Text fld ->
+                    ( Text.Section.Component.editable fld, Text.Section.Component.text_field_id fld )
 
-                Question field ->
-                    ( Question.Field.editable field, Question.Field.id field )
+                Question fld ->
+                    ( Question.Field.editable fld, Question.Field.id fld )
 
-                Answer field ->
-                    ( Answer.Field.editable field, Answer.Field.id field )
+                Answer fld ->
+                    ( Answer.Field.editable fld, Answer.Field.id fld )
     in
     if not field_editable then
         selectAllInputText field_id

--- a/web/src/Text/View.elm
+++ b/web/src/Text/View.elm
@@ -1,18 +1,18 @@
 module Text.View exposing (view_text)
 
-import Date.Utils
 import Dict
 import Html exposing (..)
 import Html.Attributes exposing (attribute, class, classList)
 import Html.Events exposing (onBlur, onClick, onInput)
-import Instructor.Profile
+import InstructorAdmin.Text.Create exposing (..)
 import Text.Component
-import Text.Create exposing (..)
 import Text.Field exposing (TextAuthor, TextConclusion, TextDifficulty, TextIntro, TextSource, TextTags, TextTitle)
 import Text.Section.View
 import Text.Tags.View
 import Text.Translations.View
 import Text.Update
+import User.Instructor.Profile as InstructorProfile
+import Utils.Date
 
 
 view_text_date : TextViewParams -> Html Msg
@@ -24,7 +24,7 @@ view_text_date params =
                     Just last_modified_by ->
                         [ span []
                             [ Html.text
-                                ("Last Modified by " ++ last_modified_by ++ " on " ++ Date.Utils.monthDayYearFormat modified_dt)
+                                ("Last Modified by " ++ last_modified_by ++ " on " ++ Utils.Date.monthDayYearFormat modified_dt)
                             ]
                         ]
 
@@ -40,7 +40,7 @@ view_text_date params =
                             Just created_by ->
                                 [ span []
                                     [ Html.text
-                                        ("Created by " ++ created_by ++ " on " ++ Date.Utils.monthDayYearFormat created_dt)
+                                        ("Created by " ++ created_by ++ " on " ++ Utils.Date.monthDayYearFormat created_dt)
                                     ]
                                 ]
 
@@ -215,7 +215,7 @@ view_text_lock params =
             view_edit_text_lock params
 
         ReadOnlyMode write_locker ->
-            if write_locker == Instructor.Profile.usernameToString (Instructor.Profile.username params.profile) then
+            if write_locker == InstructorProfile.usernameToString (InstructorProfile.username params.profile) then
                 view_edit_text_lock params
 
             else
@@ -226,7 +226,7 @@ view_text_lock params =
 
 
 view_author : TextViewParams -> (TextViewParams -> TextAuthor -> Html Msg) -> TextAuthor -> Html Msg
-view_author params edit_author text_author =
+view_author params editAuthor text_author =
     let
         text_author_attrs =
             Text.Field.text_author_attrs text_author
@@ -234,7 +234,7 @@ view_author params edit_author text_author =
     div [ attribute "id" "text_author_view", attribute "class" "text_property" ] <|
         [ div [] [ Html.text "Text Author" ]
         , if text_author_attrs.editable then
-            div [] [ edit_author params text_author ]
+            div [] [ editAuthor params text_author ]
 
           else
             div

--- a/web/src/Text/View.elm
+++ b/web/src/Text/View.elm
@@ -4,18 +4,29 @@ import Dict
 import Html exposing (..)
 import Html.Attributes exposing (attribute, class, classList)
 import Html.Events exposing (onBlur, onClick, onInput)
-import InstructorAdmin.Text.Create exposing (..)
 import Text.Component
-import Text.Field exposing (TextAuthor, TextConclusion, TextDifficulty, TextIntro, TextSource, TextTags, TextTitle)
+import Text.Field
+    exposing
+        ( TextAuthor
+        , TextConclusion
+        , TextDifficulty
+        , TextField(..)
+        , TextIntro
+        , TextSource
+        , TextTags
+        , TextTitle
+        )
 import Text.Section.View
 import Text.Tags.View
+import Text.Translations.Msg as TranslationsMsg
 import Text.Translations.View
 import Text.Update
+import TextEdit exposing (Mode(..), Tab(..), TextViewParams)
 import User.Instructor.Profile as InstructorProfile
 import Utils.Date
 
 
-view_text_date : TextViewParams -> Html Msg
+view_text_date : TextViewParams -> Html msg
 view_text_date params =
     div [ attribute "class" "text_dates" ] <|
         (case params.text.modified_dt of
@@ -52,21 +63,43 @@ view_text_date params =
                )
 
 
-view_text_title : TextViewParams -> (TextViewParams -> TextTitle -> Html Msg) -> TextTitle -> Html Msg
-view_text_title params edit_view text_title =
+view_text_title :
+    TextViewParams
+    ->
+        { onToggleEditable : TextField -> Bool -> msg
+        , onUpdateTextAttributes : String -> String -> msg
+        }
+    ->
+        (TextViewParams
+         ->
+            { onToggleEditable : TextField -> Bool -> msg
+            , onUpdateTextAttributes : String -> String -> msg
+            }
+         -> TextTitle
+         -> Html msg
+        )
+    -> TextTitle
+    -> Html msg
+view_text_title params messages edit_view text_title =
     let
         text_title_attrs =
             Text.Field.text_title_attrs text_title
     in
     div
-        [ onClick (ToggleEditable (Title text_title) True)
+        -- [ onClick (ToggleEditable (Title text_title) True)
+        [ onClick (messages.onToggleEditable (Title text_title) True)
         , attribute "id" text_title_attrs.id
         , classList [ ( "input_error", text_title_attrs.error ) ]
         ]
     <|
         [ div [] [ Html.text "Text Title" ]
         , if text_title_attrs.editable then
-            div [] [ edit_view params text_title ]
+            div []
+                [ edit_view
+                    params
+                    messages
+                    text_title
+                ]
 
           else
             div [ attribute "class" "editable" ] <|
@@ -80,8 +113,15 @@ view_text_title params edit_view text_title =
                )
 
 
-edit_text_title : TextViewParams -> TextTitle -> Html Msg
-edit_text_title params text_title =
+edit_text_title :
+    TextViewParams
+    ->
+        { onToggleEditable : TextField -> Bool -> msg
+        , onUpdateTextAttributes : String -> String -> msg
+        }
+    -> TextTitle
+    -> Html msg
+edit_text_title params messages text_title =
     let
         text_title_attrs =
             Text.Field.text_title_attrs text_title
@@ -90,14 +130,22 @@ edit_text_title params text_title =
         [ attribute "id" text_title_attrs.input_id
         , attribute "type" "text"
         , attribute "value" params.text.title
-        , onInput (UpdateTextAttributes "title")
-        , onBlur (ToggleEditable (Title text_title) False)
+
+        -- , onInput (UpdateTextAttributes "title")
+        , onInput (messages.onUpdateTextAttributes "title")
+
+        -- , onBlur (ToggleEditable (Title text_title) False)
+        , onBlur (messages.onToggleEditable (Title text_title) False)
         ]
         []
 
 
-view_text_conclusion : TextViewParams -> TextConclusion -> Html Msg
-view_text_conclusion params text_conclusion =
+view_text_conclusion :
+    TextViewParams
+    -> (String -> String -> msg)
+    -> TextConclusion
+    -> Html msg
+view_text_conclusion params onUpdateTextAttributes text_conclusion =
     let
         text_conclusion_attrs =
             Text.Field.text_conclusion_attrs text_conclusion
@@ -112,7 +160,9 @@ view_text_conclusion params text_conclusion =
             [ textarea
                 [ attribute "id" text_conclusion_attrs.input_id
                 , classList [ ( "text_conclusion", True ), ( "input_error", text_conclusion_attrs.error ) ]
-                , onInput (UpdateTextAttributes "conclusion")
+
+                -- , onInput (UpdateTextAttributes "conclusion")
+                , onInput (onUpdateTextAttributes "conclusion")
                 ]
                 [ Html.text (Maybe.withDefault "" params.text.conclusion) ]
             ]
@@ -125,8 +175,18 @@ view_text_conclusion params text_conclusion =
                )
 
 
-view_text_introduction : TextViewParams -> (TextViewParams -> TextIntro -> Html Msg) -> TextIntro -> Html Msg
-view_text_introduction params edit_view text_intro =
+view_text_introduction :
+    TextViewParams
+    -> (String -> String -> msg)
+    ->
+        (TextViewParams
+         -> (String -> String -> msg)
+         -> TextIntro
+         -> Html msg
+        )
+    -> TextIntro
+    -> Html msg
+view_text_introduction params onUpdateTextAttributes edit_view text_intro =
     let
         text_intro_attrs =
             Text.Field.text_intro_attrs text_intro
@@ -137,7 +197,10 @@ view_text_introduction params edit_view text_intro =
         ]
     <|
         [ div [] [ Html.text "Text Introduction" ]
-        , edit_view params text_intro
+        , edit_view
+            params
+            onUpdateTextAttributes
+            text_intro
         ]
             ++ (if text_intro_attrs.error then
                     [ div [ class "error" ] [ Html.text text_intro_attrs.error_string ] ]
@@ -147,8 +210,12 @@ view_text_introduction params edit_view text_intro =
                )
 
 
-edit_text_introduction : TextViewParams -> TextIntro -> Html Msg
-edit_text_introduction params text_intro =
+edit_text_introduction :
+    TextViewParams
+    -> (String -> String -> msg)
+    -> TextIntro
+    -> Html msg
+edit_text_introduction params onUpdateTextAttributes text_intro =
     let
         text_intro_attrs =
             Text.Field.text_intro_attrs text_intro
@@ -157,14 +224,21 @@ edit_text_introduction params text_intro =
         [ textarea
             [ attribute "id" text_intro_attrs.input_id
             , classList [ ( "text_introduction", True ), ( "input_error", text_intro_attrs.error ) ]
-            , onInput (UpdateTextAttributes "introduction")
+
+            -- , onInput (UpdateTextAttributes "introduction")
+            , onInput (onUpdateTextAttributes "introduction")
             ]
             [ Html.text params.text.introduction ]
         ]
 
 
-view_edit_text_tags : TextViewParams -> TextTags -> Html Msg
-view_edit_text_tags params text_tags =
+view_edit_text_tags :
+    TextViewParams
+    -> (String -> String -> msg)
+    -> (String -> msg)
+    -> TextTags
+    -> Html msg
+view_edit_text_tags params onAddTagInput onDeleteTag text_tags =
     let
         tags =
             Text.Component.tags params.text_component
@@ -175,11 +249,15 @@ view_edit_text_tags params text_tags =
         tag_attrs =
             Text.Field.text_tags_attrs text_tags
     in
-    Text.Tags.View.view_tags "add_tag" tag_list tags ( onInput (AddTagInput "add_tag"), DeleteTag ) tag_attrs
+    -- Text.Tags.View.view_tags "add_tag" tag_list tags ( onInput (AddTagInput "add_tag"), DeleteTag ) tag_attrs
+    Text.Tags.View.view_tags "add_tag" tag_list tags ( onInput (onAddTagInput "add_tag"), onDeleteTag ) tag_attrs
 
 
-view_edit_text_lock : TextViewParams -> Html Msg
-view_edit_text_lock params =
+view_edit_text_lock :
+    TextViewParams
+    -> msg
+    -> Html msg
+view_edit_text_lock params onToggleLock =
     let
         write_locked =
             params.write_locked
@@ -193,7 +271,14 @@ view_edit_text_lock params =
                 else
                     "Text Unlocked"
             ]
-        , div [ attribute "id" "lock_box", classList [ ( "dimgray_bg", write_locked ) ], onClick ToggleLock ]
+        , div
+            [ attribute "id" "lock_box"
+            , classList
+                [ ( "dimgray_bg", write_locked ) ]
+
+            -- , onClick ToggleLock
+            , onClick onToggleLock
+            ]
             [ div
                 [ attribute "id"
                     (if write_locked then
@@ -208,15 +293,18 @@ view_edit_text_lock params =
         ]
 
 
-view_text_lock : TextViewParams -> Html Msg
-view_text_lock params =
+view_text_lock :
+    TextViewParams
+    -> msg
+    -> Html msg
+view_text_lock params onToggleLock =
     case params.mode of
         EditMode ->
-            view_edit_text_lock params
+            view_edit_text_lock params onToggleLock
 
         ReadOnlyMode write_locker ->
             if write_locker == InstructorProfile.usernameToString (InstructorProfile.username params.profile) then
-                view_edit_text_lock params
+                view_edit_text_lock params onToggleLock
 
             else
                 div [] []
@@ -225,8 +313,24 @@ view_text_lock params =
             div [] []
 
 
-view_author : TextViewParams -> (TextViewParams -> TextAuthor -> Html Msg) -> TextAuthor -> Html Msg
-view_author params editAuthor text_author =
+view_author :
+    TextViewParams
+    ->
+        { onToggleEditable : TextField -> Bool -> msg
+        , onUpdateTextAttributes : String -> String -> msg
+        }
+    ->
+        (TextViewParams
+         ->
+            { onToggleEditable : TextField -> Bool -> msg
+            , onUpdateTextAttributes : String -> String -> msg
+            }
+         -> TextAuthor
+         -> Html msg
+        )
+    -> TextAuthor
+    -> Html msg
+view_author params messages editAuthor text_author =
     let
         text_author_attrs =
             Text.Field.text_author_attrs text_author
@@ -234,13 +338,15 @@ view_author params editAuthor text_author =
     div [ attribute "id" "text_author_view", attribute "class" "text_property" ] <|
         [ div [] [ Html.text "Text Author" ]
         , if text_author_attrs.editable then
-            div [] [ editAuthor params text_author ]
+            div [] [ editAuthor params messages text_author ]
 
           else
             div
                 [ attribute "id" text_author_attrs.id
                 , attribute "class" "editable"
-                , onClick (ToggleEditable (Author text_author) True)
+
+                -- , onClick (ToggleEditable (Author text_author) True)
+                , onClick (messages.onToggleEditable (Author text_author) True)
                 ]
                 [ div [] [ Html.text params.text.author ]
                 ]
@@ -253,8 +359,15 @@ view_author params editAuthor text_author =
                )
 
 
-edit_author : TextViewParams -> TextAuthor -> Html Msg
-edit_author params text_author =
+edit_author :
+    TextViewParams
+    ->
+        { onToggleEditable : TextField -> Bool -> msg
+        , onUpdateTextAttributes : String -> String -> msg
+        }
+    -> TextAuthor
+    -> Html msg
+edit_author params messages text_author =
     let
         text_author_attrs =
             Text.Field.text_author_attrs text_author
@@ -264,18 +377,27 @@ edit_author params text_author =
         , attribute "value" params.text.author
         , attribute "id" text_author_attrs.input_id
         , classList [ ( "input_error", text_author_attrs.error ) ]
-        , onInput (UpdateTextAttributes "author")
-        , onBlur (ToggleEditable (Author text_author) False)
+
+        -- , onInput (UpdateTextAttributes "author")
+        , onInput (messages.onUpdateTextAttributes "author")
+
+        -- , onBlur (ToggleEditable (Author text_author) False)
+        , onBlur (messages.onToggleEditable (Author text_author) False)
         ]
         [ Html.text params.text.author ]
 
 
-edit_difficulty : TextViewParams -> TextDifficulty -> Html Msg
-edit_difficulty params text_difficulty =
+edit_difficulty :
+    TextViewParams
+    -> (String -> String -> msg)
+    -> TextDifficulty
+    -> Html msg
+edit_difficulty params onUpdateTextAttributes text_difficulty =
     div [ attribute "class" "text_property" ]
         [ div [] [ Html.text "Text Difficulty" ]
         , Html.select
-            [ onInput (UpdateTextAttributes "difficulty")
+            -- [ onInput (UpdateTextAttributes "difficulty")
+            [ onInput (onUpdateTextAttributes "difficulty")
             ]
             [ Html.optgroup []
                 (List.map
@@ -297,18 +419,40 @@ edit_difficulty params text_difficulty =
         ]
 
 
-view_source : TextViewParams -> (TextViewParams -> TextSource -> Html Msg) -> TextSource -> Html Msg
-view_source params edit_view text_source =
+view_source :
+    TextViewParams
+    ->
+        { onToggleEditable : TextField -> Bool -> msg
+        , onUpdateTextAttributes : String -> String -> msg
+        }
+    ->
+        (TextViewParams
+         ->
+            { onToggleEditable : TextField -> Bool -> msg
+            , onUpdateTextAttributes : String -> String -> msg
+            }
+         -> TextSource
+         -> Html msg
+        )
+    -> TextSource
+    -> Html msg
+view_source params messages edit_view text_source =
     let
         text_source_attrs =
             Text.Field.text_source_attrs text_source
     in
     if text_source_attrs.editable then
-        edit_view params text_source
+        edit_view
+            params
+            { onToggleEditable = messages.onToggleEditable
+            , onUpdateTextAttributes = messages.onUpdateTextAttributes
+            }
+            text_source
 
     else
         div
-            [ onClick (ToggleEditable (Source text_source) True)
+            -- [ onClick (ToggleEditable (Source text_source) True)
+            [ onClick (messages.onToggleEditable (Source text_source) True)
             , classList [ ( "text_property", True ), ( "input_error", text_source_attrs.error ) ]
             ]
         <|
@@ -323,8 +467,15 @@ view_source params edit_view text_source =
                    )
 
 
-edit_source : TextViewParams -> TextSource -> Html Msg
-edit_source params text_source =
+edit_source :
+    TextViewParams
+    ->
+        { onToggleEditable : TextField -> Bool -> msg
+        , onUpdateTextAttributes : String -> String -> msg
+        }
+    -> TextSource
+    -> Html msg
+edit_source params messages text_source =
     let
         text_source_attrs =
             Text.Field.text_source_attrs text_source
@@ -337,56 +488,110 @@ edit_source params text_source =
             [ attribute "id" text_source_attrs.input_id
             , attribute "type" "text"
             , attribute "value" params.text.source
-            , onInput (UpdateTextAttributes "source")
-            , onBlur (ToggleEditable (Source text_source) False)
+
+            -- , onInput (UpdateTextAttributes "source")
+            , onInput (messages.onUpdateTextAttributes "source")
+
+            -- , onBlur (ToggleEditable (Source text_source) False)
+            , onBlur (messages.onToggleEditable (Source text_source) False)
             ]
             []
         ]
 
 
-view_text_attributes : TextViewParams -> Html Msg
-view_text_attributes params =
+view_text_attributes :
+    TextViewParams
+    ->
+        { onToggleEditable : TextField -> Bool -> msg
+        , onUpdateTextAttributes : String -> String -> msg
+        , onToggleLock : msg
+        , onAddTagInput : String -> String -> msg
+        , onDeleteTag : String -> msg
+        }
+    -> Html msg
+view_text_attributes params messages =
     div [ attribute "id" "text_attributes" ]
-        [ view_text_title params edit_text_title (Text.Field.title params.text_fields)
-        , view_text_introduction params edit_text_introduction (Text.Field.intro params.text_fields)
-        , view_author params edit_author (Text.Field.author params.text_fields)
-        , edit_difficulty params (Text.Field.difficulty params.text_fields)
-        , view_source params edit_source (Text.Field.source params.text_fields)
-        , view_text_lock params
+        [ view_text_title
+            params
+            { onToggleEditable = messages.onToggleEditable
+            , onUpdateTextAttributes = messages.onUpdateTextAttributes
+            }
+            edit_text_title
+            (Text.Field.title params.text_fields)
+        , view_text_introduction
+            params
+            messages.onUpdateTextAttributes
+            edit_text_introduction
+            (Text.Field.intro params.text_fields)
+        , view_author
+            params
+            { onToggleEditable = messages.onToggleEditable
+            , onUpdateTextAttributes = messages.onUpdateTextAttributes
+            }
+            edit_author
+            (Text.Field.author params.text_fields)
+        , edit_difficulty
+            params
+            messages.onUpdateTextAttributes
+            (Text.Field.difficulty params.text_fields)
+        , view_source params
+            { onToggleEditable = messages.onToggleEditable
+            , onUpdateTextAttributes = messages.onUpdateTextAttributes
+            }
+            edit_source
+            (Text.Field.source params.text_fields)
+        , view_text_lock params messages.onToggleLock
         , view_text_date params
-        , view_text_conclusion params (Text.Field.conclusion params.text_fields)
+        , view_text_conclusion
+            params
+            messages.onUpdateTextAttributes
+            (Text.Field.conclusion params.text_fields)
         , div [ classList [ ( "text_property", True ) ] ]
             [ div [] [ Html.text "Text Tags" ]
-            , view_edit_text_tags params (Text.Field.tags params.text_fields)
+            , view_edit_text_tags
+                params
+                messages.onAddTagInput
+                messages.onDeleteTag
+                (Text.Field.tags params.text_fields)
             ]
         ]
 
 
-view_submit : Html Msg
-view_submit =
+view_submit :
+    { onTextComponentMsg : Text.Update.Msg -> msg
+    , onDeleteText : msg
+    , onSubmitText : msg
+    }
+    -> Html msg
+view_submit messages =
     div [ classList [ ( "submit_section", True ) ] ]
-        [ div [ attribute "class" "submit", onClick (TextComponentMsg Text.Update.AddTextSection) ]
+        -- [ div [ attribute "class" "submit", onClick (TextComponentMsg Text.Update.AddTextSection) ]
+        [ div [ attribute "class" "submit", onClick (messages.onTextComponentMsg Text.Update.AddTextSection) ]
             [ Html.img
-                [ attribute "src" "/static/img/add_text_section.svg"
+                [ attribute "src" "/public/img/add_text_section.svg"
                 , attribute "height" "20px"
                 , attribute "width" "20px"
                 ]
                 []
             , Html.text "Add Text Section"
             ]
-        , div [ attribute "class" "submit", onClick DeleteText ]
+
+        -- , div [ attribute "class" "submit", onClick DeleteText ]
+        , div [ attribute "class" "submit", onClick messages.onDeleteText ]
             [ Html.text "Delete Text"
             , Html.img
-                [ attribute "src" "/static/img/delete.svg"
+                [ attribute "src" "/public/img/delete.svg"
                 , attribute "height" "18px"
                 , attribute "width" "18px"
                 ]
                 []
             ]
         , div [] []
-        , div [ attribute "class" "submit", onClick SubmitText ]
+
+        -- , div [ attribute "class" "submit", onClick SubmitText ]
+        , div [ attribute "class" "submit", onClick messages.onSubmitText ]
             [ Html.img
-                [ attribute "src" "/static/img/save_disk.svg"
+                [ attribute "src" "/public/img/save_disk.svg"
                 , attribute "height" "20px"
                 , attribute "width" "20px"
                 ]
@@ -396,23 +601,50 @@ view_submit =
         ]
 
 
-view_tab_menu : TextViewParams -> Html Msg
-view_tab_menu params =
+view_tab_menu :
+    TextViewParams
+    -> (Tab -> msg)
+    -> Html msg
+view_tab_menu params onToggleTab =
     div [ attribute "id" "tabs_menu" ]
-        [ div [ classList [ ( "selected", params.selected_tab == TextTab ) ], onClick (ToggleTab TextTab) ]
+        -- [ div [ classList [ ( "selected", params.selected_tab == TextTab ) ], onClick (ToggleTab TextTab) ]
+        [ div [ classList [ ( "selected", params.selected_tab == TextTab ) ], onClick (onToggleTab TextTab) ]
             [ Html.text "Text"
             ]
-        , div [ classList [ ( "selected", params.selected_tab == TranslationsTab ) ], onClick (ToggleTab TranslationsTab) ]
+
+        -- , div [ classList [ ( "selected", params.selected_tab == TranslationsTab ) ], onClick (ToggleTab TranslationsTab) ]
+        , div [ classList [ ( "selected", params.selected_tab == TranslationsTab ) ], onClick (onToggleTab TranslationsTab) ]
             [ Html.text "Translations"
             ]
         ]
 
 
-view_text_tab : TextViewParams -> Int -> Html Msg
-view_text_tab params answer_feedback_limit =
+view_text_tab :
+    TextViewParams
+    ->
+        { onToggleEditable : TextField -> Bool -> msg
+        , onTextComponentMsg : Text.Update.Msg -> msg
+        , onDeleteText : msg
+        , onSubmitText : msg
+        , onUpdateTextAttributes : String -> String -> msg
+        , onToggleLock : msg
+        , onAddTagInput : String -> String -> msg
+        , onDeleteTag : String -> msg
+        }
+    -> Int
+    -> Html msg
+view_text_tab params messages answer_feedback_limit =
     div [ attribute "id" "text" ] <|
         [ view_text_attributes params
-        , Text.Section.View.view_text_section_components TextComponentMsg
+            { onToggleEditable = messages.onToggleEditable
+            , onUpdateTextAttributes = messages.onUpdateTextAttributes
+            , onToggleLock = messages.onToggleLock
+            , onAddTagInput = messages.onAddTagInput
+            , onDeleteTag = messages.onDeleteTag
+            }
+
+        -- , Text.Section.View.view_text_section_components TextComponentMsg
+        , Text.Section.View.view_text_section_components messages.onTextComponentMsg
             (Text.Component.text_section_components params.text_component)
             answer_feedback_limit
             params.text_difficulties
@@ -422,30 +654,83 @@ view_text_tab params answer_feedback_limit =
                         []
 
                     _ ->
-                        [ view_submit ]
+                        [ view_submit
+                            { onTextComponentMsg = messages.onTextComponentMsg
+                            , onDeleteText = messages.onDeleteText
+                            , onSubmitText = messages.onSubmitText
+                            }
+                        ]
                )
 
 
-view_translations_tab : TextViewParams -> Html Msg
-view_translations_tab params =
-    Text.Translations.View.view_translations params.text_translation_msg params.text_translations_model
+view_translations_tab :
+    TextViewParams
+    -> (TranslationsMsg.Msg -> msg)
+    -> Html msg
+view_translations_tab params onTextTranslationMsg =
+    Text.Translations.View.view_translations
+        -- params.text_translation_msg
+        onTextTranslationMsg
+        params.text_translations_model
 
 
-view_tab_contents : TextViewParams -> Int -> Html Msg
-view_tab_contents params answer_feedback_limit =
+view_tab_contents :
+    TextViewParams
+    ->
+        { onToggleEditable : TextField -> Bool -> msg
+        , onTextComponentMsg : Text.Update.Msg -> msg
+        , onDeleteText : msg
+        , onSubmitText : msg
+        , onUpdateTextAttributes : String -> String -> msg
+        , onToggleLock : msg
+        , onAddTagInput : String -> String -> msg
+        , onDeleteTag : String -> msg
+        }
+    -> (TranslationsMsg.Msg -> msg)
+    -> Int
+    -> Html msg
+view_tab_contents params messages onTextTranslationMsg answer_feedback_limit =
     case params.selected_tab of
         TextTab ->
-            view_text_tab params answer_feedback_limit
+            view_text_tab params messages answer_feedback_limit
 
         TranslationsTab ->
-            view_translations_tab params
+            -- view_translations_tab params
+            view_translations_tab params onTextTranslationMsg
 
 
-view_text : TextViewParams -> Int -> Html Msg
-view_text params answer_feedback_limit =
+view_text :
+    TextViewParams
+    ->
+        { onToggleEditable : TextField -> Bool -> msg
+        , onTextComponentMsg : Text.Update.Msg -> msg
+        , onDeleteText : msg
+        , onSubmitText : msg
+        , onUpdateTextAttributes : String -> String -> msg
+        , onToggleTab : Tab -> msg
+        , onToggleLock : msg
+        , onAddTagInput : String -> String -> msg
+        , onDeleteTag : String -> msg
+        , onTextTranslationMsg : TranslationsMsg.Msg -> msg
+        }
+    -> Int
+    -> Html msg
+view_text params messages answer_feedback_limit =
     div [ attribute "id" "tabs" ]
-        [ view_tab_menu params
+        -- [ view_tab_menu params
+        [ view_tab_menu params messages.onToggleTab
         , div [ attribute "id" "tabs_contents" ]
-            [ view_tab_contents params answer_feedback_limit
+            [ view_tab_contents params
+                { onToggleEditable = messages.onToggleEditable
+                , onTextComponentMsg = messages.onTextComponentMsg
+                , onDeleteText = messages.onDeleteText
+                , onSubmitText = messages.onSubmitText
+                , onUpdateTextAttributes = messages.onUpdateTextAttributes
+                , onToggleLock = messages.onToggleLock
+                , onAddTagInput = messages.onAddTagInput
+                , onDeleteTag = messages.onDeleteTag
+                }
+                messages.onTextTranslationMsg
+                answer_feedback_limit
             ]
         ]

--- a/web/src/TextEdit.elm
+++ b/web/src/TextEdit.elm
@@ -1,0 +1,50 @@
+module TextEdit exposing (Mode(..), Tab(..), TextViewParams)
+
+import Dict exposing (Dict)
+import Text.Component exposing (TextComponent)
+import Text.Field
+    exposing
+        ( TextField(..)
+        )
+import Text.Model
+import Text.Translations.Model as TranslationsModel
+import User.Instructor.Profile exposing (InstructorProfile)
+
+
+{-| Params passed to a editable text from the create or edit text page
+-}
+type alias TextViewParams =
+    { text : Text.Model.Text
+    , text_component : TextComponent
+    , text_fields : Text.Field.TextFields
+    , profile : InstructorProfile
+    , tags : Dict String String
+    , selected_tab : Tab
+    , write_locked : WriteLocked
+    , mode : Mode
+    , text_difficulties : List Text.Model.TextDifficulty
+    , text_translations_model : Maybe TranslationsModel.Model
+    }
+
+
+type alias WriteLocked =
+    Bool
+
+
+{-| Editing mode
+-}
+type Mode
+    = EditMode
+    | CreateMode
+    | ReadOnlyMode InstructorUser
+
+
+type alias InstructorUser =
+    String
+
+
+{-| Tab selected in create or edit text page
+-}
+type Tab
+    = TextTab
+    | TranslationsTab

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -24,5 +24,6 @@
     <link rel="stylesheet" href="../public/css/text.css">
     <link rel="stylesheet" href="../public/css/text_search.css">
     <link rel="stylesheet" href="../public/css/create_text.css">
+    <script src="https://cdn.ckeditor.com/4.15.0/standard/ckeditor.js"></script>
   </body>
 </html>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -23,5 +23,6 @@
     <link rel="stylesheet" href="../public/css/user_reset_pass.css">
     <link rel="stylesheet" href="../public/css/text.css">
     <link rel="stylesheet" href="../public/css/text_search.css">
+    <link rel="stylesheet" href="../public/css/create_text.css">
   </body>
 </html>

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -139,3 +139,91 @@ app.ports.sendSocketCommand.subscribe(config => {
   console.log(config);
   sendSocketCommand(config);
 });
+
+// INPUTS
+
+app.ports.clearInputText.subscribe(id => {
+  // wrap call in requestAnimationFrame to ensure that Elm has time to finish refreshing the view
+  window.requestAnimationFrame(() => {
+    const input = document.getElementById(id) as HTMLInputElement;
+
+    if (input) {
+      input.value = '';
+    }
+  });
+});
+
+app.ports.selectAllInputText.subscribe(id => {
+  // wrap call in requestAnimationFrame to ensure that Elm has time to finish refreshing the view
+  window.requestAnimationFrame(() => {
+    const input = document.getElementById(id) as HTMLInputElement;
+
+    if (input) {
+      input.focus();
+      input.setSelectionRange(0, -1);
+    }
+  });
+});
+
+// SCROLL
+
+app.ports.scrollTo.subscribe(id => {
+  // wrap call in requestAnimationFrame to ensure that Elm has time to finish refreshing the view
+  window.requestAnimationFrame(() => {
+    const elem = document.getElementById(id);
+
+    if (elem) {
+      elem.scrollIntoView(false);
+    }
+  });
+});
+
+// EDITOR
+
+app.ports.ckEditor.subscribe(id => {
+  // wrap call in requestAnimationFrame to ensure that Elm has time to finish refreshing the view
+  window.requestAnimationFrame(() => {
+    if (window.CKEDITOR) {
+      // implicit detach
+      if (window.CKEDITOR.instances[id]) {
+        window.CKEDITOR.instances[id].destroy();
+      }
+
+      window.CKEDITOR.inline(id).on('change', function (evt) {
+        console.log(evt.editor.getData());
+        app.ports.ckEditorUpdate.send([id, evt.editor.getData()]);
+      });
+    }
+  });
+});
+
+// app.ports.addClassToCKEditor.subscribe(([ckeditorInstance, className]) => {
+//   // wrap call in requestAnimationFrame to ensure that Elm has time to finish refreshing the view
+//   window.requestAnimationFrame(() => {
+//     if (CKEDITOR) {
+//       const elem = document.getElementById(ckeditorInstance)
+//         .nextSibling as HTMLElement;
+
+//       if (elem) {
+//         elem.classList.add(className);
+//       }
+//     }
+//   });
+// });
+
+app.ports.ckEditorSetHtml.subscribe(([id, html]) => {
+  // wrap call in requestAnimationFrame to ensure that Elm has time to finish refreshing the view
+  window.requestAnimationFrame(function (timestamp) {
+    if (window.CKEDITOR) {
+      window.CKEDITOR.instances[id].setData(html);
+    }
+  });
+});
+
+app.ports.confirm.subscribe(msg => {
+  // wrap call in requestAnimationFrame to ensure that Elm has time to finish refreshing the view
+  window.requestAnimationFrame(() => {
+    const confirm = window.confirm(msg);
+    app.ports.confirmation.send(confirm);
+  });
+});


### PR DESCRIPTION
This PR adds the starts for the instructor create and edit text pages. More work will be needed to integrate them with the backend, which will come after #172 is resolved and with #176.

With this PR, it should be possible to log in as an instructor and

- Navigate to the create text page ("Create a new text" link)
- Interact with the page adding text, tags, questions, and answers

It should also be possible to:

- Navigate to the text editor search page ("Find a text to edit" link)
- Select a text from the list
- The text editor should be loaded with the selected text

Note that the translations tab will not work in either case and needs more work. 