### PR TITLE
Upgrade/performance report jwt

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -4,6 +4,7 @@ WORKDIR '/app'
 
 RUN apt update -y \
     && apt upgrade -y \
+    && apt install wktohtmlpdf \
     && mkdir logs \
     && touch logs/access.log \
     && touch logs/error.log \

--- a/user/views/student_performance.py
+++ b/user/views/student_performance.py
@@ -1,7 +1,4 @@
-from django.utils.decorators import method_decorator
-from django.views.decorators.csrf import csrf_exempt
 import pdfkit
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.files.base import ContentFile
 from django.http import HttpResponse, HttpRequest, HttpResponseForbidden
 from django.template import loader
@@ -22,7 +19,7 @@ class StudentPerformancePDFView(View):
 
         # confirm the user_id from the URL is the same as the JWT's
         if jwt_user == None or jwt_user.pk != kwargs['pk']:
-            return HttpResponse(status=403)
+            return HttpResponseForbidden()
 
         student = Student.objects.get(pk=kwargs['pk'])
 


### PR DESCRIPTION
Brings in the dependency to generate a PDF. Also cleans up the code in that same file.

This can be tested by attempting to download a PDF from the staging site. Otherwise we can rebuild the image to the same effect. 