### PR TITLE
Styling fixes for mobile

### DIFF
--- a/web/public/css/user.css
+++ b/web/public/css/user.css
@@ -127,6 +127,10 @@ select {
     width: 100%;
   }
 
+  .button {
+    height: 40px;
+  }
+
   select {
     height: 50px;
   }
@@ -162,10 +166,6 @@ select {
 
     margin-left: 20px;
     margin-right: 20px;
-  }
-
-  .signup_submit {
-    margin-top: 50px;
   }
 
   .signup_box > input,

--- a/web/public/css/user_reset_pass.css
+++ b/web/public/css/user_reset_pass.css
@@ -4,7 +4,6 @@
 
 .password-reset-msg {
   display: grid;
-  /* justify-content: center; */
 
   grid-column: 1;
   grid-row: auto;
@@ -12,7 +11,6 @@
 
 .login_label {
   display: grid;
-  /* justify-content: center; */
 }
 
 .disabled {
@@ -31,4 +29,8 @@
   justify-content: left;
 
   grid-template-columns: 20px 100px;
+}
+
+.show-password-label {
+  padding: 3px 0 0 5px;
 }

--- a/web/src/Pages/User/ResetPassword/Uidb64_String/Token_String.elm
+++ b/web/src/Pages/User/ResetPassword/Uidb64_String/Token_String.elm
@@ -323,7 +323,7 @@ viewShowPasswordToggle model =
                    )
             )
             []
-        , Html.label [] [ Html.text "Show Password" ]
+        , Html.label [ class "show-password-label" ] [ Html.text "Show Password" ]
         ]
     ]
 


### PR DESCRIPTION
This PR fixes inconsistent button heights on public pages and adds some padding to the reset password page. 

To test it out, inspect the application in a couple of mobile devices in landscape and portrait mode in the developer tools. The reset password page is at `user/reset-password/<UUID>/<token>`. No need to test the ability to reset a password, so fill in anything you like for `UUID` and `token`.