### PR TITLE
Change questions attempted message for none

### DIFF
--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -67,8 +67,6 @@ type SafeModel
         , textApiEndpoint : AdminText.TextAPIEndpoint
         , help : TextSearch.Help.TextSearchHelp
         , errorMessage : Maybe String
-
-        -- , welcome : Bool
         }
 
 
@@ -356,7 +354,7 @@ viewSearchResults textListItems =
                             String.fromInt (Tuple.first correct) ++ " out of " ++ String.fromInt (Tuple.second correct)
 
                         Nothing ->
-                            "None"
+                            "None attempted"
             in
             div [ class "search_result" ]
                 [ div [ class "result_item" ]


### PR DESCRIPTION
Updates the message when no questions have been attempted per #57.

To test, log in as a student and navigate to the text search page. Texts that you have not begun should say "None attempted" for questions correct as seen here:

![none-attempted](https://user-images.githubusercontent.com/7957636/97515216-dca66280-194d-11eb-88cd-639197077864.png)
