### PR TITLE
Fix authed page redirects

### DIFF
--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -76,20 +76,37 @@ init flags url key =
         Just viewer ->
             case Viewer.role viewer of
                 Student ->
-                    Cmd.batch
-                        [ requestStudentProfile session config (Viewer.id viewer)
-                        , Browser.Navigation.replaceUrl key (Route.toString Route.Profile__Student)
-                        ]
+                    if List.any (\path -> url.path == path) publicPaths then
+                        Cmd.batch
+                            [ requestStudentProfile session config (Viewer.id viewer)
+                            , Browser.Navigation.replaceUrl key (Route.toString Route.Profile__Student)
+                            ]
+
+                    else
+                        requestStudentProfile session config (Viewer.id viewer)
 
                 Instructor ->
-                    Cmd.batch
-                        [ requestInstructorProfile session config (Viewer.id viewer)
-                        , Browser.Navigation.replaceUrl key (Route.toString Route.Profile__Instructor)
-                        ]
+                    if List.any (\path -> url.path == path) publicPaths then
+                        Cmd.batch
+                            [ requestInstructorProfile session config (Viewer.id viewer)
+                            , Browser.Navigation.replaceUrl key (Route.toString Route.Profile__Instructor)
+                            ]
+
+                    else
+                        requestInstructorProfile session config (Viewer.id viewer)
 
         Nothing ->
             Cmd.none
     )
+
+
+publicPaths : List String
+publicPaths =
+    [ "/"
+    , "/login/instructor"
+    , "/signup/student"
+    , "/signup/instructor"
+    ]
 
 
 


### PR DESCRIPTION
This PR fixes a bug where all pages would redirect to the profile page on reload or when pasting a URL into the browser. It adds a list of public paths that should be redirected.

To test it out, log in as a student. Remove `/profile/student` from the URL in the URL bar and reload the page. The app should redirect you to the profile page. `/login/instructor`, `/signup/student`, and `/signup/instructor` should also redirect to the profile page, but authed pages that allow you to search or read a text should not redirect.

The same should be true when logged in as an instructor with the additional authed pages that an instructor has available to them.