### PR TITLE
Add more to student profile page

### DIFF
--- a/web/public/css/user_profile.css
+++ b/web/public/css/user_profile.css
@@ -95,7 +95,7 @@ table td {
   grid-row: 3;
   grid-column: 1 / 3;
   grid-template-columns: auto;
-  grid-template-rows: auto 35px 35px;
+  grid-template-rows: auto 35px 60px;
   grid-row-gap: 10px;
   margin-bottom: 15px;
 }

--- a/web/public/css/user_profile.css
+++ b/web/public/css/user_profile.css
@@ -18,12 +18,20 @@ table td {
   grid-template-columns: 4% 10% [content] auto 15% 4%;
 }
 
+.profile-title {
+  grid-column: content;
+
+  margin-top: 20px;
+
+  font-size: x-large;
+}
+
 .profile_items {
   display: grid;
   grid-column: content;
 
   padding: 25px;
-  margin-top: 100px;
+  margin-top: 30px;
 
   grid-template-columns: 35% 35% 25%;
 

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -101,7 +101,7 @@ init shared { params } =
         , config = shared.config
         , navKey = shared.key
         , profile = Profile.toStudentProfile shared.profile
-        , consentedToResearch = False
+        , consentedToResearch = shared.researchConsent
         , flashcards = Nothing
         , editing = Dict.empty
         , usernameValidation = { username = Nothing, valid = Nothing, msg = Nothing }
@@ -924,12 +924,17 @@ save (SafeModel model) shared =
     { shared
         | config = model.config
         , profile = Profile.fromStudentProfile model.profile
+        , researchConsent = model.consentedToResearch
     }
 
 
 load : Shared.Model -> SafeModel -> ( SafeModel, Cmd Msg )
 load shared (SafeModel model) =
-    ( SafeModel { model | profile = Profile.toStudentProfile shared.profile }
+    ( SafeModel
+        { model
+            | profile = Profile.toStudentProfile shared.profile
+            , consentedToResearch = shared.researchConsent
+        }
     , Cmd.none
     )
 

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -35,6 +35,7 @@ import User.Student.Profile as StudentProfile exposing (StudentProfile)
 import User.Student.Profile.Help as Help exposing (StudentHelp)
 import User.Student.Resource as StudentResource
 import Utils
+import Viewer exposing (Viewer)
 import Views
 
 
@@ -79,7 +80,6 @@ type SafeModel
         , config : Config
         , navKey : Key
         , profile : StudentProfile
-        , performanceReport : PerformanceReport
         , consentedToResearch : Bool
         , flashcards : Maybe (List String)
         , editing : Dict String Bool
@@ -101,7 +101,6 @@ init shared { params } =
         , config = shared.config
         , navKey = shared.key
         , profile = Profile.toStudentProfile shared.profile
-        , performanceReport = PerformanceReport.emptyPerformanceReport
         , consentedToResearch = False
         , flashcards = Nothing
         , editing = Dict.empty
@@ -569,7 +568,7 @@ viewStudentPerformance : SafeModel -> Html Msg
 viewStudentPerformance (SafeModel model) =
     let
         performanceReport =
-            model.performanceReport
+            StudentProfile.performanceReport model.profile
     in
     div [ class "performance" ] <|
         viewPerformanceHint (SafeModel model)
@@ -579,7 +578,19 @@ viewStudentPerformance (SafeModel model) =
                         (performanceReportNode performanceReport.html)
                     ]
                , div [ class "performance_download_link" ]
-                    [ Html.a [ attribute "href" performanceReport.pdf_link ]
+                    [ Html.a
+                        [ attribute "href" <|
+                            Config.restApiUrl model.config
+                                ++ "/profile/student/"
+                                ++ (case StudentProfile.studentID model.profile of
+                                        Just id ->
+                                            String.fromInt id
+
+                                        Nothing ->
+                                            "0"
+                                   )
+                                ++ "/performance_report.pdf"
+                        ]
                         [ Html.text "Download the \"My Performance\" table as a PDF"
                         ]
                     ]

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -574,8 +574,9 @@ viewStudentPerformance (SafeModel model) =
         viewPerformanceHint (SafeModel model)
             ++ [ span [ class "profile_item_title" ] [ Html.text "My Performance: " ]
                , span [ class "profile_item_value" ]
-                    [ div [ class "performance_report" ]
-                        (performanceReportNode performanceReport.html)
+                    [ div [ class "performance_report" ] []
+
+                    -- (performanceReportNode performanceReport.html)
                     ]
                , div [ class "performance_download_link" ]
                     [ Html.a

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -580,7 +580,7 @@ viewStudentPerformance (SafeModel model) =
                     ]
                , div [ class "performance_download_link" ]
                     [ Html.a [ attribute "href" performanceReport.pdf_link ]
-                        [ Html.text "Download as PDF"
+                        [ Html.text "Download the \"My Performance\" table as a PDF"
                         ]
                     ]
                ]

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -416,7 +416,9 @@ view (SafeModel model) =
 viewContent : SafeModel -> Html Msg
 viewContent (SafeModel model) =
     div [ classList [ ( "profile", True ) ] ]
-        [ div [ classList [ ( "profile_items", True ) ] ]
+        [ div [ class "profile-title" ]
+            [ Html.text "Student Profile" ]
+        , div [ classList [ ( "profile_items", True ) ] ]
             [ viewPreferredDifficulty (SafeModel model)
             , viewUsername (SafeModel model)
             , viewUserEmail (SafeModel model)

--- a/web/src/User/Profile.elm
+++ b/web/src/User/Profile.elm
@@ -12,6 +12,7 @@ import User.Instructor.Profile
         , InstructorUsername(..)
         )
 import User.Instructor.View
+import User.Student.Performance.Report as PerformanceReport exposing (PerformanceReport)
 import User.Student.Profile
     exposing
         ( StudentProfile(..)
@@ -53,7 +54,7 @@ initProfile flags =
         Nothing ->
             case flags.student_profile of
                 Just student_profile_params ->
-                    Student (User.Student.Profile.initProfile student_profile_params)
+                    Student (User.Student.Profile.initProfile student_profile_params PerformanceReport.emptyPerformanceReport)
 
                 Nothing ->
                     EmptyProfile
@@ -82,6 +83,7 @@ toStudentProfile profile =
                     (User.Student.Resource.toStudentLogoutURI "")
                     (User.Student.Resource.toStudentProfileURI "")
                 )
+                PerformanceReport.emptyPerformanceReport
 
 
 toInstructorProfile : Profile -> User.Instructor.Profile.InstructorProfile

--- a/web/src/User/Student/Performance/Report.elm
+++ b/web/src/User/Student/Performance/Report.elm
@@ -3,12 +3,10 @@ module User.Student.Performance.Report exposing (PerformanceReport, emptyPerform
 
 type alias PerformanceReport =
     { html : String
-    , pdf_link : String
     }
 
 
 emptyPerformanceReport : PerformanceReport
 emptyPerformanceReport =
     { html = "<div>No results found.</div>"
-    , pdf_link = ""
     }

--- a/web/src/User/Student/Profile/Decode.elm
+++ b/web/src/User/Student/Profile/Decode.elm
@@ -1,6 +1,7 @@
 module User.Student.Profile.Decode exposing
-    ( studentConsentRespDecoder
-    , studentProfileDecoder
+    (  studentConsentRespDecoder
+       -- , studentProfileDecoder
+
     , usernameValidationDecoder
     )
 
@@ -51,11 +52,12 @@ wordTextWordDecoder =
         )
 
 
-performanceReportDecoder : Json.Decode.Decoder PerformanceReport
-performanceReportDecoder =
-    Json.Decode.succeed PerformanceReport
-        |> required "html" Json.Decode.string
-        |> required "pdf_link" Json.Decode.string
+
+-- performanceReportDecoder : Json.Decode.Decoder PerformanceReport
+-- performanceReportDecoder =
+--     Json.Decode.succeed PerformanceReport
+--         |> required "html" Json.Decode.string
+--         |> required "pdf_link" Json.Decode.string
 
 
 studentProfileURIParamsDecoder : Json.Decode.Decoder StudentProfile.StudentURIParams
@@ -65,20 +67,20 @@ studentProfileURIParamsDecoder =
         |> required "profile_uri" Json.Decode.string
 
 
-studentProfileParamsDecoder : Json.Decode.Decoder StudentProfileParams
-studentProfileParamsDecoder =
-    Json.Decode.succeed StudentProfileParams
-        |> required "id" (Json.Decode.nullable Json.Decode.int)
-        |> required "username" (Json.Decode.nullable Json.Decode.string)
-        |> required "email" Json.Decode.string
-        |> required "difficulty_preference" (Json.Decode.nullable stringTupleDecoder)
-        |> required "difficulties" (Json.Decode.list stringTupleDecoder)
-        |> required "uris" studentProfileURIParamsDecoder
 
-
-studentProfileDecoder : Json.Decode.Decoder StudentProfile.StudentProfile
-studentProfileDecoder =
-    Json.Decode.map StudentProfile.initProfile studentProfileParamsDecoder
+-- studentProfileParamsDecoder : Json.Decode.Decoder StudentProfileParams
+-- studentProfileParamsDecoder =
+--     Json.Decode.succeed StudentProfileParams
+--         |> required "id" (Json.Decode.nullable Json.Decode.int)
+--         |> required "username" (Json.Decode.nullable Json.Decode.string)
+--         |> required "email" Json.Decode.string
+--         |> required "difficulty_preference" (Json.Decode.nullable stringTupleDecoder)
+--         |> required "difficulties" (Json.Decode.list stringTupleDecoder)
+--         |> required "uris" studentProfileURIParamsDecoder
+--
+-- studentProfileDecoder : Json.Decode.Decoder StudentProfile.StudentProfile
+-- studentProfileDecoder =
+--     Json.Decode.map StudentProfile.initProfile studentProfileParamsDecoder
 
 
 studentConsentRespDecoder : Json.Decode.Decoder StudentProfileModel.StudentConsentResp


### PR DESCRIPTION
This PR implements a number of missing parts of the student profile page. All checked off items in #149 should work now. Note that we are holding off on flashcards and performance reports for now.

In addition to the changes listed there, a couple of other issues are addressed here:

- A heading that reads "Student Profile" was added above the student profile (#47)
- The link text for downloading performance report PDFs was updated (#52)

