### PR TITLE
New setting for sandbox emails

### DIFF
--- a/ereadingtool/settings.py
+++ b/ereadingtool/settings.py
@@ -105,7 +105,7 @@ LOGGING = {
 
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 
-DEBUG = True 
+DEBUG = False 
 DEV = False
 
 ALLOWED_HOSTS = ['0.0.0.0',
@@ -157,6 +157,8 @@ AUTH_USER_MODEL = 'user.ReaderUser'
 EMAIL_BACKEND = 'sendgrid_backend.SendgridBackend'
 
 SENDGRID_API_KEY = os.getenv('SENDGRID_API_KEY')
+# You must set DEBUG=False for sandbox_mode to be enabled
+SENDGRID_SANDBOX_MODE_IN_DEBUG = True
 
 ASGI_APPLICATION = 'ereadingtool.routing.application'
 # CHANNEL_LAYERS = {}

--- a/user/urls/forgot_pass.py
+++ b/user/urls/forgot_pass.py
@@ -10,6 +10,7 @@ api_urlpatterns = [
     path('api/password/reset/confirm', PasswordResetConfirmAPIView.as_view(), name='api-password-reset-confirm'),
 ]
 
+# TODO: --------- These appear to never be hit -------------
 urlpatterns = [
     path('load_elm_unauth_pass_reset_confirm.js',
          ElmLoadPassResetConfirmView.as_view(), name='load-elm-unauth-pass-reset-confirm'),


### PR DESCRIPTION
Adding this new setting results in debug mode being on or off dependent
on both the setting itself as well as the setting of `DEBUG` in
`settings.py`. Issue #239 details this more, but you must have both
`DEBUG=True` and `SENDGRID_SANDBOX_MODE_IN_DEBUG=True` for sandbox mode
to be enabled. This means no emails will actually be sent by SendGrid.

To turn off sandbox mode it's advised to simply set
`SENDGRID_SANDBOX_MODE_IN_DEBUG=False`.