### PR TITLE
Performance report data goes to frontend.

### DIFF
--- a/user/views/student.py
+++ b/user/views/student.py
@@ -198,14 +198,18 @@ class StudentAPIView(LoginRequiredMixin, APIView):
 
         student_dict = student.to_dict()
 
-        if 'performance_report' in student_dict:
-            student_performance_report = student_dict.pop('performance_report')
-        else:
-            student_performance_report = None
+        try:
+            performance_report = {
+                'html' : loader.render_to_string('student_performance_report.html', {
+                                                 'performance_report': student.performance.to_dict()}),
+                'pdf_link' : "steps2ar.org/profile/student/" + str(student.id) + "/performance_report.pdf"
+            }
+        except Exception as e:
+            performance_report = None
 
         return HttpResponse(json.dumps({
             'profile': student_dict,
-            'performance_report': student_performance_report,
+            'performance_report': performance_report
         }))
         
     def post_success(self, request: HttpRequest, form: Form) -> HttpResponse:

--- a/user/views/student.py
+++ b/user/views/student.py
@@ -169,6 +169,14 @@ class StudentView(ProfileView):
 class StudentAPIConsentToResearchView(LoginRequiredMixin, APIView):
     # returns permission denied HTTP message rather than redirect to login
 
+    def get(self, request: HttpRequest, **kwargs) -> HttpResponse:
+        if not Student.objects.filter(pk=kwargs['pk']).count():
+            return HttpResponse(status=400)
+
+        student = Student.objects.get(pk=kwargs['pk']) 
+
+        return HttpResponse(json.dumps({'consented': student.is_consenting_to_research}))
+
     def form(self, request: HttpRequest, params: Dict, **kwargs) -> forms.ModelForm:
         return StudentConsentForm(params, **kwargs)
 

--- a/user/views/student.py
+++ b/user/views/student.py
@@ -169,6 +169,10 @@ class StudentView(ProfileView):
 class StudentAPIConsentToResearchView(LoginRequiredMixin, APIView):
     # returns permission denied HTTP message rather than redirect to login
 
+    def get(self, request: HttpRequest, **kwargs) -> HttpResponse:
+        if not Student.objects.filter(pk=kwargs['pk']).count():
+            return HttpResponse(status=400)
+
     def form(self, request: HttpRequest, params: Dict, **kwargs) -> forms.ModelForm:
         return StudentConsentForm(params, **kwargs)
 
@@ -202,7 +206,6 @@ class StudentAPIView(LoginRequiredMixin, APIView):
             performance_report = {
                 'html' : loader.render_to_string('student_performance_report.html', {
                                                  'performance_report': student.performance.to_dict()}),
-                'pdf_link' : "steps2ar.org/profile/student/" + str(student.id) + "/performance_report.pdf"
             }
         except Exception as e:
             performance_report = None

--- a/user/views/student.py
+++ b/user/views/student.py
@@ -169,10 +169,6 @@ class StudentView(ProfileView):
 class StudentAPIConsentToResearchView(LoginRequiredMixin, APIView):
     # returns permission denied HTTP message rather than redirect to login
 
-    def get(self, request: HttpRequest, **kwargs) -> HttpResponse:
-        if not Student.objects.filter(pk=kwargs['pk']).count():
-            return HttpResponse(status=400)
-
     def form(self, request: HttpRequest, params: Dict, **kwargs) -> forms.ModelForm:
         return StudentConsentForm(params, **kwargs)
 
@@ -223,8 +219,12 @@ class StudentAPIView(LoginRequiredMixin, APIView):
 
     def put_success(self, request: HttpRequest, student_form: Union[Form, forms.ModelForm]) -> HttpResponse:
         student = student_form.save()
+        
+        student_dict = student.to_dict()
 
-        return HttpResponse(json.dumps(student.to_dict()))
+        return HttpResponse(json.dumps({
+            'profile': student_dict
+        }))
 
 
 class StudentSignupAPIView(APIView):


### PR DESCRIPTION
This PR address #186 in the following ways:

[x] The "is consenting to research endpoint" now supports the GET HTTP method and returns what you'd expect.
[x] "profile" now wraps the JSON blob from the PUT request as detailed in the aforementioned issue.
[x] We are now sending back the HTML which creates the table on the frontend.