### PR TITLE
Upgrade/add performance reports

### DIFF
--- a/web/public/css/user_profile.css
+++ b/web/public/css/user_profile.css
@@ -10,6 +10,11 @@ table th {
 table td {
   padding: 5px;
   text-align: center;
+  border: 1px solid #a9a9a9;
+}
+
+table th {
+  border: 1px solid #a9a9a9;
 }
 
 .profile {

--- a/web/src/Api.elm
+++ b/web/src/Api.elm
@@ -10,6 +10,7 @@ port module Api exposing
     , get
     , login
     , logout
+    , performanceReportLink
     , post
     , put
     , toggleShowHelp
@@ -30,6 +31,7 @@ import Id exposing (Id)
 import Json.Decode as Decode exposing (Decoder, Value, field, string)
 import Json.Decode.Pipeline exposing (required)
 import Role exposing (Role)
+import Task exposing (perform)
 import Url exposing (Url)
 
 
@@ -323,6 +325,17 @@ delete url maybeCred body toMsg decoder =
         , timeout = Nothing
         , tracker = Nothing
         }
+
+
+performanceReportLink : String -> Maybe Cred -> Int -> String
+performanceReportLink baseUrl maybeCred id =
+    Endpoint.performanceReportLink baseUrl id <|
+        case maybeCred of
+            Just (Cred cred) ->
+                cred
+
+            Nothing ->
+                ""
 
 
 

--- a/web/src/Api/Endpoint.elm
+++ b/web/src/Api/Endpoint.elm
@@ -11,6 +11,7 @@ module Api.Endpoint exposing
     , inviteInstructor
     , matchTranslation
     , mergeWords
+    , performanceReportLink
     , request
     , resetPassword
     , studentProfile
@@ -25,6 +26,7 @@ module Api.Endpoint exposing
 
 import Http
 import Url.Builder exposing (QueryParameter)
+import User.Student.Performance.Report exposing (performanceReportDecoder)
 
 
 type Endpoint
@@ -215,6 +217,21 @@ matchTranslation baseUrl =
 inviteInstructor : String -> Endpoint
 inviteInstructor baseUrl =
     url baseUrl [ "api", "instructor", "invite" ] []
+
+
+
+-- LINKS
+
+
+performanceReportLink : String -> Int -> String -> String
+performanceReportLink baseUrl id token =
+    Url.Builder.crossOrigin baseUrl
+        [ "profile"
+        , "student"
+        , String.fromInt id
+        , "performance_report.pdf"
+        ]
+        [ Url.Builder.string "token" token ]
 
 
 

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -583,16 +583,15 @@ viewStudentPerformance (SafeModel model) =
                , div [ class "performance_download_link" ]
                     [ Html.a
                         [ attribute "href" <|
-                            Config.restApiUrl model.config
-                                ++ "/profile/student/"
-                                ++ (case StudentProfile.studentID model.profile of
-                                        Just id ->
-                                            String.fromInt id
+                            case StudentProfile.studentID model.profile of
+                                Just id ->
+                                    Api.performanceReportLink
+                                        (Config.restApiUrl model.config)
+                                        (Session.cred model.session)
+                                        id
 
-                                        Nothing ->
-                                            "0"
-                                   )
-                                ++ "/performance_report.pdf"
+                                Nothing ->
+                                    ""
                         ]
                         [ Html.text "Download the \"My Performance\" table as a PDF"
                         ]

--- a/web/src/User/Student/Performance/Report.elm
+++ b/web/src/User/Student/Performance/Report.elm
@@ -1,12 +1,74 @@
-module User.Student.Performance.Report exposing (PerformanceReport, emptyPerformanceReport)
+module User.Student.Performance.Report exposing
+    ( PerformanceMetrics
+    , PerformanceReport
+    , emptyPerformanceReport
+    , metrics
+    , performanceReportDecoder
+    )
+
+import Dict exposing (Dict)
+import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Pipeline exposing (custom, required)
 
 
 type alias PerformanceReport =
-    { html : String
+    { all : Dict String PerformanceMetrics
+    , intermediateMid : Dict String PerformanceMetrics
+    , intermediateHigh : Dict String PerformanceMetrics
+    , advancedLow : Dict String PerformanceMetrics
+    , advancedMid : Dict String PerformanceMetrics
+    }
+
+
+type alias PerformanceMetrics =
+    { percentCorrect : Float
+    , textsComplete : Int
+    , totalTexts : Int
     }
 
 
 emptyPerformanceReport : PerformanceReport
 emptyPerformanceReport =
-    { html = "<div>No results found.</div>"
+    { all = Dict.empty
+    , intermediateMid = Dict.empty
+    , intermediateHigh = Dict.empty
+    , advancedLow = Dict.empty
+    , advancedMid = Dict.empty
     }
+
+
+metrics : String -> Dict String PerformanceMetrics -> PerformanceMetrics
+metrics timePeriod metricsDict =
+    case Dict.get timePeriod metricsDict of
+        Just dict ->
+            dict
+
+        Nothing ->
+            { percentCorrect = 0
+            , textsComplete = 0
+            , totalTexts = 0
+            }
+
+
+
+-- DECODE
+
+
+performanceReportDecoder : Decoder PerformanceReport
+performanceReportDecoder =
+    Decode.succeed PerformanceReport
+        |> custom (Decode.at [ "all", "categories" ] (Decode.dict metricsDecoder))
+        |> custom (Decode.at [ "intermediate_mid", "categories" ] (Decode.dict metricsDecoder))
+        |> custom (Decode.at [ "intermediate_high", "categories" ] (Decode.dict metricsDecoder))
+        |> custom (Decode.at [ "advanced_low", "categories" ] (Decode.dict metricsDecoder))
+        |> custom (Decode.at [ "advanced_mid", "categories" ] (Decode.dict metricsDecoder))
+
+
+metricsDecoder : Decoder PerformanceMetrics
+metricsDecoder =
+    Decode.field "metrics"
+        (Decode.succeed PerformanceMetrics
+            |> required "percent_correct" (Decode.oneOf [ Decode.float, Decode.null 0 ])
+            |> required "texts_complete" Decode.int
+            |> required "total_texts" Decode.int
+        )

--- a/web/src/User/Student/Profile.elm
+++ b/web/src/User/Student/Profile.elm
@@ -22,7 +22,7 @@ import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline exposing (hardcoded, required)
 import Task exposing (perform)
 import Text.Model as Text
-import User.Student.Performance.Report exposing (PerformanceReport)
+import User.Student.Performance.Report as PerformanceReport exposing (PerformanceReport)
 import User.Student.Resource as StudentResource
 import Utils
 
@@ -153,12 +153,6 @@ uriParamsDecoder =
         |> required "profile_uri" Decode.string
 
 
-performanceReportDecoder : Decoder PerformanceReport
-performanceReportDecoder =
-    Decode.succeed PerformanceReport
-        |> required "html" Decode.string
-
-
 paramsDecoder : Decoder StudentProfileParams
 paramsDecoder =
     Decode.succeed StudentProfileParams
@@ -174,4 +168,4 @@ decoder : Decoder StudentProfile
 decoder =
     Decode.map2 initProfile
         (Decode.field "profile" paramsDecoder)
-        (Decode.field "performance_report" performanceReportDecoder)
+        (Decode.field "performance_report" PerformanceReport.performanceReportDecoder)


### PR DESCRIPTION
This PR adds the original performance reports table rendered in Elm. It also add a performance report PDF link that uses the JWT as a querystring to validate the request.

To test this PR, log in as a student and view your performance table and hover over the download link to see the URL.