### PR TITLE
More work on create and edit text pages

### DIFF
--- a/web/public/css/create_text.css
+++ b/web/public/css/create_text.css
@@ -1,766 +1,804 @@
 body {
-    background: #FFFFFF;
-    margin-top: 0;
-    margin-right: 0;
-    margin-left: 0;
+  background: #ffffff;
+  margin-top: 0;
+  margin-right: 0;
+  margin-left: 0;
 }
 
 .preview {
-    display: grid;
-    grid-template-rows: 67px;
+  display: grid;
+  grid-template-rows: 67px;
 
-    margin-top: 3%;
-    margin-bottom: 4%;
+  margin-top: 3%;
+  margin-bottom: 4%;
 
-    background: #f9f9f9;
+  background: #f9f9f9;
 
-    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 18px;
+  font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 18px;
 
-    align-items: right;
-    justify-items: right;
+  align-items: right;
+  justify-items: right;
 
-    border: solid 0.5px lightgrey;
+  border: solid 0.5px lightgrey;
 }
 
 .preview_menu {
-    grid-column: 5 / 6;
-    display: grid;
+  grid-column: 5 / 6;
+  display: grid;
 
-    grid-template-rows: 35px;
-    grid-template-columns: 200px;
+  grid-template-rows: 35px;
+  grid-template-columns: 200px;
 }
 
 .filter {
-    grid-column: 2 / 2;
+  grid-column: 2 / 2;
 }
 
 .filter_items {
-    display: grid;
-    margin-top: 50px;
-    margin-bottom: 0;
-    grid-template-columns: 4% auto 4%;
+  display: grid;
+  margin-top: 50px;
+  margin-bottom: 0;
+  grid-template-columns: 4% auto 4%;
 
-    align-items: right;
-    justify-items: right;
+  align-items: right;
+  justify-items: right;
 
-    grid-auto-rows: 50px;
+  grid-auto-rows: 50px;
 
-    grid-row-gap: 5%;
-    row-gap: 5%;
+  grid-row-gap: 5%;
+  row-gap: 5%;
 }
 
 .item_property {
+  display: grid;
+
+  align-items: center;
+  justify-items: center;
+
+  font-size: 23px;
+  font-weight: 300;
+}
+
+.sub_description {
+  color: #a4a4a4;
+  font-size: 14px;
+  font-weight: 300;
+
+  display: block;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.message {
+  margin: 8px;
+  color: #737373;
+}
+
+.body {
+  font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 17px;
+}
+
+.body > textarea {
+  width: 100%;
+  height: 100%;
+}
+
+.body > div:nth-child(1) {
+  font-weight: 300;
+  margin-bottom: 10px;
+}
+
+.body > div:nth-child(2) {
+  padding: 15px;
+  background-color: white;
+}
+
+#text_attributes {
+  grid-column: 2;
+  display: grid;
+
+  padding: 15px 20px 15px 20px;
+
+  background: #f9f9f9;
+
+  font-size: 23px;
+  font-weight: 300;
+
+  grid-template-columns: 100%;
+}
+
+#text_introduction {
+  display: grid;
+
+  grid-column: 1;
+
+  grid-template-columns: 100%;
+  grid-template-rows: 25px minmax(130px, auto);
+  grid-row-gap: 10px;
+
+  border-bottom: solid 2px white;
+  margin-bottom: 15px;
+}
+
+#text_introduction div:nth-child(2) {
+  background: white;
+}
+
+#text_conclusion {
+  display: grid;
+
+  grid-column: 1;
+
+  grid-template-columns: 100%;
+  grid-template-rows: 25px minmax(130px, auto);
+  grid-row-gap: 10px;
+
+  border-bottom: solid 2px white;
+  margin-bottom: 15px;
+}
+
+#text_conclusion div:nth-child(2) {
+  background: white;
+}
+
+#text_author_view {
+  display: grid;
+  grid-column: 1;
+}
+
+#text_attributes > div > div:nth-child(1) {
+  font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 17px;
+  color: #000e2d;
+}
+
+.text_introduction {
+  padding: 15px;
+}
+
+#text_lock {
+  display: grid;
+
+  font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 17px;
+
+  grid-column: 1;
+
+  margin-bottom: 15px;
+}
+
+#lock_box {
+  cursor: pointer;
+  margin-top: 15px;
+  border: 1px solid black;
+  border-radius: 25px;
+  width: 35px;
+}
+
+#lock_left {
+  position: relative;
+  float: left;
+
+  width: 15px;
+  height: 15px;
+
+  transition-property: float;
+  transition-duration: 2s;
+
+  border-radius: 50%;
+
+  background: black;
+}
+
+#lock_right {
+  position: relative;
+  float: right;
+
+  width: 15px;
+  height: 15px;
+
+  transition-property: float;
+  transition-duration: 7s;
+
+  border-radius: 50%;
+
+  background: black;
+}
+
+#tabs {
+  display: grid;
+
+  grid-template-columns: 10% auto 10%;
+
+  row-gap: 0;
+
+  font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 18px;
+  font-weight: 200;
+
+  margin-top: 25px;
+  margin-bottom: 15px;
+}
+
+#tabs_menu {
+  grid-column: 2;
+  display: grid;
+
+  grid-template-columns: 6% 12% auto;
+  text-align: center;
+}
+
+#tabs_menu > div {
+  cursor: pointer;
+  border-top: solid 1px #a4a4a4;
+  border-left: solid 1px #a4a4a4;
+  border-right: solid 1px #a4a4a4;
+  border-radius: 10px 10px 0 0;
+}
+
+#tabs_menu > .selected {
+  background: #f9f9f9;
+  font-weight: bold;
+}
+
+#tabs_contents {
+  grid-column: 2;
+  border: solid 1px #a4a4a4;
+}
+
+#text_tags > div {
+  font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 18px;
+  color: #000e2d;
+}
+
+.text_sections {
+  grid-column: 2;
+  display: grid;
+}
+
+#text_title {
+  display: grid;
+  grid-column: 1;
+
+  grid-template-columns: 100%;
+  grid-template-rows: 25px 30px;
+
+  grid-row-gap: 2px;
+  row-gap: 2px;
+
+  margin-bottom: 10px;
+}
+
+.text {
+  display: grid;
+
+  background: #f9f9f9;
+  padding: 10px 20px 15px 20px;
+  margin-top: 25px;
+}
+
+.text > .cursor {
+  margin-top: 10px;
+}
+
+.text_content {
+  grid-column: 2;
+}
+
+.text_properties {
+  display: grid;
+  grid-row-gap: 5%;
+  row-gap: 5%;
+
+  margin-bottom: 15px;
+}
+
+.editable:hover {
+  background-color: #d1e1ed;
+}
+
+.text_property_items {
+  display: grid;
+
+  font-size: 23px;
+  font-weight: 300;
+  grid-row-gap: 10px;
+  row-gap: 10px;
+}
+
+.text_property {
+  display: grid;
+
+  grid-template-columns: 100%;
+  grid-template-rows: 25px 30px;
+
+  grid-row-gap: 5px;
+
+  padding-left: 5px;
+  padding-bottom: 5px;
+}
+
+.text_property > div:nth-child(1) {
+  font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 17px;
+  color: #000e2d;
+}
+
+.text_property > select {
+  width: 150px;
+}
+
+#letter_menu {
+  padding-bottom: 10px;
+}
+
+#letter_menu > span {
+  margin-right: 10px;
+}
+
+.underline {
+  border-bottom: 0.5px solid grey;
+}
+
+@media screen and (min-width: 300px) and (max-width: 568px) {
+  .text_items {
+    margin-top: 2%;
+    display: grid;
+    grid-row-gap: 5%;
+    row-gap: 5%;
+
+    grid-template-columns: 4% auto 4%;
+    grid-auto-rows: 110px;
+  }
+
+  .item_property {
     display: grid;
 
     align-items: center;
     justify-items: center;
 
-    font-size: 23px;
-    font-weight: 300;
-}
+    font-size: 9px;
+  }
 
-.sub_description {
+  .sub_description {
     color: #a4a4a4;
-    font-size: 14px;
-    font-weight: 300;
+    font-size: 9px;
 
     display: block;
 
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-}
-
-.message {
-    margin: 8px;
-    color: #737373;
-}
-
-.body {
-    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 17px;
-}
-
-.body > textarea {
-    width: 100%;
-    height: 100%;
-}
-
-.body > div:nth-child(1) {
-    font-weight: 300;
-    margin-bottom: 10px;
-}
-
-.body > div:nth-child(2) {
-    padding: 15px;
-    background-color: white;
-}
-
-#text_attributes {
-    grid-column: 2;
-    display: grid;
-
-    padding: 15px 20px 15px 20px;
-
-    background: #f9f9f9;
-
-    font-size: 23px;
-    font-weight: 300;
-
-    grid-template-columns: 100%;
-}
-
-#text_introduction {
-    display: grid;
-
-    grid-column: 1;
-
-    grid-template-columns: 100%;
-    grid-template-rows: 25px minmax(130px, auto);
-    grid-row-gap: 10px;
-
-    border-bottom: solid 2px white;
-    margin-bottom: 15px;
-}
-
-#text_introduction div:nth-child(2) {
-    background: white;
-}
-
-#text_conclusion {
-    display: grid;
-
-    grid-column: 1;
-
-    grid-template-columns: 100%;
-    grid-template-rows: 25px minmax(130px, auto);
-    grid-row-gap: 10px;
-
-    border-bottom: solid 2px white;
-    margin-bottom: 15px;
-}
-
-#text_conclusion div:nth-child(2) {
-    background: white;
-}
-
-#text_author_view {
-    display: grid;
-    grid-column: 1;
-}
-
-#text_attributes > div > div:nth-child(1) {
-    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 17px;
-    color: #000e2d;
-}
-
-
-.text_introduction {
-    padding: 15px;
-}
-
-#text_lock {
-    display: grid;
-
-    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 17px;
-
-    grid-column: 1;
-
-    margin-bottom: 15px;
-}
-
-#lock_box {
-    cursor: pointer;
-    margin-top: 15px;
-    border: 1px solid black;
-    border-radius: 25px;
-    width: 35px;
-}
-
-#lock_left {
-    position: relative;
-    float: left;
-
-    width: 15px;
-    height: 15px;
-
-    transition-property: float;
-    transition-duration: 2s;
-
-    border-radius: 50%;
-
-    background: black;
-}
-
-
-#lock_right {
-    position: relative;
-    float: right;
-
-    width: 15px;
-    height: 15px;
-
-    transition-property: float;
-    transition-duration: 7s;
-
-    border-radius: 50%;
-
-    background: black;
-}
-
-#tabs {
-    display: grid;
-
-    grid-template-columns: 10% auto 10%;
-
-    row-gap: 0;
-
-    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 18px;
-    font-weight: 200;
-
-    margin-top: 25px;
-    margin-bottom: 15px;
-}
-
-#tabs_menu {
-    grid-column: 2;
-    display: grid;
-
-    grid-template-columns: 6% 12% auto;
-    text-align: center;
-}
-
-#tabs_menu > div {
-    cursor: pointer;
-    border-top: solid 1px #a4a4a4;
-    border-left: solid 1px #a4a4a4;
-    border-right: solid 1px #a4a4a4;
-    border-radius: 10px 10px 0 0;
-}
-
-#tabs_menu > .selected {
-    background: #f9f9f9;
-    font-weight: bold;
-}
-
-#tabs_contents {
-    grid-column: 2;
-    border: solid 1px #a4a4a4;
-}
-
-#text_tags > div {
-    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 18px;
-    color: #000e2d;
-}
-
-.text_sections {
-    grid-column: 2;
-    display: grid;
-}
-
-#text_title {
-    display: grid;
-    grid-column: 1;
-
-    grid-template-columns: 100%;
-    grid-template-rows: 25px 30px;
-
-    grid-row-gap: 2px;
-    row-gap: 2px;
-
-    margin-bottom: 10px;
-}
-
-.text {
-    display: grid;
-
-    background: #f9f9f9;
-    padding: 10px 20px 15px 20px;
-    margin-top: 25px;
-}
-
-.text > .cursor {
-    margin-top: 10px;
-}
-
-.text_content {
-    grid-column: 2;
-}
-
-.text_properties {
-    display: grid;
-    grid-row-gap: 5%;
-    row-gap: 5%;
-
-    margin-bottom: 15px;
-}
-
-.editable:hover {
-    background-color: #d1e1ed;
-}
-
-.text_property_items {
-    display: grid;
-
-    font-size: 23px;
-    font-weight: 300;
-    grid-row-gap: 10px;
-    row-gap: 10px;
-}
-
-.text_property {
-    display: grid;
-
-    grid-template-columns: 100%;
-    grid-template-rows: 25px 30px;
-
-    grid-row-gap: 5px;
-
-    padding-left: 5px;
-    padding-bottom: 5px;
-}
-
-.text_property > div:nth-child(1) {
-    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 17px;
-    color: #000e2d;
-}
-
-.text_property > select {
-    width: 150px;
-}
-
-#letter_menu {
-    padding-bottom: 10px;
-}
-
-#letter_menu > span {
-    margin-right: 10px;
-}
-
-.underline {
-    border-bottom: 0.5px solid grey;
-}
-
-@media screen and (min-width:300px) and (max-width: 568px) {
-    .text_items {
-        margin-top: 2%;
-        display: grid;
-        grid-row-gap: 5%;
-        row-gap: 5%;
-
-        grid-template-columns: 4% auto 4%;
-        grid-auto-rows: 110px;
-    }
-
-    .item_property {
-        display: grid;
-
-        align-items: center;
-        justify-items: center;
-
-        font-size: 9px;
-    }
-
-    .sub_description {
-        color: #a4a4a4;
-        font-size: 9px;
-
-        display: block;
-
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
+  }
 }
 
 .footer_items {
-    margin-top: 50px;
-    margin-bottom: 0;
+  margin-top: 50px;
+  margin-bottom: 0;
 
-    display: grid;
-    grid-template-columns: 4% auto 4%;
+  display: grid;
+  grid-template-columns: 4% auto 4%;
 
-    align-items: center;
-    justify-items: center;
+  align-items: center;
+  justify-items: center;
 }
 
 .footer {
-    grid-column: 2 / 2;
+  grid-column: 2 / 2;
 }
 
 .question_section {
-    display: grid;
+  display: grid;
 
-    padding-top: 5%;
+  padding-top: 5%;
 
-    grid-row-gap: 50px;
-    row-gap: 50px;
+  grid-row-gap: 50px;
+  row-gap: 50px;
 
-    grid-template-columns: 0% auto 0%;
+  grid-template-columns: 0% auto 0%;
 }
 
 .question_parts {
-    display: grid;
-    background: #FFFFFF;
+  display: grid;
+  background: #ffffff;
 
-    border: solid 1px lightgrey;
+  border: solid 1px lightgrey;
 
-    grid-column: 2;
+  grid-column: 2;
 
-    grid-template-columns: 3% auto 2%;
-    grid-row-gap: 15px;
-    row-gap: 15px;
+  grid-template-columns: 3% auto 2%;
+  grid-row-gap: 15px;
+  row-gap: 15px;
 }
 
 .question {
-    padding: 5px 20px 20px 0px;
-    display: grid;
-    grid-row-gap: 15px;
-    row-gap: 15px;
+  padding: 5px 20px 20px 0px;
+  display: grid;
+  grid-row-gap: 15px;
+  row-gap: 15px;
 
-    grid-template-columns: 0 auto 10%;
+  grid-template-columns: 0 auto 10%;
 }
 
 .question_item {
-    grid-column: 2;
-    word-wrap: break-word;
+  grid-column: 2;
+  word-wrap: break-word;
 }
 
 .question_menu {
-    position: relative;
-    cursor: pointer;
+  position: relative;
+  cursor: pointer;
 }
 
 .question_menu_overlay {
-    display: grid;
-    position: absolute;
+  display: grid;
+  position: absolute;
 
-    z-index: 2;
-    right: 0;
+  z-index: 2;
+  right: 0;
 
-    background: #FFFFFF;
+  background: #ffffff;
 
-    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 14px;
+  font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 14px;
 
-    border: solid 0.5px lightgrey;
-    border-radius: 2px;
-    box-shadow: 0 1px 16px rgba(0,0,0,.1);
+  border: solid 0.5px lightgrey;
+  border-radius: 2px;
+  box-shadow: 0 1px 16px rgba(0, 0, 0, 0.1);
 
-    grid-template-columns: 20% 200px 20%;
+  grid-template-columns: 20% 200px 20%;
 
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .question_menu_item {
-    margin: 5px 5px 5px 5px;
-    grid-column: 2;
+  margin: 5px 5px 5px 5px;
+  grid-column: 2;
 }
 
 .answer_item {
-    grid-column: 2;
-    display: grid;
-    grid-template-columns: 22px auto 20px;
-    color: #a4a4a4;
+  grid-column: 2;
+  display: grid;
+  grid-template-columns: 22px auto 20px;
+  color: #a4a4a4;
 }
 
 .answer_delete {
-    visibility: hidden;
+  visibility: hidden;
 }
 
 .answer_item:hover > .answer_delete {
-    visibility: visible;
+  visibility: visible;
 }
 
 .answer_add {
-    visibility: hidden;
+  visibility: hidden;
 }
 
 .answer_item:hover > .answer_add {
-    visibility: visible;
+  visibility: visible;
 }
 
 .answer_feedback {
-    margin: 10px 10px 10px 10px;
-    padding: 20px 20px 20px 20px;
-    word-wrap: break-word;
-    color: #000000;
+  margin: 10px 10px 10px 10px;
+  padding: 20px 20px 20px 20px;
+  word-wrap: break-word;
+  color: #000000;
 }
 
 .grey_bg {
-    background: #F7F7F7;
+  background: #f7f7f7;
 }
 
 .dimgray_bg {
-    background: dimgray;
+  background: dimgray;
 }
 
 .question_buttons {
-    display: grid;
-    cursor: pointer;
-    margin-top: 20px;
+  display: grid;
+  cursor: pointer;
+  margin-top: 20px;
 
-    grid-template-columns: 300px;
+  grid-template-columns: 300px;
 }
 
 .delete {
-    align-items: right;
-    justify-items: right;
+  align-items: right;
+  justify-items: right;
 }
 
 .submit_section {
-    display: grid;
-    grid-template-columns: 160px 160px auto 120px;
-    grid-column-gap: 10px;
-    grid-column: 2;
-    margin-top: 10px;
+  display: grid;
+  grid-template-columns: 160px 160px auto 120px;
+  grid-column-gap: 10px;
+  grid-column: 2;
+  margin-top: 10px;
 
-    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 18px;
+  font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 18px;
 }
 
 .submit > img {
-    margin-left: 10px;
+  margin-left: 10px;
 }
 
 /* TODO(andrew): cleanup */
 .submit {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .tag_delete_btn {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .input_error {
-    border: 1px solid #ff0000;
-    background-color: #ffeeee;
+  border: 1px solid #ff0000;
+  background-color: #ffeeee;
 }
 
 .error {
-    background-color: #ffeeee;
-    font-size: 15px;
-    font-style: italic;
-    font-weight: 300;
+  background-color: #ffeeee;
+  font-size: 15px;
+  font-style: italic;
+  font-weight: 300;
 }
 
 .chars_remaining {
-    margin-top: 10px;
-    font-size: 15px;
-    font-style: italic;
+  margin-top: 10px;
+  font-size: 15px;
+  font-style: italic;
 }
 
 .text_dates {
-    display: grid;
-    grid-column: 1;
-    grid-template-columns: auto;
+  display: grid;
+  grid-column: 1;
+  grid-template-columns: auto;
 
-    font-size: 13px;
+  font-size: 13px;
 
-    margin-top: 25px;
+  margin-top: 25px;
 }
 
 .answer_note {
-    font-style: italic;
-    font-size: 14px;
+  font-style: italic;
+  font-size: 14px;
 }
 
-.word_instance  {
-    grid-row: 2;
-    grid-column: 2;
+.word_instance {
+  grid-row: 2;
+  grid-column: 2;
 
-    display: grid;
+  display: grid;
 
-    margin: 5px;
+  margin: 5px;
 }
 
 .word_instance > .word {
-    margin: 5px 0 25px 0;
-    font-size: larger;
+  margin: 5px 0 25px 0;
+  font-size: larger;
 }
 
 .translations {
-    display: grid;
+  display: grid;
 
-    grid-template-columns: auto;
+  grid-template-columns: auto;
 }
 
 .translation {
-    display: grid;
+  display: grid;
 
-    grid-template-columns: 1fr min-content;
+  grid-template-columns: 1fr min-content;
 
-    margin-top: 5px;
-    cursor: pointer;
+  margin-top: 5px;
+  cursor: pointer;
 }
 
 .correct_checkmark {
-    margin-left: 5px;
+  margin-left: 5px;
 }
 
 .grammemes {
-    margin-top: 15px;
+  margin-top: 15px;
 }
 
 .word_phrase {
-    display: inline-block;
-    font-weight: bolder;
-    margin-bottom: 5px;
+  display: inline-block;
+  font-weight: bolder;
+  margin-bottom: 5px;
 }
 
 .word > .grammemes {
-    display: grid;
-    font-size: smaller;
+  display: grid;
+  font-size: smaller;
 }
 
 .grammemes > .add {
-    display: grid;
+  display: grid;
 
-    grid-template-columns: 70px 1fr 1fr;
-    grid-column-gap: 2px;
+  /* grid-template-columns: 70px 1fr 1fr; */
+  grid-template-columns: 70px auto 1fr;
+  grid-column-gap: 2px;
 
-    margin-top: 15px;
+  margin-top: 15px;
 }
 
 #translations_tab {
-    background: #f9f9f9;
-    padding: 15px 15px 15px 15px;
+  background: #f9f9f9;
+  padding: 15px 15px 15px 15px;
 
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    hyphens: auto;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  hyphens: auto;
 }
 
 .add_translation {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    margin-top: 5px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  /* grid-template-columns: 1fr 1fr; */
+  margin-top: 5px;
 }
 
 .add_as_text_word {
-    display: grid;
-    grid-template-columns: 1fr 10%;
+  display: grid;
+  grid-template-columns: 1fr 10%;
 
-    margin-top: 5px;
-    font-size: large;
+  margin-top: 5px;
+  font-size: large;
 }
 
 .translation_delete {
-    visibility: hidden;
+  visibility: hidden;
 }
 
 .translation .icons {
-    display: grid;
+  display: grid;
 
-    grid-template-columns: 1fr 1fr;
-    grid-column-gap: 5px;
+  grid-template-columns: 1fr 1fr;
+  grid-column-gap: 5px;
 
-    align-items: center;
+  align-items: center;
 }
 
 .translation:hover > div > .translation_delete {
-    visibility: visible;
+  visibility: visible;
 }
 
 .text_section {
-    grid-column: 2;
+  grid-column: 2;
 }
 
 .edit_overlay {
-    display: inline-block;
-    position: relative;
+  display: inline-block;
+  position: relative;
 }
 
 .edit_menu {
-    display: grid;
-    position: absolute;
-    top: 17px;
-    left: -145px;
+  display: grid;
+  position: absolute;
+  top: 17px;
+  left: -145px;
 
-    grid-template-columns: 10px auto 10px;
-    grid-template-rows: 10px auto auto;
+  grid-template-columns: 10px auto 10px;
+  grid-template-rows: 10px auto auto;
 
-    margin-top: 5px;
+  margin-top: 5px;
 
-    z-index: 1;
-    min-width: 250px;
+  z-index: 1;
+  min-width: 250px;
 
-    background: #FFFFFF;
+  background: #ffffff;
 
-    font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 14px;
+  font-family: proxima-nova, proxima-nova-1, proxima-nova-2, HelveticaNeue,
+    'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 14px;
 
-    padding: 5px;
+  padding: 5px;
 
-    border: solid 0.5px lightgrey;
-    border-radius: 2px;
-    box-shadow: 0 1px 16px rgba(0,0,0,.1);
+  border: solid 0.5px lightgrey;
+  border-radius: 2px;
+  box-shadow: 0 1px 16px rgba(0, 0, 0, 0.1);
 
-    cursor: unset;
+  cursor: unset;
 }
 
 .edit_overlay:after {
-    position: absolute;
-    content: '';
-    left: -30px;
-    top: 11.5px;
-    width: 20px;
-    height: 20px;
-    background-color: #FFFFFF;
-    z-index: 1;
-    transform: rotate(45deg);
-    border-top: solid 0.5px lightgrey;
-    border-left: solid 0.5px lightgrey;
+  position: absolute;
+  content: '';
+  left: -30px;
+  top: 11.5px;
+  width: 20px;
+  height: 20px;
+  background-color: #ffffff;
+  z-index: 1;
+  transform: rotate(45deg);
+  border-top: solid 0.5px lightgrey;
+  border-left: solid 0.5px lightgrey;
 }
 
 .edit_overlay_close_btn {
-    grid-row: 1;
-    grid-column: 3;
+  grid-row: 1;
+  grid-column: 3;
 }
 
 .text_word_options {
-    grid-column: 2;
-    grid-row: 3;
+  grid-column: 2;
+  grid-row: 3;
 
-    display: grid;
+  display: grid;
 
-    grid-template-columns: auto auto auto;
-    grid-template-rows: min-content;
+  grid-template-columns: auto auto auto;
+  grid-template-rows: min-content;
 
-    grid-column-gap: 5px;
+  grid-column-gap: 5px;
 
-    margin-bottom: 10px;
-    margin-top: 10px;
+  margin-bottom: 10px;
+  margin-top: 10px;
 }
 
 .text-word-option {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    grid-template-rows: 1fr 1fr 1fr;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
 
-    max-height: 20px;
-    font-weight: 400;
-    white-space: nowrap;
+  max-height: 20px;
+  font-weight: 400;
+  white-space: nowrap;
 }
 
 .text-word-option > div {
-    grid-column: 2;
-    grid-row: 2;
+  grid-column: 2;
+  grid-row: 2;
 
-    border: solid 1px black;
-    padding: 5px;
+  border: solid 1px black;
+  padding: 5px;
 }
 
 .merge_words {
-    font-weight: 400;
+  font-weight: 400;
 }
 
 .merge-highlight {
-    background: lightblue;
+  background: lightblue;
+}
+
+/* Handle CSS cascades from upgrade*/
+.text-translation-input {
+  width: 100%;
+}
+
+.add > select {
+  width: 100%;
+}
+
+.translations {
+  border: none;
+  padding: none;
+}
+
+.edit-translations-icon {
+  padding-left: 10px;
+}
+
+.edit-text-section {
+  grid-template-columns: 1fr;
+  margin: 25px 0 0 0;
+  border: none;
+}
+
+#text_attributes {
+  padding-bottom: 35px;
 }

--- a/web/src/Pages/Text/Edit/Id_Int.elm
+++ b/web/src/Pages/Text/Edit/Id_Int.elm
@@ -67,6 +67,7 @@ type SafeModel
     = SafeModel
         { session : Session
         , config : Config
+        , id : Int
         , mode : Mode
         , profile : InstructorProfile
         , successMessage : Maybe String
@@ -86,6 +87,7 @@ init shared { params } =
     ( SafeModel
         { session = shared.session
         , config = shared.config
+        , id = params.id
 
         -- the writeLocker is a instructor username string,
         -- and we don't know who it is until we retrieve the text
@@ -727,7 +729,7 @@ view (SafeModel model) =
             , onTextTranslationMsg = TextTranslationMsg
             }
     in
-    { title = "Create Text"
+    { title = "Edit Text | " ++ String.fromInt model.id
     , body =
         [ div []
             [ viewMessages (SafeModel model)

--- a/web/src/Text/Section/View.elm
+++ b/web/src/Text/Section/View.elm
@@ -90,7 +90,7 @@ view_text_section_component msg text_difficulties answer_feedback_limit text_sec
             , field = field
             }
     in
-    [ div [ attribute "class" "text" ] <|
+    [ div [ classList [ ( "text", True ), ( "edit-text-section", True ) ] ] <|
         [ -- text attributes
           div [ classList [ ( "text_properties", True ) ] ]
             [ div [ classList [ ( "body", True ) ] ]

--- a/web/src/Text/Section/Words/Tag.elm
+++ b/web/src/Text/Section/Words/Tag.elm
@@ -10,6 +10,7 @@ import Dict exposing (Dict)
 import Html exposing (Html)
 import Html.Attributes
 import Html.Parser
+import Html.Parser.Util
 import Regex
 
 

--- a/web/src/Text/View.elm
+++ b/web/src/Text/View.elm
@@ -86,7 +86,6 @@ view_text_title params messages edit_view text_title =
             Text.Field.text_title_attrs text_title
     in
     div
-        -- [ onClick (ToggleEditable (Title text_title) True)
         [ onClick (messages.onToggleEditable (Title text_title) True)
         , attribute "id" text_title_attrs.id
         , classList [ ( "input_error", text_title_attrs.error ) ]
@@ -130,11 +129,7 @@ edit_text_title params messages text_title =
         [ attribute "id" text_title_attrs.input_id
         , attribute "type" "text"
         , attribute "value" params.text.title
-
-        -- , onInput (UpdateTextAttributes "title")
         , onInput (messages.onUpdateTextAttributes "title")
-
-        -- , onBlur (ToggleEditable (Title text_title) False)
         , onBlur (messages.onToggleEditable (Title text_title) False)
         ]
         []
@@ -160,8 +155,6 @@ view_text_conclusion params onUpdateTextAttributes text_conclusion =
             [ textarea
                 [ attribute "id" text_conclusion_attrs.input_id
                 , classList [ ( "text_conclusion", True ), ( "input_error", text_conclusion_attrs.error ) ]
-
-                -- , onInput (UpdateTextAttributes "conclusion")
                 , onInput (onUpdateTextAttributes "conclusion")
                 ]
                 [ Html.text (Maybe.withDefault "" params.text.conclusion) ]
@@ -224,8 +217,6 @@ edit_text_introduction params onUpdateTextAttributes text_intro =
         [ textarea
             [ attribute "id" text_intro_attrs.input_id
             , classList [ ( "text_introduction", True ), ( "input_error", text_intro_attrs.error ) ]
-
-            -- , onInput (UpdateTextAttributes "introduction")
             , onInput (onUpdateTextAttributes "introduction")
             ]
             [ Html.text params.text.introduction ]
@@ -249,7 +240,6 @@ view_edit_text_tags params onAddTagInput onDeleteTag text_tags =
         tag_attrs =
             Text.Field.text_tags_attrs text_tags
     in
-    -- Text.Tags.View.view_tags "add_tag" tag_list tags ( onInput (AddTagInput "add_tag"), DeleteTag ) tag_attrs
     Text.Tags.View.view_tags "add_tag" tag_list tags ( onInput (onAddTagInput "add_tag"), onDeleteTag ) tag_attrs
 
 
@@ -275,8 +265,6 @@ view_edit_text_lock params onToggleLock =
             [ attribute "id" "lock_box"
             , classList
                 [ ( "dimgray_bg", write_locked ) ]
-
-            -- , onClick ToggleLock
             , onClick onToggleLock
             ]
             [ div
@@ -344,8 +332,6 @@ view_author params messages editAuthor text_author =
             div
                 [ attribute "id" text_author_attrs.id
                 , attribute "class" "editable"
-
-                -- , onClick (ToggleEditable (Author text_author) True)
                 , onClick (messages.onToggleEditable (Author text_author) True)
                 ]
                 [ div [] [ Html.text params.text.author ]
@@ -377,11 +363,7 @@ edit_author params messages text_author =
         , attribute "value" params.text.author
         , attribute "id" text_author_attrs.input_id
         , classList [ ( "input_error", text_author_attrs.error ) ]
-
-        -- , onInput (UpdateTextAttributes "author")
         , onInput (messages.onUpdateTextAttributes "author")
-
-        -- , onBlur (ToggleEditable (Author text_author) False)
         , onBlur (messages.onToggleEditable (Author text_author) False)
         ]
         [ Html.text params.text.author ]
@@ -396,7 +378,6 @@ edit_difficulty params onUpdateTextAttributes text_difficulty =
     div [ attribute "class" "text_property" ]
         [ div [] [ Html.text "Text Difficulty" ]
         , Html.select
-            -- [ onInput (UpdateTextAttributes "difficulty")
             [ onInput (onUpdateTextAttributes "difficulty")
             ]
             [ Html.optgroup []
@@ -451,7 +432,6 @@ view_source params messages edit_view text_source =
 
     else
         div
-            -- [ onClick (ToggleEditable (Source text_source) True)
             [ onClick (messages.onToggleEditable (Source text_source) True)
             , classList [ ( "text_property", True ), ( "input_error", text_source_attrs.error ) ]
             ]
@@ -488,11 +468,7 @@ edit_source params messages text_source =
             [ attribute "id" text_source_attrs.input_id
             , attribute "type" "text"
             , attribute "value" params.text.source
-
-            -- , onInput (UpdateTextAttributes "source")
             , onInput (messages.onUpdateTextAttributes "source")
-
-            -- , onBlur (ToggleEditable (Source text_source) False)
             , onBlur (messages.onToggleEditable (Source text_source) False)
             ]
             []
@@ -565,7 +541,6 @@ view_submit :
     -> Html msg
 view_submit messages =
     div [ classList [ ( "submit_section", True ) ] ]
-        -- [ div [ attribute "class" "submit", onClick (TextComponentMsg Text.Update.AddTextSection) ]
         [ div [ attribute "class" "submit", onClick (messages.onTextComponentMsg Text.Update.AddTextSection) ]
             [ Html.img
                 [ attribute "src" "/public/img/add_text_section.svg"
@@ -575,8 +550,6 @@ view_submit messages =
                 []
             , Html.text "Add Text Section"
             ]
-
-        -- , div [ attribute "class" "submit", onClick DeleteText ]
         , div [ attribute "class" "submit", onClick messages.onDeleteText ]
             [ Html.text "Delete Text"
             , Html.img
@@ -587,8 +560,6 @@ view_submit messages =
                 []
             ]
         , div [] []
-
-        -- , div [ attribute "class" "submit", onClick SubmitText ]
         , div [ attribute "class" "submit", onClick messages.onSubmitText ]
             [ Html.img
                 [ attribute "src" "/public/img/save_disk.svg"
@@ -607,12 +578,9 @@ view_tab_menu :
     -> Html msg
 view_tab_menu params onToggleTab =
     div [ attribute "id" "tabs_menu" ]
-        -- [ div [ classList [ ( "selected", params.selected_tab == TextTab ) ], onClick (ToggleTab TextTab) ]
         [ div [ classList [ ( "selected", params.selected_tab == TextTab ) ], onClick (onToggleTab TextTab) ]
             [ Html.text "Text"
             ]
-
-        -- , div [ classList [ ( "selected", params.selected_tab == TranslationsTab ) ], onClick (ToggleTab TranslationsTab) ]
         , div [ classList [ ( "selected", params.selected_tab == TranslationsTab ) ], onClick (onToggleTab TranslationsTab) ]
             [ Html.text "Translations"
             ]
@@ -642,8 +610,6 @@ view_text_tab params messages answer_feedback_limit =
             , onAddTagInput = messages.onAddTagInput
             , onDeleteTag = messages.onDeleteTag
             }
-
-        -- , Text.Section.View.view_text_section_components TextComponentMsg
         , Text.Section.View.view_text_section_components messages.onTextComponentMsg
             (Text.Component.text_section_components params.text_component)
             answer_feedback_limit
@@ -669,7 +635,6 @@ view_translations_tab :
     -> Html msg
 view_translations_tab params onTextTranslationMsg =
     Text.Translations.View.view_translations
-        -- params.text_translation_msg
         onTextTranslationMsg
         params.text_translations_model
 
@@ -695,7 +660,6 @@ view_tab_contents params messages onTextTranslationMsg answer_feedback_limit =
             view_text_tab params messages answer_feedback_limit
 
         TranslationsTab ->
-            -- view_translations_tab params
             view_translations_tab params onTextTranslationMsg
 
 
@@ -717,7 +681,6 @@ view_text :
     -> Html msg
 view_text params messages answer_feedback_limit =
     div [ attribute "id" "tabs" ]
-        -- [ view_tab_menu params
         [ view_tab_menu params messages.onToggleTab
         , div [ attribute "id" "tabs_contents" ]
             [ view_tab_contents params

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -8,6 +8,7 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <main></main>
+    <script src="https://cdn.ckeditor.com/4.15.0/standard/ckeditor.js"></script>
     <script src="./index.ts"></script>
     <link rel="stylesheet" href="../public/css/ereader.css">
     <link rel="stylesheet" href="../public/css/ereader-unauth.css">
@@ -24,6 +25,5 @@
     <link rel="stylesheet" href="../public/css/text.css">
     <link rel="stylesheet" href="../public/css/text_search.css">
     <link rel="stylesheet" href="../public/css/create_text.css">
-    <script src="https://cdn.ckeditor.com/4.15.0/standard/ckeditor.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR adds missing functionality to the create and edit text pages and fixes a couple of issues:

- The translations should display when the Translations tab is selected and words can be selected to edit their translations (they cannot be edited yet, this will follow after #200)
- The styling in the page should match the production page more or less with a few minor improvements to the edit translations modal
- The text ID should display as a title in the browser tab