### PR TITLE
Fix broken link and broken styles

### DIFF
--- a/web/public/css/instructor_profile.css
+++ b/web/public/css/instructor_profile.css
@@ -1,48 +1,79 @@
-.text {
-    display: grid;
+.instructor-profile-text {
+  display: grid;
 
-    grid-template-columns: 50% 50%;
-    margin: 5px;
-    padding: 5px 25px 0 15px;
+  grid-template-columns: 50% 50%;
+  margin-bottom: 10px;
+  padding: 5px 25px 0 15px;
 
-    border: solid 0.5px lightgrey;
+  border: solid 0.5px lightgrey;
 }
 
-.text > div {
-    margin: 2px 0 7px 0;
+.instructor-profile-text > div {
+  margin: 2px 0 7px 0;
 }
 
 .invites {
-    grid-column: 1;
+  grid-template-columns: auto;
+  grid-template-rows: 25px 35px;
 
-    grid-template-columns: auto;
-    grid-template-rows: 25px 35px;
-
-    margin-bottom: 15px;
+  margin-bottom: 15px;
 }
 
 .invite {
-    margin-top: 15px;
+  margin-top: 15px;
 }
 
 .invite > .label {
-    margin-top: 5px;
+  margin-top: 5px;
 }
 
 .invite > .value {
-    font-size: larger;
+  font-size: larger;
 }
 
 #create_invite {
-    margin-top: 15px;
+  /* margin-top: 15px; */
 }
 
 #create_invite > #submit {
-    margin-top: 5px;
+  margin-top: 5px;
 }
 
 .invites > .profile_item_value > .list {
-    display: grid;
+  display: grid;
 
-    grid-template-columns: auto;
+  grid-template-columns: auto;
+}
+
+.instructor-profile-items {
+  display: grid;
+  grid-column: content;
+
+  padding: 25px;
+  margin-top: 30px;
+
+  grid-template-columns: 50% 50%;
+  grid-template-rows: 1fr auto;
+
+  border: solid 0.5px lightgrey;
+
+  grid-row-gap: 35px;
+  grid-column-gap: 10px;
+}
+
+.instructor-profile-texts {
+  display: grid;
+
+  grid-template-columns: auto;
+  margin-bottom: 15px;
+}
+
+@media only screen and (min-device-width: 320px) and (max-device-width: 768px) {
+  .instructor-profile-items {
+    display: flex;
+    flex-direction: column;
+
+    margin-top: 15px;
+    grid-template-columns: 50% 50%;
+  }
 }

--- a/web/src/Pages/Profile/Instructor.elm
+++ b/web/src/Pages/Profile/Instructor.elm
@@ -61,14 +61,6 @@ type SafeModel
         }
 
 
-
--- type alias Flags =
---     Flags.AuthedFlags
---         { instructor_invite_uri : String
---         , instructorProfile : InstructorProfile.InstructorProfileParams
---         }
-
-
 init : Shared.Model -> Url Params -> ( SafeModel, Cmd Msg )
 init shared { params } =
     ( SafeModel
@@ -190,19 +182,20 @@ view (SafeModel model) =
 viewContent : SafeModel -> Html Msg
 viewContent (SafeModel model) =
     div [ classList [ ( "profile", True ) ] ]
-        [ div [ classList [ ( "profile_items", True ) ] ] <|
-            [ div [ class "profile_item" ]
+        [ div [ classList [ ( "instructor-profile-items", True ) ] ] <|
+            [ div [ class "profile_item" ] <|
                 [ span [ class "profile_item_title" ] [ Html.text "Username" ]
                 , span [ class "profile_item_value" ]
                     [ Html.text (InstructorProfile.usernameToString (InstructorProfile.username model.profile))
                     ]
                 ]
-            , div [ class "profile_item" ]
-                [ span [ class "profile_item_title" ] [ Html.text "Texts" ]
-                , span [ class "profile_item_value" ] [ viewTexts (SafeModel model) ]
-                ]
             ]
                 ++ viewInstructorInvites (SafeModel model)
+                ++ [ div [ class "instructor-profile-texts" ]
+                        [ span [ class "profile_item_title" ] [ Html.text "Texts" ]
+                        , span [ class "profile_item_value" ] [ viewTexts (SafeModel model) ]
+                        ]
+                   ]
         ]
 
 
@@ -217,7 +210,7 @@ viewText instructorProfile text =
         instructorUsername =
             InstructorProfile.usernameToString (InstructorProfile.username instructorProfile)
     in
-    div [ class "text" ]
+    div [ class "instructor-profile-text" ]
         [ div [ class "text_label" ] [ Html.text "Title" ]
         , div [ class "text_value" ] [ Html.text text.title ]
         , div [ class "text_label" ] [ Html.text "Difficulty" ]
@@ -234,7 +227,11 @@ viewText instructorProfile text =
             ]
         , div [ class "text_label" ] [ Html.text "Tags" ]
         , div [ class "text_value" ] (viewTags text.tags)
-        , div [ class "text_label" ] [ Html.a [ attribute "href" text.edit_uri ] [ Html.text "Edit Text" ] ]
+        , div [ class "text_label" ]
+            [ Html.a
+                [ attribute "href" (Route.toString (Route.Text__Edit__Id_Int { id = text.id })) ]
+                [ Html.text "Edit Text" ]
+            ]
         , div [] []
         ]
 
@@ -251,7 +248,7 @@ viewInstructorInvites (SafeModel model) =
             invites =
                 Maybe.withDefault [] (InstructorProfile.invites model.profile)
         in
-        [ div [ class "invites" ]
+        [ div [ class "profile_item invites" ]
             [ span [ class "profile_item_title" ] [ Html.text "Invitations" ]
             , span [ class "profile_item_value" ]
                 [ div [ class "list" ] <|


### PR DESCRIPTION
This PR includes a couple of small fixes to the texts displayed in an instructor profile. Texts created by an instructor should be displayed as a list of cards. Each text should have a link to navigate to it.

The styling was updated a bit from the original styling to place the text below the other profile items. The list can get long and the styles were broken in these cases.