### PR TITLE
Upgrade/csrf errors translation

### DIFF
--- a/text/views/api/tag.py
+++ b/text/views/api/tag.py
@@ -6,10 +6,11 @@ from django.http import HttpResponse, HttpRequest, HttpResponseServerError
 from django.http import HttpResponseNotAllowed
 from django.urls import reverse_lazy
 from ereadingtool.views import APIView
-
 from text.models import Text
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 
-
+@method_decorator(csrf_exempt, name='dispatch') 
 class TextTagAPIView(LoginRequiredMixin, APIView):
     login_url = reverse_lazy('instructor-login')
 

--- a/text/views/api/text_word/group.py
+++ b/text/views/api/text_word/group.py
@@ -6,11 +6,12 @@ from django.db import transaction
 from django.http import HttpResponse, HttpRequest, HttpResponseServerError
 from django.urls import reverse_lazy
 from ereadingtool.views import APIView
-
 from text.translations.group.models import TextWordGroup, TextGroupWord
 from text.translations.models import TextWord
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 
-
+@method_decorator(csrf_exempt, name='dispatch')
 class TextWordGroupAPIView(LoginRequiredMixin, APIView):
     model = TextWordGroup
 

--- a/text/views/api/text_word/word.py
+++ b/text/views/api/text_word/word.py
@@ -1,23 +1,19 @@
 import json
-
 import jsonschema
-
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse, HttpRequest, HttpResponseServerError
 from django.http import HttpResponseNotAllowed
 from django.urls import reverse_lazy
 from ereadingtool.views import APIView
-
 from django.db import transaction, DatabaseError
 from django.core.exceptions import ObjectDoesNotExist
-
 from text.models import TextSection
-
 from text.translations.models import TextWord
-
 from text.phrase.models import TextPhrase, TextPhraseTranslation
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 
-
+@method_decorator(csrf_exempt, name='dispatch')
 class TextWordAPIView(LoginRequiredMixin, APIView):
     login_url = reverse_lazy('instructor-login')
     allowed_methods = ['post', 'put', 'delete']
@@ -83,6 +79,7 @@ class TextWordAPIView(LoginRequiredMixin, APIView):
             return HttpResponseServerError(json.dumps({'errors': 'something went wrong'}))
 
 
+@method_decorator(csrf_exempt, name='dispatch')
 class TextWordTranslationsAPIView(LoginRequiredMixin, APIView):
     login_url = reverse_lazy('instructor-login')
     allowed_methods = ['put', 'post', 'delete']

--- a/text/views/api/translations.py
+++ b/text/views/api/translations.py
@@ -12,7 +12,10 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from text.phrase.models import TextPhrase, TextPhraseTranslation
 
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 
+@method_decorator(csrf_exempt, name='dispatch')
 class TextTranslationMatchAPIView(LoginRequiredMixin, APIView):
     login_url = reverse_lazy('instructor-login')
     allowed_methods = ['put']


### PR DESCRIPTION
Simply added the necessary decorators to classes that inherit from `APIView`. Now they should all give a 200 on their respective route. 

Tested `api/text/word/<int:pk>/translation` by doing the following:

1. Logged in as a content editors
2. Chose to edit a text `text/edit/100` for example
3. Clicked a word
4. Selected the already correct English translation for that word

What was previously a `403` is now a `200`.

E: This aims to solve issue #200 