### PR TITLE
Add text reader and update websocket implementation

### DIFF
--- a/web/public/css/text.css
+++ b/web/public/css/text.css
@@ -36,7 +36,7 @@
 
   padding-top: 25px;
 
-  grid-template-columns: 50% 50%;
+  grid-template-columns: repeat(auto-fit, minmax(175px, 1fr));
 
   grid-template-rows: minmax(25px, 50px);
   align-items: center;
@@ -54,6 +54,28 @@
 }
 
 #nav > div:hover {
+  background-color: #00458a;
+}
+
+#nav > a {
+  text-decoration: none;
+}
+
+#nav > a > span {
+  display: block;
+
+  text-align: center;
+  color: white;
+
+  background-color: #0054a6;
+
+  cursor: pointer;
+
+  margin-right: 5px;
+  transition: background 0.3s ease-out;
+}
+
+#nav > a > span:hover {
   background-color: #00458a;
 }
 
@@ -244,5 +266,11 @@
 
   #text-section {
     padding-top: 0;
+  }
+
+  #nav {
+    grid-template-columns: repeat(auto-fit, minmax(275px, 1fr));
+
+    row-gap: 20px;
   }
 }

--- a/web/public/css/text.css
+++ b/web/public/css/text.css
@@ -1,248 +1,248 @@
 #text-section {
-    display: grid;
+  display: grid;
 
-    grid-template-columns: 10% [body-col] auto 10%;
-    grid-template-rows: 10% [body-row] auto 10%;
+  grid-template-columns: 10% [body-col] auto 10%;
+  grid-template-rows: 10% [body-row] auto 10%;
 
-    font-family: "Lora,Palatino,Times,Times New Roman,serif";
-    font-size: 20px;
-    line-height: 1.7;
-    letter-spacing: 0;
+  font-family: 'Lora,Palatino,Times,Times New Roman,serif';
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0;
 
-    padding-top: 50px;
+  padding-top: 50px;
 }
 
 #complete {
-    grid-column: body-col;
+  grid-column: body-col;
 }
 
 #text-body {
-    grid-column: body-col;
-    grid-row: body-row;
+  grid-column: body-col;
+  grid-row: body-row;
 
-    display: grid;
+  display: grid;
 
-    grid-template-rows: auto auto auto;
+  grid-template-rows: auto auto auto;
 }
 
-#text-body > #body {
-    word-wrap: break-word;
-    overflow-wrap: break-word;
+#text-body > #text {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 #nav {
-    grid-column: 2;
-    display: grid;
+  grid-column: 2;
+  display: grid;
 
-    padding-top: 25px;
+  padding-top: 25px;
 
-    grid-template-columns: 50% 50%;
+  grid-template-columns: 50% 50%;
 
-    grid-template-rows: minmax(25px, 50px);
-    align-items: center;
+  grid-template-rows: minmax(25px, 50px);
+  align-items: center;
 }
 
 #nav > div {
-    text-align: center;
-    color: white;
-    background-color: #0054a6;
+  text-align: center;
+  color: white;
+  background-color: #0054a6;
 
-    cursor: pointer;
+  cursor: pointer;
 
-    margin-right: 5px;
-    transition: background 0.3s ease-out;
+  margin-right: 5px;
+  transition: background 0.3s ease-out;
 }
 
 #nav > div:hover {
-    background-color: #00458a;
+  background-color: #00458a;
 }
 
 .exception {
-    grid-column: 2;
-    display: grid;
-    font-size: 20px;
-    font-style: italic;
-    color: #bf2639;
+  grid-column: 2;
+  display: grid;
+  font-size: 20px;
+  font-style: italic;
+  color: #bf2639;
 }
 
 .nav > div {
-    display: inline-block;
+  display: inline-block;
 
-    cursor: pointer;
+  cursor: pointer;
 
-    margin: 15px;
+  margin: 15px;
 
-    background: #f9f9f9;
-    text-align: center;
+  background: #f9f9f9;
+  text-align: center;
 
-    padding: 2px;
-    border: solid 1px white;
-    border-radius: 5px;
+  padding: 2px;
+  border: solid 1px white;
+  border-radius: 5px;
 }
 
 .start-btn {
-    grid-column: 1 / 3;
+  grid-column: 1 / 3;
 }
 
 #text-score {
-    display: grid;
-    grid-column: 2;
+  display: grid;
+  grid-column: 2;
 
-    margin: 50px 15px 15px 15px;
+  margin: 50px 15px 15px 15px;
 }
 
 #text-intro {
-    grid-column: 2;
-    display: grid;
+  grid-column: 2;
+  display: grid;
 
-    margin-top: 100px;
+  margin-top: 100px;
 
-    align-items: center;
-    justify-items: center;
+  align-items: center;
+  justify-items: center;
 }
 
 #text-conclusion {
-    grid-column: 2;
-    display: grid;
+  grid-column: 2;
+  display: grid;
 
-    align-items: center;
-    justify-items: center;
+  align-items: center;
+  justify-items: center;
 }
 
 #title {
-    font-size: 20px;
+  font-size: 20px;
 }
 
 #questions {
-    display: grid;
-    padding-top: 15px;
+  display: grid;
+  padding-top: 15px;
 
-    border-top: rgb(238, 238, 238) solid 1px;
+  border-top: rgb(238, 238, 238) solid 1px;
 
-    grid-template-columns: auto;
-    grid-row-gap: 50px;
-    row-gap: 50px;
+  grid-template-columns: auto;
+  grid-row-gap: 50px;
+  row-gap: 50px;
 }
 
-.question {
-    display: grid;
-    grid-template-columns: auto;
+.reader-question {
+  display: grid;
+  grid-template-columns: auto;
 }
 
 .question-body {
-    font-size: 18px;
-    margin-bottom: 30px;
+  font-size: 18px;
+  margin-bottom: 30px;
 }
 
 .answer-selected {
-    background: #FFFFFF !important;
+  background: #ffffff !important;
 }
 
 .correct {
-    border-color: #07e200 !important;
+  border-color: #07e200 !important;
 }
 
 .incorrect {
-    border-color: #fc3605 !important;
+  border-color: #fc3605 !important;
 }
 
 .answer {
-    background: #f9f9f9;
-    margin-bottom: 15px;
-    padding: 10px;
+  background: #f9f9f9;
+  margin-bottom: 15px;
+  padding: 10px;
 
-    border: solid 1px lightgrey;
-    border-radius: 5px;
-    font-size: 17px;
-    cursor: pointer;
+  border: solid 1px lightgrey;
+  border-radius: 5px;
+  font-size: 17px;
+  cursor: pointer;
 
-    transition: border 0.2s ease-out;
+  transition: border 0.2s ease-out;
 }
 
 .answer:hover {
-    border: solid 1px #0071bc;
+  border: solid 1px #0071bc;
 }
 
 .answer-feedback {
-    margin-top: 10px;
+  margin-top: 10px;
 }
 
 .answer-text {
-    font-size: 18px;
+  font-size: 18px;
 }
 
 .bolder {
-    font-weight: bolder;
+  font-weight: bolder;
 }
 
 .gloss-menu {
-    position: relative;
+  position: relative;
 }
 
 .translations {
-    padding-top: 10px;
-    border-top: solid 0.5px lightgrey;
+  padding-top: 10px;
+  border-top: solid 0.5px lightgrey;
 }
 
 .gloss-flashcard-options {
-    display: grid;
+  display: grid;
 
-    margin-top: 10px;
+  margin-top: 10px;
 
-    border-top: solid 0.5px lightgrey;
+  border-top: solid 0.5px lightgrey;
 
-    grid-template-columns: auto auto;
+  grid-template-columns: auto auto;
 }
 
 .gloss-flashcard-options > div:nth-child(1) {
-    margin-top: 5px;
-    grid-column: 1 / 3;
+  margin-top: 5px;
+  grid-column: 1 / 3;
 }
 
 .gloss-overlay {
-    display: grid;
-    position: absolute;
+  display: grid;
+  position: absolute;
 
-    -webkit-tap-highlight-color: rgba(0,0,0,0);
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 
-    grid-template-columns: auto;
-    grid-template-rows: auto auto auto;
+  grid-template-columns: auto;
+  grid-template-rows: auto auto auto;
 
-    margin-top: 5px;
+  margin-top: 5px;
 
-    z-index: 2;
-    max-width: 200px;
+  z-index: 2;
+  max-width: 200px;
 
-    background: #FFFFFF;
+  background: #ffffff;
 
-    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 14px;
+  font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 14px;
 
-    padding: 5px;
+  padding: 5px;
 
-    border: solid 0.5px lightgrey;
-    border-radius: 2px;
-    box-shadow: 0 1px 16px rgba(0,0,0,.1);
+  border: solid 0.5px lightgrey;
+  border-radius: 2px;
+  box-shadow: 0 1px 16px rgba(0, 0, 0, 0.1);
 }
 
-@media only screen and (min-device-width : 320px) and (max-device-width : 480px) {
-    .header {
-        display: flex;
-    }
+@media only screen and (min-device-width: 320px) and (max-device-width: 480px) {
+  .header {
+    display: flex;
+  }
 
-    .menu {
-        display: flex;
-        flex-wrap: wrap;
+  .menu {
+    display: flex;
+    flex-wrap: wrap;
 
-        align-items: center;
-    }
+    align-items: center;
+  }
 
-    .footer_items {
-        margin-top: 0;
-    }
+  .footer_items {
+    margin-top: 0;
+  }
 
-    #text-section {
-        padding-top: 0;
-    }
-
+  #text-section {
+    padding-top: 0;
+  }
 }

--- a/web/src/Api.elm
+++ b/web/src/Api.elm
@@ -22,7 +22,7 @@ port module Api exposing
 
 import Api.Config as Config exposing (Config)
 import Api.Endpoint as Endpoint exposing (Endpoint)
-import Api.WebSocket as WebSocket exposing (WebSocketCmd, WebSocketMsg)
+import Api.WebSocket as WebSocket exposing (Address, WebSocketCmd, WebSocketMsg)
 import Browser
 import Browser.Navigation as Nav
 import Http
@@ -335,13 +335,8 @@ port receiveSocketMsg : (Value -> msg) -> Sub msg
 port sendSocketCommand : Value -> Cmd msg
 
 
-
--- wsSend : WebSocketCmd -> Cmd msg
--- wsSend command =
-
-
 websocketConnect :
-    { name : String, address : String }
+    { name : String, address : Address }
     -> Maybe Cred
     -> Cmd msg
 websocketConnect { name, address } maybeCred =
@@ -350,7 +345,7 @@ websocketConnect { name, address } maybeCred =
             WebSocket.send sendSocketCommand <|
                 WebSocket.Connect
                     { name = name
-                    , address = address ++ "?" ++ token
+                    , address = WebSocket.unwrap address ++ "?" ++ token
                     , protocol = ""
                     }
 
@@ -360,10 +355,6 @@ websocketConnect { name, address } maybeCred =
 
 websocketSend : { name : String, content : Value } -> Cmd msg
 websocketSend message =
-    let
-        dbg =
-            Debug.log "ws message out" message
-    in
     WebSocket.send sendSocketCommand <|
         WebSocket.Send message
 
@@ -375,6 +366,5 @@ websocketReceive toMsg =
 
 websocketDisconnect : String -> Cmd msg
 websocketDisconnect name =
-    -- weSend <| WebSocket.Close { name = name }
     WebSocket.send sendSocketCommand <|
         WebSocket.Close { name = name }

--- a/web/src/Api/WebSocket.elm
+++ b/web/src/Api/WebSocket.elm
@@ -5,6 +5,7 @@ module Api.WebSocket exposing
     , encodeCmd
     , receive
     , send
+    , Address, flashcards, textReader, unwrap
     )
 
 {-| NOTE: We modified this package:<https://github.com/bburdette/websocket> and adapted it
@@ -62,6 +63,45 @@ where the actual websocket sending and receiving will take place. See the README
 
 import Json.Decode as JD
 import Json.Encode as JE
+import Role exposing (Role(..))
+import Url.Builder exposing (QueryParameter)
+
+
+type Address
+    = Address String
+
+
+unwrap : Address -> String
+unwrap (Address val) =
+    val
+
+
+url : String -> List String -> List QueryParameter -> Address
+url baseUrl paths queryParams =
+    Url.Builder.crossOrigin baseUrl
+        paths
+        queryParams
+        |> Address
+
+
+textReader : String -> Role -> Int -> Address
+textReader baseUrl role textId =
+    case role of
+        Student ->
+            url baseUrl [ "student", "text_read", String.fromInt textId ] []
+
+        Instructor ->
+            url baseUrl [ "instructor", "text_read", String.fromInt textId ] []
+
+
+flashcards : String -> Role -> Address
+flashcards baseUrl role =
+    case role of
+        Student ->
+            url baseUrl [ "student", "flashcards" ] []
+
+        Instructor ->
+            url baseUrl [ "instructor", "flashcards" ] []
 
 
 {-| use send to make a websocket convenience function,

--- a/web/src/Pages/Flashcards/Student.elm
+++ b/web/src/Pages/Flashcards/Student.elm
@@ -76,15 +76,9 @@ init shared { params } =
             Api.websocketConnect
                 { name = "flashcard"
                 , address =
-                    Config.websocketBaseUrl shared.config
-                        ++ (case Viewer.role viewer of
-                                Student ->
-                                    "/student"
-
-                                Instructor ->
-                                    "/instructor"
-                           )
-                        ++ "/flashcards"
+                    WebSocket.flashcards
+                        (Config.websocketBaseUrl shared.config)
+                        (Viewer.role viewer)
                 }
                 (Session.cred shared.session)
 

--- a/web/src/Pages/Text/Id_Int.elm
+++ b/web/src/Pages/Text/Id_Int.elm
@@ -599,6 +599,7 @@ viewTextComplete (SafeModel model) scores =
         , div [ id "nav" ]
             [ viewPreviousButton
             , div [ onClick StartOver ] [ Html.text "Start Over" ]
+            , Html.a [ attribute "href" (Route.toString Route.Text__Search) ] [ span [] [ Html.text "Read Another Text" ] ]
             ]
         ]
 

--- a/web/src/Text/Section/Words/Tag.elm
+++ b/web/src/Text/Section/Words/Tag.elm
@@ -9,9 +9,8 @@ module Text.Section.Words.Tag exposing
 import Dict exposing (Dict)
 import Html exposing (Html)
 import Html.Attributes
-import Html.Parser 
+import Html.Parser
 import Regex
--- import VirtualDom
 
 
 punctuation_re : Regex.Regex
@@ -178,8 +177,7 @@ tagWordAndToVDOM tag_word is_part_of_compound_word node ( html, occurrences ) =
             ( html ++ [ new_node ], new_occurrences )
 
         (Html.Parser.Comment str) as comment ->
-            -- ( html ++ [ VirtualDom.text "" ], occurrences )
-            ( html ++ [  ], occurrences )
+            ( html ++ [ Html.text "" ], occurrences )
 
 
 tagWordsToVDOMWithFreqs :

--- a/web/src/TextReader/Question/Decode.elm
+++ b/web/src/TextReader/Question/Decode.elm
@@ -2,6 +2,7 @@ module TextReader.Question.Decode exposing (..)
 
 import Array exposing (Array)
 import DateTime
+import Iso8601
 import Json.Decode
 import Json.Decode.Extra exposing (posix)
 import Json.Decode.Pipeline exposing (required)
@@ -30,8 +31,10 @@ questionDecoder =
     Json.Decode.succeed Question
         |> required "id" Json.Decode.int
         |> required "text_section_id" Json.Decode.int
-        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
-        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
+        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
+        -- |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        -- |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
         |> required "body" Json.Decode.string
         |> required "order" Json.Decode.int
         |> required "answers" answersDecoder

--- a/web/src/TextReader/Text/Decode.elm
+++ b/web/src/TextReader/Text/Decode.elm
@@ -1,6 +1,7 @@
 module TextReader.Text.Decode exposing (..)
 
 import DateTime
+import Iso8601
 import Json.Decode
 import Json.Decode.Extra exposing (posix)
 import Json.Decode.Pipeline exposing (required)
@@ -20,5 +21,5 @@ textDecoder =
         |> required "created_by" (Json.Decode.nullable Json.Decode.string)
         |> required "last_modified_by" (Json.Decode.nullable Json.Decode.string)
         |> required "tags" (Json.Decode.nullable (Json.Decode.list Json.Decode.string))
-        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
-        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
+        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -111,13 +111,17 @@ window.addEventListener(
 // WEBSOCKETS
 
 const sendSocketCommand = wat => {
-  console.log('ssc: ' + JSON.stringify(wat, null, 4));
+  // console.log('ssc: ' + JSON.stringify(wat, null, 4));
   if (wat.cmd == 'connect') {
+    // implicit disconnect on new socket connection, explicit would be better
+    if (mySockets[wat.name]) {
+      mySockets[wat.name].close();
+    }
+
     // console.log("connecting!");
-    // let socket = new WebSocket(wat.address, wat.protocol);
     let socket = new WebSocket(wat.address);
     socket.onmessage = function (event) {
-      // console.log( "onmessage: " +  JSON.stringify(event.data, null, 4));
+      // console.log("onmessage: " + JSON.stringify(event.data, null, 4));
       app.ports.receiveSocketMsg.send({
         name: wat.name,
         msg: 'data',
@@ -126,10 +130,10 @@ const sendSocketCommand = wat => {
     };
     mySockets[wat.name] = socket;
   } else if (wat.cmd == 'send') {
-    console.log('sending to socket: ' + wat.name);
-    mySockets[wat.name].send(wat.content);
+    // console.log('sending to socket: ' + wat.name);
+    mySockets[wat.name].send(JSON.stringify(wat.content));
   } else if (wat.cmd == 'close') {
-    console.log('closing socket: ' + wat.name);
+    // console.log('closing socket: ' + wat.name);
     mySockets[wat.name].close();
     delete mySockets[wat.name];
   }


### PR DESCRIPTION
This PR adds most of the remaining functionality to the text reader page. It includes missing portions of UI, Elm 0.19 upgrades, a few styles that were broken by cascades, and an updated websocket implementation. All items checked in #157 should work.

In addition, a button was added to the text conclusion page to address #62. The text "Read Another Text" was used instead of "Find a text to read" because it is shorter and works better with the UI.