### PR TITLE
Upgrade/elm spa add public pages

### DIFF
--- a/web/public/css/user.css
+++ b/web/public/css/user.css
@@ -39,7 +39,7 @@ input {
 .login_label,
 .signup_label {
   display: inline-block;
-  padding-top: 15px;
+  padding-top: 20px;
   -webkit-padding-before: 2.5%;
 }
 

--- a/web/public/css/user.css
+++ b/web/public/css/user.css
@@ -43,6 +43,12 @@ input {
   -webkit-padding-before: 2.5%;
 }
 
+.validation-error {
+  display: inline-block;
+  padding-top: 5px;
+  -webkit-padding-before: 0.5%;
+}
+
 .signup_submit,
 .login_submit {
   display: grid;

--- a/web/public/css/user.css
+++ b/web/public/css/user.css
@@ -1,156 +1,185 @@
-.help_msgs, .button, .signup_submit, select, input {
-    width: 60%;
+.help_msgs,
+.button,
+.signup_submit,
+select,
+input {
+  width: 60%;
 }
 
-.login, .signup {
-    display: grid;
+.login,
+.signup {
+  display: grid;
 
-    grid-auto-rows: minmax(65px, auto);
+  grid-auto-rows: minmax(65px, auto);
 
-    margin-bottom: 0;
-    grid-template-columns: 7% 13% [content] auto 13% 7%;
+  margin-bottom: 0;
+  grid-template-columns: 7% 13% [content] auto 13% 7%;
 }
 
-.login_box, .signup_box {
-    grid-column: content;
-    display: grid;
+.login_box,
+.signup_box {
+  grid-column: content;
+  display: grid;
 
-    grid-template-columns: auto;
-    grid-auto-rows: minmax(50px, auto);
+  grid-template-columns: auto;
+  grid-auto-rows: minmax(50px, auto);
 }
 
 .login_options {
-    display: grid;
+  display: grid;
 
-    margin: 15px 0 15px 0;
+  margin: 15px 0 15px 0;
 }
 
 .login_type {
-    grid-column: content;
-    font-size: x-large;
+  grid-column: content;
+  font-size: x-large;
 }
 
-.login_label, .signup_label {
-    display: inline-block;
-    padding-top: 15px;
-    -webkit-padding-before: 2.5%;
+.login_label,
+.signup_label {
+  display: inline-block;
+  padding-top: 15px;
+  -webkit-padding-before: 2.5%;
 }
 
-.signup_submit, .login_submit {
-    display: grid;
-    justify-content: center;
+.signup_submit,
+.login_submit {
+  display: grid;
+  justify-content: center;
 }
 
 .cursor {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .signup_title {
-    grid-column: content;
-    font-size: x-large;
+  grid-column: content;
+  font-size: x-large;
 }
 
 .input_error {
-    border: 1px solid #ff0000;
-    background-color: #ffeeee;
+  border: 1px solid #ff0000;
+  background-color: #ffeeee;
 }
 
 select {
-   border: 0;
-   border-radius: 0;
+  border: 0;
+  border-radius: 0;
 }
 
 .errors {
-    display: grid;
+  display: grid;
 }
 
 .help_msgs {
-    margin-top: 5px;
-    font-style: italic;
-    font-size: larger;
+  margin-top: 5px;
+  font-style: italic;
+  font-size: larger;
 }
 
 .welcome_msg {
-    grid-column: content;
-    display: grid;
-    margin-bottom: 10px;
-    font-size: larger;
+  grid-column: content;
+  display: grid;
+  margin-bottom: 10px;
+  font-size: larger;
 }
 
 .welcome_msg > .headline {
-    padding-bottom: 15px;
+  padding-bottom: 15px;
+}
+
+.welcome-msg-text {
+  display: grid;
+
+  grid-column: 1;
+  grid-row: 2;
 }
 
 #acknowledgements-and-about {
-    padding-top: 2%;
+  padding-top: 2%;
 
-    display: grid;
+  display: grid;
 
-    grid-template-columns: 150px 15px;
+  grid-template-columns: 150px 15px;
 
-    grid-column-gap: 2px;
+  grid-column-gap: 2px;
 }
 
-@media only screen and (max-width:768px) {
-    .help_msgs, .button, .signup_submit, select, input {
-        width: 100%;
-    }
+@media only screen and (max-width: 768px) {
+  .help_msgs,
+  .button,
+  .signup_submit,
+  select,
+  input {
+    width: 100%;
+  }
 
-    #header {
-        padding-left: 10px;
-    }
+  #header {
+    padding-left: 10px;
+  }
 
-    select {
-        height: 50px;
-    }
+  select {
+    height: 50px;
+  }
 
-    #lower-menu {
-        margin-top: 0;
-        padding: 0;
-    }
+  #lower-menu {
+    margin-top: 0;
+    padding: 0;
+  }
 
-    .signup_title {
-        font-family: "Open Sans";
-        font-size: 21px;
-    }
+  .signup_title {
+    font-family: 'Open Sans';
+    font-size: 21px;
+  }
 
-    .headline {
-        padding-top: 25px;
-    }
+  .headline {
+    padding-top: 25px;
+  }
 
-    .welcome_msg > .headline {
-        padding-bottom: 0;
-    }
+  .welcome_msg > .headline {
+    padding-bottom: 0;
+  }
 
-    .signup {
-        margin-top: 15px;
-    }
+  .signup {
+    margin-top: 15px;
+  }
 
-    .login, .signup, .login_box, .signup_box {
-        display: flex;
-        flex-direction: column;
+  .login,
+  .signup,
+  .login_box,
+  .signup_box {
+    display: flex;
+    flex-direction: column;
 
-        margin-left: 20px;
-        margin-right: 20px;
-    }
+    margin-left: 20px;
+    margin-right: 20px;
+  }
 
-    .signup_submit {
-        margin-top: 50px;
-    }
+  .signup_submit {
+    margin-top: 50px;
+  }
 
-    .signup_box > input, .login_box > input {
-        height: 45px;
-    }
+  .signup_box > input,
+  .login_box > input {
+    height: 45px;
+  }
 
-    .filter {
-        display: none;
-    }
+  .filter {
+    display: none;
+  }
 
-    .menu {
-        display: flex;
-        flex-wrap: wrap;
+  .menu {
+    display: flex;
+    flex-wrap: wrap;
 
-        align-items: center;
-        justify-items: center;
-    }
+    align-items: center;
+    justify-items: center;
+  }
+}
+
+/* CSS fixes to deal with incorrect styles */
+.signup_submit {
+  width: 100%;
+  padding: 15px 0;
 }

--- a/web/public/css/user_reset_pass.css
+++ b/web/public/css/user_reset_pass.css
@@ -16,6 +16,7 @@
 }
 
 .disabled {
+  cursor: not-allowed;
   color: #e6e6e6;
   background-color: #546c84;
 }

--- a/web/public/css/user_reset_pass.css
+++ b/web/public/css/user_reset_pass.css
@@ -1,17 +1,33 @@
 .login_box {
-    grid-gap: 10px;
+  grid-gap: 10px;
 }
 
-.msg {
-    display: grid;
-    justify-content: center;
+.password-reset-msg {
+  display: grid;
+  /* justify-content: center; */
+
+  grid-column: 1;
+  grid-row: auto;
 }
 
 .login_label {
-    display: grid;
-    justify-content: center;
+  display: grid;
+  /* justify-content: center; */
 }
 
 .disabled {
-    color: darkgrey;
+  color: #e6e6e6;
+  background-color: #546c84;
+}
+
+.disabled:hover {
+  background-color: #546c84;
+}
+
+.password-reset-show {
+  display: grid;
+  padding-top: 5px;
+  justify-content: left;
+
+  grid-template-columns: 20px 100px;
 }

--- a/web/src/Api/Endpoint.elm
+++ b/web/src/Api/Endpoint.elm
@@ -76,12 +76,12 @@ request config =
 
 forgotPassword : String -> Endpoint
 forgotPassword baseUrl =
-    url baseUrl [ "password", "reset" ] []
+    url baseUrl [ "api", "password", "reset" ] []
 
 
 resetPassword : String -> Endpoint
 resetPassword baseUrl =
-    url baseUrl [ "password", "reset", "confirm" ] []
+    url baseUrl [ "api", "password", "reset", "confirm" ] []
 
 
 instructorSignup : String -> Endpoint

--- a/web/src/Pages/Login/Instructor.elm
+++ b/web/src/Pages/Login/Instructor.elm
@@ -124,7 +124,8 @@ viewContent : Model -> Html Msg
 viewContent model =
     div [ classList [ ( "login", True ) ] ]
         [ Login.viewLoginForm
-            { onEmailUpdate = UpdateEmail
+            { loginParams = model.loginParams
+            , onEmailUpdate = UpdateEmail
             , onPasswordUpdate = UpdatePassword
             , onSubmittedForm = SubmittedLogin
             , signUpRoute = Route.Signup__Instructor

--- a/web/src/Pages/Login/Instructor.elm
+++ b/web/src/Pages/Login/Instructor.elm
@@ -9,6 +9,7 @@ import Dict exposing (Dict)
 import Html exposing (..)
 import Html.Attributes exposing (classList)
 import Http exposing (..)
+import Ports
 import Role exposing (Role(..))
 import Shared
 import Spa.Document exposing (Document)
@@ -53,7 +54,10 @@ init shared { params } =
       , loginParams = LoginParams "" "" "instructor"
       , errors = Dict.fromList []
       }
-    , Cmd.none
+    , Cmd.batch
+        [ Ports.clearInputText "email-input"
+        , Ports.clearInputText "password-input"
+        ]
     )
 
 

--- a/web/src/Pages/Signup/Instructor.elm
+++ b/web/src/Pages/Signup/Instructor.elm
@@ -264,7 +264,7 @@ viewInviteCodeInput model =
             Dict.member "invite_code" model.errors
 
         err_msg =
-            [ SignUp.signupLabel
+            [ SignUp.validationError
                 (Html.em [] [ Html.text (Maybe.withDefault "" (Dict.get "invite_code" model.errors)) ])
             ]
     in

--- a/web/src/Pages/Signup/Instructor.elm
+++ b/web/src/Pages/Signup/Instructor.elm
@@ -12,7 +12,7 @@ import Browser.Navigation exposing (Key)
 import Dict exposing (Dict)
 import Html exposing (Html, div)
 import Html.Attributes exposing (attribute, class, classList)
-import Html.Events exposing (onInput)
+import Html.Events exposing (onClick, onInput)
 import Http exposing (..)
 import Json.Decode
 import Json.Decode.Pipeline exposing (required)
@@ -21,6 +21,7 @@ import Menu.Msg as MenuMsg
 import Session exposing (Session)
 import Shared
 import Spa.Document exposing (Document)
+import Spa.Generated.Route as Route
 import Spa.Page as Page exposing (Page)
 import Spa.Url exposing (Url)
 import User.SignUp as SignUp
@@ -131,7 +132,7 @@ update msg model =
 
         Submitted (Ok resp) ->
             ( model
-            , Browser.Navigation.replaceUrl model.navKey (SignUp.uriToString (SignUp.redirectURI resp.redirect))
+            , Browser.Navigation.replaceUrl model.navKey (Route.toString Route.Login__Instructor)
             )
 
         Submitted (Err err) ->
@@ -230,7 +231,25 @@ view model =
                     SignUp.view_email_input UpdateEmail model
                         ++ SignUp.view_password_input ( ToggleShowPassword, UpdatePassword, UpdateConfirmPassword ) model
                         ++ viewInviteCodeInput model
-                        ++ SignUp.view_submit Submit model
+                        ++ [ Html.div
+                                [ attribute "class" "signup_label" ]
+                                [ if
+                                    not (Dict.isEmpty model.errors)
+                                        || String.isEmpty model.signup_params.email
+                                        || String.isEmpty model.signup_params.password
+                                        || String.isEmpty model.signup_params.confirm_password
+                                        || String.isEmpty model.signup_params.invite_code
+                                  then
+                                    div [ class "button", class "disabled" ]
+                                        [ div [ class "signup_submit" ] [ Html.span [] [ Html.text "Sign Up" ] ]
+                                        ]
+
+                                  else
+                                    div [ class "button", onClick Submit, class "cursor" ]
+                                        [ div [ class "signup_submit" ] [ Html.span [] [ Html.text "Sign Up" ] ]
+                                        ]
+                                ]
+                           ]
                 ]
             , Views.view_footer
             ]

--- a/web/src/Pages/Signup/Student.elm
+++ b/web/src/Pages/Signup/Student.elm
@@ -226,7 +226,7 @@ viewStudentWelcomeMsg =
     in
     div [ class "welcome_msg" ]
         [ span [ class "headline" ] [ Html.text welcomeTitle ]
-        , div [ class "msg" ]
+        , div [ class "welcome-msg-text" ]
             [ Html.p []
                 [ Html.text
                     """The purpose of this site is to help students improve their reading proficiency in Flagship

--- a/web/src/Pages/Top.elm
+++ b/web/src/Pages/Top.elm
@@ -124,7 +124,8 @@ viewContent : Model -> Html Msg
 viewContent model =
     div [ classList [ ( "login", True ) ] ]
         [ Login.viewLoginForm
-            { onEmailUpdate = UpdateEmail
+            { loginParams = model.loginParams
+            , onEmailUpdate = UpdateEmail
             , onPasswordUpdate = UpdatePassword
             , onSubmittedForm = SubmittedLogin
             , signUpRoute = Route.Signup__Student

--- a/web/src/Pages/Top.elm
+++ b/web/src/Pages/Top.elm
@@ -9,6 +9,7 @@ import Dict exposing (Dict)
 import Html exposing (..)
 import Html.Attributes exposing (classList)
 import Http exposing (..)
+import Ports
 import Role exposing (Role(..))
 import Shared
 import Spa.Document exposing (Document)
@@ -53,7 +54,10 @@ init shared { params } =
       , loginParams = LoginParams "" "" "student"
       , errors = Dict.fromList []
       }
-    , Cmd.none
+    , Cmd.batch
+        [ Ports.clearInputText "email-input"
+        , Ports.clearInputText "password-input"
+        ]
     )
 
 

--- a/web/src/Pages/User/ForgotPassword.elm
+++ b/web/src/Pages/User/ForgotPassword.elm
@@ -242,7 +242,7 @@ viewResponse forgotPasswordResponse =
 
 loginLabel : List (Html.Attribute Msg) -> Html Msg -> Html Msg
 loginLabel attributes html =
-    div (attribute "class" "loginLabel" :: attributes)
+    div (attribute "class" "login_label" :: attributes)
         [ html
         ]
 

--- a/web/src/Pages/User/ForgotPassword.elm
+++ b/web/src/Pages/User/ForgotPassword.elm
@@ -175,7 +175,7 @@ viewEmailInput model =
         errorHTML =
             case Dict.get "email" model.errors of
                 Just errMsg ->
-                    loginLabel [] (Html.em [] [ Html.text errMsg ])
+                    validationError (Html.em [] [ Html.text errMsg ])
 
                 Nothing ->
                     Html.text ""
@@ -243,6 +243,13 @@ viewResponse forgotPasswordResponse =
 loginLabel : List (Html.Attribute Msg) -> Html Msg -> Html Msg
 loginLabel attributes html =
     div (attribute "class" "login_label" :: attributes)
+        [ html
+        ]
+
+
+validationError : Html Msg -> Html Msg
+validationError html =
+    div [ class "validation-error" ]
         [ html
         ]
 

--- a/web/src/Pages/User/ForgotPassword.elm
+++ b/web/src/Pages/User/ForgotPassword.elm
@@ -230,7 +230,7 @@ viewErrors model =
 viewResponse : ForgotPassResp -> Html Msg
 viewResponse forgotPasswordResponse =
     if not (String.isEmpty forgotPasswordResponse.body) then
-        div [ class "msg" ]
+        div [ class "password-reset-msg" ]
             [ span [] [ Html.text forgotPasswordResponse.body ]
             ]
 

--- a/web/src/Pages/User/ForgotPassword.elm
+++ b/web/src/Pages/User/ForgotPassword.elm
@@ -10,10 +10,11 @@ import Api.Config as Config exposing (Config)
 import Api.Endpoint as Endpoint
 import Dict exposing (Dict)
 import Html exposing (Html, div, span)
-import Html.Attributes exposing (attribute, class, classList)
+import Html.Attributes exposing (attribute, class, classList, id)
 import Html.Events exposing (onClick, onInput)
 import Http exposing (..)
 import Json.Encode as Encode
+import Ports
 import Session exposing (Session)
 import Shared
 import Spa.Document exposing (Document)
@@ -66,7 +67,7 @@ init shared { params } =
       , resp = ForgotPassword.emptyForgotPassResp
       , errors = Dict.fromList []
       }
-    , Cmd.none
+    , Ports.clearInputText "email-input"
     )
 
 
@@ -188,7 +189,8 @@ viewEmailInput model =
     in
     [ loginLabel [] (span [] [ Html.text "E-mail address:" ])
     , Html.input
-        ([ attribute "size" "25"
+        ([ id "email-input"
+         , attribute "size" "25"
          , onInput UpdateEmail
          ]
             ++ emailError

--- a/web/src/Pages/User/ResetPassword/Uidb64_String/Token_String.elm
+++ b/web/src/Pages/User/ResetPassword/Uidb64_String/Token_String.elm
@@ -218,7 +218,7 @@ viewPasswordInput model =
         errorHTML =
             case Dict.get "password" model.errors of
                 Just err_msg ->
-                    loginLabel [] (Html.em [] [ Html.text err_msg ])
+                    validationError (Html.em [] [ Html.text err_msg ])
 
                 Nothing ->
                     Html.text ""
@@ -257,7 +257,7 @@ viewPasswordConfirmInput model =
         errorHTML =
             case Dict.get "confirmPassword" model.errors of
                 Just errMsg ->
-                    loginLabel [] (Html.em [] [ Html.text errMsg ])
+                    validationError (Html.em [] [ Html.text errMsg ])
 
                 Nothing ->
                     Html.text ""
@@ -305,7 +305,7 @@ viewErrors : Model -> List (Html Msg)
 viewErrors model =
     List.map
         (\( k, v ) ->
-            loginLabel [] (span [ attribute "class" "errors" ] [ Html.em [] [ Html.text v ] ])
+            validationError (span [ attribute "class" "errors" ] [ Html.em [] [ Html.text v ] ])
         )
         (Dict.toList model.errors)
 
@@ -372,6 +372,13 @@ viewSubmit model =
 loginLabel : List (Html.Attribute Msg) -> Html Msg -> Html Msg
 loginLabel attributes html =
     div (attribute "class" "login_label" :: attributes)
+        [ html
+        ]
+
+
+validationError : Html msg -> Html msg
+validationError html =
+    div [ class "validation-error" ]
         [ html
         ]
 

--- a/web/src/Pages/User/ResetPassword/Uidb64_String/Token_String.elm
+++ b/web/src/Pages/User/ResetPassword/Uidb64_String/Token_String.elm
@@ -311,7 +311,7 @@ viewErrors model =
 
 viewShowPasswordToggle : Model -> List (Html Msg)
 viewShowPasswordToggle model =
-    [ span []
+    [ div [ class "password-reset-show" ]
         [ Html.input
             ([ attribute "type" "checkbox", onCheck ToggleShowPassword ]
                 ++ (if model.showPassword then
@@ -322,7 +322,7 @@ viewShowPasswordToggle model =
                    )
             )
             []
-        , Html.text "Show Password"
+        , Html.label [] [ Html.text "Show Password" ]
         ]
     ]
 

--- a/web/src/Pages/User/ResetPassword/Uidb64_String/Token_String.elm
+++ b/web/src/Pages/User/ResetPassword/Uidb64_String/Token_String.elm
@@ -5,6 +5,7 @@ module Pages.User.ResetPassword.Uidb64_String.Token_String exposing
     , page
     )
 
+import Answer.Field exposing (attributes)
 import Api exposing (post)
 import Api.Config as Config exposing (Config)
 import Api.Endpoint as Endpoint
@@ -346,9 +347,26 @@ viewSubmit model =
             else
                 [ onClick Submit, class "cursor" ]
     in
-    [ loginLabel (class "button" :: buttonDisabled)
-        (div [ class "login_submit" ] [ span [] [ Html.text "Change Password" ] ])
-    ]
+    if hasError || emptyPasswords || not passwordsMatch then
+        [ div
+            [ classList
+                [ ( "button", True )
+                , ( "disabled", True )
+                ]
+            ]
+            [ div [ class "login_submit" ] [ span [] [ Html.text "Change Password" ] ] ]
+        ]
+
+    else
+        [ div
+            [ classList
+                [ ( "button", True )
+                , ( "cursor", True )
+                ]
+            , onClick Submit
+            ]
+            [ div [ class "login_submit" ] [ span [] [ Html.text "Change Password" ] ] ]
+        ]
 
 
 loginLabel : List (Html.Attribute Msg) -> Html Msg -> Html Msg

--- a/web/src/User/Login.elm
+++ b/web/src/User/Login.elm
@@ -4,7 +4,7 @@ import Api
 import Dict exposing (Dict)
 import Html exposing (Html, div, span)
 import Html.Attributes exposing (attribute, class, classList, id)
-import Html.Events exposing (onClick, onInput)
+import Html.Events exposing (onClick, onInput, onSubmit)
 import Http exposing (..)
 import Json.Encode as Encode
 import Spa.Generated.Route as Route exposing (Route)
@@ -40,7 +40,8 @@ login loginParams =
 
 
 viewLoginForm :
-    { onEmailUpdate : String -> msg
+    { loginParams : LoginParams
+    , onEmailUpdate : String -> msg
     , onPasswordUpdate : String -> msg
     , onSubmittedForm : msg
     , signUpRoute : Route
@@ -64,7 +65,10 @@ viewLoginForm loginOptions =
                 , otherLoginRole = loginOptions.otherLoginRole
                 , otherLoginRoute = loginOptions.otherLoginRoute
                 }
-            ++ viewSubmit loginOptions.onSubmittedForm
+            ++ viewSubmit
+                { loginParams = loginOptions.loginParams
+                , onSubmittedForm = loginOptions.onSubmittedForm
+                }
             ++ viewHelpMessages loginOptions.maybeHelpMessage
             ++ viewLinks
             ++ viewErrors loginOptions.errors
@@ -194,12 +198,24 @@ viewOtherLoginOption { otherRole, otherRoute } =
 
 
 viewSubmit :
-    msg
+    { loginParams : LoginParams
+    , onSubmittedForm : msg
+    }
     -> List (Html msg)
-viewSubmit onSubmittedForm =
-    [ div [ class "button", onClick onSubmittedForm, class "cursor" ]
-        [ div [ class "login_submit" ] [ span [] [ Html.text "Login" ] ] ]
-    ]
+viewSubmit options =
+    if
+        String.isEmpty options.loginParams.username
+            || String.isEmpty options.loginParams.password
+    then
+        [ div [ class "button", class "disabled" ]
+            [ div [ class "login_submit" ] [ Html.span [] [ Html.text "Login" ] ]
+            ]
+        ]
+
+    else
+        [ div [ class "button", onClick options.onSubmittedForm, class "cursor" ]
+            [ div [ class "login_submit" ] [ span [] [ Html.text "Login" ] ] ]
+        ]
 
 
 viewHelpMessages : Maybe String -> List (Html msg)

--- a/web/src/User/Login.elm
+++ b/web/src/User/Login.elm
@@ -86,7 +86,8 @@ viewEmailInput { onEmailUpdate, errors } =
     in
     [ div [] [ span [] [ Html.text "E-mail Address:" ] ]
     , Html.input
-        ([ attribute "size" "25"
+        ([ id "email-input"
+         , attribute "size" "25"
          , onInput onEmailUpdate
          ]
             ++ emailErrorClass
@@ -127,7 +128,8 @@ viewPasswordInput { onPasswordUpdate, onSubmittedForm, errors } =
     [ div []
         [ span [] [ Html.text "Password:" ] ]
     , Html.input
-        ([ attribute "size" "35"
+        ([ id "password-input"
+         , attribute "size" "35"
          , attribute "type" "password"
          , onInput onPasswordUpdate
          , Utils.onEnterUp onSubmittedForm

--- a/web/src/User/Login.elm
+++ b/web/src/User/Login.elm
@@ -84,7 +84,7 @@ viewEmailInput { onEmailUpdate, errors } =
             else
                 []
     in
-    [ div [] [ span [] [ Html.text "E-mail Address:" ] ]
+    [ div [ class "login_label" ] [ span [] [ Html.text "E-mail Address:" ] ]
     , Html.input
         ([ id "email-input"
          , attribute "size" "25"
@@ -125,7 +125,7 @@ viewPasswordInput { onPasswordUpdate, onSubmittedForm, errors } =
                 Nothing ->
                     Html.text ""
     in
-    [ div []
+    [ div [ class "login_label" ]
         [ span [] [ Html.text "Password:" ] ]
     , Html.input
         ([ id "password-input"

--- a/web/src/User/SignUp.elm
+++ b/web/src/User/SignUp.elm
@@ -200,9 +200,8 @@ view_password_input ( toggle_msg, update_msg, update_confirm_msg ) model =
 view_submit : msg -> a -> List (Html msg)
 view_submit submit_msg model =
     [ signupLabel
-        (Html.span [ class "cursor", class "signup_submit", class "button", onClick submit_msg ]
-            [ Html.text "Sign Up"
-            ]
+        (div [ class "button", onClick submit_msg, class "cursor" ]
+            [ div [ class "signup_submit" ] [ Html.span [] [ Html.text "Sign Up" ] ] ]
         )
     ]
 

--- a/web/src/User/SignUp.elm
+++ b/web/src/User/SignUp.elm
@@ -36,6 +36,13 @@ signupLabel html =
     Html.div [ attribute "class" "signup_label" ] [ html ]
 
 
+validationError : Html msg -> Html msg
+validationError html =
+    div [ class "validation-error" ]
+        [ html
+        ]
+
+
 submit : { b | errors : Dict comparable v } -> { b | errors : Dict comparable v }
 submit model =
     { model | errors = Dict.fromList [] }
@@ -125,7 +132,7 @@ view_email_input update_email_msg model =
         errMsgHTML =
             case Dict.get "email" model.errors of
                 Just errMsg ->
-                    signupLabel (Html.em [] [ Html.text errMsg ])
+                    validationError (Html.em [] [ Html.text errMsg ])
 
                 Nothing ->
                     Html.text ""
@@ -152,7 +159,7 @@ view_password_input ( toggle_msg, update_msg, update_confirm_msg ) model =
         confirm_err_msg =
             case Dict.get "confirm_password" model.errors of
                 Just err_msg ->
-                    signupLabel (Html.em [] [ Html.text err_msg ])
+                    validationError (Html.em [] [ Html.text err_msg ])
 
                 Nothing ->
                     Html.text ""
@@ -160,7 +167,7 @@ view_password_input ( toggle_msg, update_msg, update_confirm_msg ) model =
         password_err_msg =
             case Dict.get "password" model.errors of
                 Just err_msg ->
-                    signupLabel (Html.em [] [ Html.text err_msg ])
+                    validationError (Html.em [] [ Html.text err_msg ])
 
                 Nothing ->
                     Html.text ""

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -63,11 +63,29 @@ app.ports.login.subscribe(async (creds: Creds) => {
     localStorage.setItem(authStoreKey, JSON.stringify(user));
     app.ports.onAuthStoreChange.send(user);
   } else {
-    const errorMessage = jsonResponse.all;
-    if (errorMessage) {
+    const authErrorMessage = jsonResponse.all;
+    const usernameMissingError = jsonResponse.username;
+    const passwordMissingError = jsonResponse.password;
+
+    if (usernameMissingError && passwordMissingError) {
       app.ports.onAuthResponse.send({
         result: 'error',
-        message: errorMessage
+        message: 'E-mail address and password fields are required.'
+      });
+    } else if (usernameMissingError) {
+      app.ports.onAuthResponse.send({
+        result: 'error',
+        message: 'E-mail address field is required.'
+      });
+    } else if (passwordMissingError) {
+      app.ports.onAuthResponse.send({
+        result: 'error',
+        message: 'Password field is required.'
+      });
+    } else if (authErrorMessage) {
+      app.ports.onAuthResponse.send({
+        result: 'error',
+        message: authErrorMessage
       });
     } else {
       app.ports.onAuthResponse.send({


### PR DESCRIPTION
This PR updates styling and validation across public pages. It adds client-side validation disabling buttons when a user has not completed all form fields.

The styling fixes include consistent buttons on all forms and spacing for labels and validation error messages. These should look consistent across the student login, instructor login, student signup, instructor signup, forgot password, and reset password pages.

In addition, a small addition makes sure that all form fields are cleared when navigating between public pages.