### PR TITLE
Upgrade/performance report jwt

### DIFF
--- a/auth/normal_auth.py
+++ b/auth/normal_auth.py
@@ -1,0 +1,43 @@
+import os
+import time
+import jwt
+from jwt.exceptions import InvalidTokenError
+from user.student.models import Student
+from user.instructor.models import Instructor
+
+def jwt_validation(scope):
+    """ Take JWT from query string to check the user against the db and validate its timestamp """
+    if not scope['query_string']:
+        return None
+    else:
+        secret_key = os.getenv('DJANGO_SECRET_KEY')
+        try:
+            jwt_decoded = jwt.decode(scope['query_string'], secret_key, algorithms=['HS256'])
+
+            if jwt_decoded['exp'] <= time.time():
+                # then their token has expired 
+                raise InvalidTokenError
+
+            if "student/text_read/" in scope['path']:
+                if not Student.objects.filter(user_id=jwt_decoded['user_id']):
+                    # then there is no user in the QuerySet
+                    raise InvalidTokenError
+                # force evaluation of the QuerySet. We already know it contains at least one element
+                student = list(Student.objects.filter(user_id=jwt_decoded['user_id']))[0]
+
+                # TODO: there may be need to make user an object and have the student object be a member
+                return student.user
+            elif "instructor/text_read/" in scope['path']:
+                if not Instructor.objects.filter(user_id=jwt_decoded['user_id']):
+                     # then there is no user in the QuerySet
+                     raise InvalidTokenError
+                # force evaluation of the QuerySet. We already know it contains at least one element
+                instructor = list(Instructor.objects.filter(user_id=jwt_decoded['user_id']))[0]
+
+                # TODO: there may be need to make user an object and have the student object be a member
+                return instructor.user
+            else:
+                # path error, same result
+                raise InvalidTokenError
+        except InvalidTokenError: 
+            return None

--- a/auth/normal_auth.py
+++ b/auth/normal_auth.py
@@ -12,30 +12,21 @@ def jwt_validation(scope):
     else:
         secret_key = os.getenv('DJANGO_SECRET_KEY')
         try:
-            jwt_decoded = jwt.decode(scope['query_string'], secret_key, algorithms=['HS256'])
+            qs = scope['query_string'][6:] if scope['query_string'][:6] == b'token=' else scope['query_string']
+            jwt_decoded = jwt.decode(qs, secret_key, algorithms=['HS256'])
 
             if jwt_decoded['exp'] <= time.time():
                 # then their token has expired 
                 raise InvalidTokenError
 
-            if "student/text_read/" in scope['path']:
+            if "performance_report.pdf" in scope['path']:
                 if not Student.objects.filter(user_id=jwt_decoded['user_id']):
                     # then there is no user in the QuerySet
                     raise InvalidTokenError
                 # force evaluation of the QuerySet. We already know it contains at least one element
                 student = list(Student.objects.filter(user_id=jwt_decoded['user_id']))[0]
 
-                # TODO: there may be need to make user an object and have the student object be a member
-                return student.user
-            elif "instructor/text_read/" in scope['path']:
-                if not Instructor.objects.filter(user_id=jwt_decoded['user_id']):
-                     # then there is no user in the QuerySet
-                     raise InvalidTokenError
-                # force evaluation of the QuerySet. We already know it contains at least one element
-                instructor = list(Instructor.objects.filter(user_id=jwt_decoded['user_id']))[0]
-
-                # TODO: there may be need to make user an object and have the student object be a member
-                return instructor.user
+                return student
             else:
                 # path error, same result
                 raise InvalidTokenError

--- a/user/views/student_performance.py
+++ b/user/views/student_performance.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 import pdfkit
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.files.base import ContentFile
@@ -8,8 +10,9 @@ from django.views.generic import View
 
 from user.student.models import Student
 
+from auth.normal_auth import jwt_validation
 
-class StudentPerformancePDFView(LoginRequiredMixin, View):
+class StudentPerformancePDFView(View):
 
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         if not Student.objects.filter(pk=kwargs['pk']).exists():
@@ -17,8 +20,11 @@ class StudentPerformancePDFView(LoginRequiredMixin, View):
 
         student = Student.objects.get(pk=kwargs['pk'])
 
-        if student.user != self.request.user:
-            return HttpResponseForbidden()
+        # if student.user != self.request.user:
+            # return HttpResponseForbidden()
+
+        # do the jwt auth here
+        qs = jwt_validation(self.request.scope)
 
         today = dt.now()
 

--- a/user/views/student_performance.py
+++ b/user/views/student_performance.py
@@ -20,11 +20,12 @@ class StudentPerformancePDFView(View):
 
         student = Student.objects.get(pk=kwargs['pk'])
 
-        # if student.user != self.request.user:
-            # return HttpResponseForbidden()
-
         # do the jwt auth here
-        qs = jwt_validation(self.request.scope)
+        verified_user = jwt_validation(self.request.scope)
+
+        # confirm the user_id from the URL is the same as the JWT's
+        if verified_user == None or student.pk != verified_user.pk:
+            return HttpResponse(status=403)
 
         today = dt.now()
 


### PR DESCRIPTION
I reused much of the same logic for checking the validity of the JWT on websocket connections (as you may imagine they're quite similar). The difference being this is not an asynchronous action, so I simply wrote another function and placed it in a different file `auth/normal_auth.py`. 

We compare the JWT's primary key against the primary key requested by the frontend. If they don't match, or an `InvalidTokenError` is raised for some reason, the frontend is provided a 403.

To test, I used Firefox with the network tab up. I then sent a request with a happy path to download the PDF. This is the happy path and should succeed if your JWT is valid.

To test an access control vulnerability select the successful GET of the PDF. Edit and Resend this request with a different pk. You should receive a 403 error.