### PR TITLE
Add text title or ID to browser tabs

### DIFF
--- a/web/src/Pages/Text/Edit/Id_Int.elm
+++ b/web/src/Pages/Text/Edit/Id_Int.elm
@@ -728,8 +728,16 @@ view (SafeModel model) =
             , onDeleteTag = DeleteTag
             , onTextTranslationMsg = TextTranslationMsg
             }
+
+        title =
+            (Text.Component.text model.text_component).title
     in
-    { title = "Edit Text | " ++ String.fromInt model.id
+    { title =
+        if String.isEmpty title then
+            "Editing"
+
+        else
+            "Editing | " ++ title
     , body =
         [ div []
             [ viewMessages (SafeModel model)

--- a/web/src/Pages/Text/Id_Int.elm
+++ b/web/src/Pages/Text/Id_Int.elm
@@ -73,6 +73,7 @@ type SafeModel
         { session : Session
         , config : Config
         , navKey : Key
+        , id : Int
         , text : Text
         , profile : User.Profile.Profile
         , flashcard : User.Profile.TextReader.Flashcards.ProfileFlashcards
@@ -102,6 +103,7 @@ init shared { params } =
         { session = shared.session
         , config = shared.config
         , navKey = shared.key
+        , id = params.id
         , text = TextReader.Text.Model.emptyText
         , gloss = Dict.empty
         , profile = shared.profile
@@ -393,7 +395,15 @@ textScoresDecoder =
 
 view : SafeModel -> Document Msg
 view (SafeModel model) =
-    { title = "Text"
+    { title = "Reading | " ++ String.fromInt model.id
+
+    {- This would be better, but we need to add title to all websocket
+       responses
+    -}
+    -- if String.isEmpty model.text.title then
+    --     "Reading"
+    -- else
+    --     "Reading | " ++ model.text.title
     , body =
         [ div []
             [ viewContent (SafeModel model)


### PR DESCRIPTION
This PR adds the text title or ID to the browser tab the the text reader and the text edit page. 

Note that we can add the title on the text edit page but not the text reader page at the moment. We could add the title to all websocket messages in the text reader to use the title there as well.