### PR TITLE
Localize datetimes

### DIFF
--- a/web/elm.json
+++ b/web/elm.json
@@ -7,7 +7,6 @@
     "dependencies": {
         "direct": {
             "NoRedInk/elm-json-decode-pipeline": "1.0.0",
-            "PanagiotisGeorgiadis/elm-datetime": "1.3.0",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
@@ -18,6 +17,8 @@
             "elm/url": "1.0.0",
             "elm-explorations/markdown": "1.0.0",
             "hecrj/html-parser": "2.4.0",
+            "justinmimbs/time-extra": "1.1.0",
+            "justinmimbs/timezone-data": "2.1.4",
             "jzxhuang/http-extras": "2.1.0",
             "panthershark/email-parser": "1.0.2",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3",
@@ -29,7 +30,7 @@
             "elm/file": "1.0.5",
             "elm/parser": "1.1.0",
             "elm/virtual-dom": "1.0.2",
-            "justinmimbs/timezone-data": "2.1.4",
+            "justinmimbs/date": "3.2.1",
             "rtfeldman/elm-hex": "1.0.0",
             "waratuman/time-extra": "1.1.0"
         }

--- a/web/src/Pages/Text/Create.elm
+++ b/web/src/Pages/Text/Create.elm
@@ -69,6 +69,7 @@ type SafeModel
     = SafeModel
         { session : Session
         , config : Config
+        , timezone : Time.Zone
         , mode : Mode
         , profile : InstructorProfile
         , successMessage : Maybe String
@@ -88,6 +89,7 @@ init shared { params } =
     ( SafeModel
         { session = shared.session
         , config = shared.config
+        , timezone = shared.timezone
         , mode = CreateMode
         , successMessage = Nothing
         , errorMessage = Nothing
@@ -618,6 +620,7 @@ view (SafeModel model) =
             , Text.View.view_text
                 textViewParams
                 messages
+                model.timezone
                 Shared.answerFeedbackCharacterLimit
             ]
         ]
@@ -656,8 +659,10 @@ save model shared =
 
 
 load : Shared.Model -> SafeModel -> ( SafeModel, Cmd Msg )
-load shared safeModel =
-    ( safeModel, Cmd.none )
+load shared (SafeModel model) =
+    ( SafeModel { model | timezone = shared.timezone }
+    , Cmd.none
+    )
 
 
 

--- a/web/src/Pages/Text/Edit/Id_Int.elm
+++ b/web/src/Pages/Text/Edit/Id_Int.elm
@@ -70,6 +70,7 @@ type SafeModel
     = SafeModel
         { session : Session
         , config : Config
+        , timezone : Time.Zone
         , id : Int
         , mode : Mode
         , profile : InstructorProfile
@@ -91,6 +92,7 @@ init shared { params } =
         { session = shared.session
         , config = shared.config
         , id = params.id
+        , timezone = shared.timezone
 
         -- the writeLocker is a instructor username string,
         -- and we don't know who it is until we retrieve the text
@@ -741,6 +743,7 @@ view (SafeModel model) =
             , Text.View.view_text
                 textViewParams
                 messages
+                model.timezone
                 Shared.answerFeedbackCharacterLimit
             ]
         ]
@@ -779,8 +782,10 @@ save model shared =
 
 
 load : Shared.Model -> SafeModel -> ( SafeModel, Cmd Msg )
-load shared safeModel =
-    ( safeModel, Cmd.none )
+load shared (SafeModel model) =
+    ( SafeModel { model | timezone = shared.timezone }
+    , Cmd.none
+    )
 
 
 

--- a/web/src/Pages/Text/EditorSearch.elm
+++ b/web/src/Pages/Text/EditorSearch.elm
@@ -15,6 +15,7 @@ import Spa.Page as Page exposing (Page)
 import Spa.Url as Url exposing (Url)
 import Text.Decode
 import Text.Model exposing (TextListItem)
+import Time exposing (Zone)
 import User.Profile exposing (Profile)
 import Utils.Date
 import Views
@@ -47,6 +48,7 @@ type alias Model =
 type SafeModel
     = SafeModel
         { texts : List TextListItem
+        , timezone : Zone
         , profile : Profile
         , loading : Bool
         }
@@ -56,6 +58,7 @@ init : Shared.Model -> Url Params -> ( SafeModel, Cmd Msg )
 init shared { params } =
     ( SafeModel
         { texts = []
+        , timezone = shared.timezone
         , profile = shared.profile
         , loading = True
         }
@@ -122,17 +125,17 @@ view (SafeModel model) =
 viewTexts : SafeModel -> Html Msg
 viewTexts (SafeModel model) =
     div [ classList [ ( "text_items", True ) ] ]
-        (List.map viewText model.texts)
+        (List.map (viewText model.timezone) model.texts)
 
 
-viewText : TextListItem -> Html Msg
-viewText textListItem =
+viewText : Time.Zone -> TextListItem -> Html Msg
+viewText timezone textListItem =
     div [ classList [ ( "text_item", True ) ] ]
         [ div [ classList [ ( "item_property", True ) ], attribute "data-id" (String.fromInt textListItem.id) ] [ Html.text "" ]
         , div [ classList [ ( "item_property", True ) ] ]
             [ Html.a [ attribute "href" ("/text/edit/" ++ String.fromInt textListItem.id) ] [ Html.text textListItem.title ]
             , span [ classList [ ( "sub_description", True ) ] ]
-                [ Html.text <| "Modified:   " ++ Utils.Date.monthDayYearFormat textListItem.modified_dt
+                [ Html.text <| "Modified:   " ++ Utils.Date.monthDayYearFormat timezone textListItem.modified_dt
                 ]
             ]
         , div [ classList [ ( "item_property", True ) ] ]
@@ -157,7 +160,7 @@ viewText textListItem =
         , div [ classList [ ( "item_property", True ) ] ]
             [ Html.text textListItem.created_by
             , span [ classList [ ( "sub_description", True ) ] ]
-                [ Html.text ("Created By (" ++ Utils.Date.monthDayYearFormat textListItem.created_dt ++ ")")
+                [ Html.text ("Created By (" ++ Utils.Date.monthDayYearFormat timezone textListItem.created_dt ++ ")")
                 ]
             ]
         ]
@@ -215,8 +218,10 @@ save model shared =
 
 
 load : Shared.Model -> SafeModel -> ( SafeModel, Cmd Msg )
-load shared safeModel =
-    ( safeModel, Cmd.none )
+load shared (SafeModel model) =
+    ( SafeModel { model | timezone = shared.timezone }
+    , Cmd.none
+    )
 
 
 

--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -26,6 +26,7 @@ import Text.Search.Option
 import Text.Search.ReadingStatus exposing (TextReadStatus, TextReadStatusSearch)
 import Text.Search.Tag exposing (TagSearch)
 import TextSearch.Help
+import Time exposing (Zone)
 import User.Profile
 import User.Student.Profile as StudentProfile
 import Utils.Date
@@ -61,6 +62,7 @@ type SafeModel
         { session : Session
         , config : Config
         , navKey : Key
+        , timezone : Zone
         , results : List Text.Model.TextListItem
         , profile : User.Profile.Profile
         , textSearch : TextSearch
@@ -115,6 +117,7 @@ init shared { params } =
         { session = shared.session
         , config = shared.config
         , navKey = shared.key
+        , timezone = shared.timezone
         , results = []
         , profile = shared.profile
         , textSearch = textSearch
@@ -272,7 +275,7 @@ viewContent (SafeModel model) =
             []
         )
             ++ [ viewSearchFilters (SafeModel model)
-               , viewSearchResults model.results
+               , viewSearchResults model.timezone model.results
                , viewSearchFooter (SafeModel model)
                ]
 
@@ -319,8 +322,8 @@ viewSearchFilters (SafeModel model) =
         ]
 
 
-viewSearchResults : List Text.Model.TextListItem -> Html Msg
-viewSearchResults textListItems =
+viewSearchResults : Time.Zone -> List Text.Model.TextListItem -> Html Msg
+viewSearchResults timezone textListItems =
     let
         viewSearchResult textItem =
             let
@@ -343,7 +346,7 @@ viewSearchResults textListItems =
                 lastRead =
                     case textItem.last_read_dt of
                         Just dt ->
-                            Utils.Date.monthDayYearFormat dt
+                            Utils.Date.monthDayYearFormat timezone dt
 
                         Nothing ->
                             ""
@@ -610,8 +613,10 @@ save model shared =
 
 
 load : Shared.Model -> SafeModel -> ( SafeModel, Cmd Msg )
-load shared safeModel =
-    ( safeModel, Cmd.none )
+load shared (SafeModel model) =
+    ( SafeModel { model | timezone = shared.timezone }
+    , Cmd.none
+    )
 
 
 subscriptions : SafeModel -> Sub Msg

--- a/web/src/Question/Decode.elm
+++ b/web/src/Question/Decode.elm
@@ -2,7 +2,6 @@ module Question.Decode exposing (questionDecoder, questionsDecoder)
 
 import Answer.Decode
 import Array exposing (Array)
-import DateTime
 import Iso8601
 import Json.Decode
 import Json.Decode.Extra exposing (posix)
@@ -15,10 +14,8 @@ questionDecoder =
     Json.Decode.succeed Question
         |> required "id" (Json.Decode.nullable Json.Decode.int)
         |> required "text_section_id" (Json.Decode.nullable Json.Decode.int)
-        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
-        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
-        -- |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
-        -- |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
+        |> required "created_dt" (Json.Decode.nullable Iso8601.decoder)
+        |> required "modified_dt" (Json.Decode.nullable Iso8601.decoder)
         |> required "body" Json.Decode.string
         |> required "order" Json.Decode.int
         |> required "answers" Answer.Decode.answersDecoder

--- a/web/src/Question/Model.elm
+++ b/web/src/Question/Model.elm
@@ -2,14 +2,14 @@ module Question.Model exposing (Question, initial_questions, new_question)
 
 import Answer.Model
 import Array exposing (Array)
-import DateTime exposing (DateTime)
+import Time exposing (Posix)
 
 
 type alias Question =
     { id : Maybe Int
     , text_id : Maybe Int
-    , created_dt : Maybe DateTime
-    , modified_dt : Maybe DateTime
+    , created_dt : Maybe Posix
+    , modified_dt : Maybe Posix
     , body : String
     , order : Int
     , answers : Array Answer.Model.Answer

--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -120,7 +120,7 @@ init flags url key =
                             ]
 
         Nothing ->
-            Cmd.none
+            Task.attempt GotTimezone TimeZone.getZone
     )
 
 

--- a/web/src/Text/Decode.elm
+++ b/web/src/Text/Decode.elm
@@ -14,7 +14,6 @@ module Text.Decode exposing
     )
 
 import Array
-import DateTime
 import Dict exposing (Dict)
 import Iso8601
 import Json.Decode
@@ -70,10 +69,8 @@ textDecoder =
         |> required "created_by" (Json.Decode.nullable Json.Decode.string)
         |> required "last_modified_by" (Json.Decode.nullable Json.Decode.string)
         |> required "tags" (Json.Decode.nullable (Json.Decode.list Json.Decode.string))
-        -- |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
-        -- |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
-        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
-        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
+        |> required "created_dt" (Json.Decode.nullable Iso8601.decoder)
+        |> required "modified_dt" (Json.Decode.nullable Iso8601.decoder)
         |> required "text_sections" (Json.Decode.map Array.fromList Text.Section.Decode.textSectionsDecoder)
         |> required "write_locker" (Json.Decode.nullable Json.Decode.string)
         |> required "words" Text.Translations.Decode.wordsDecoder
@@ -89,12 +86,9 @@ textListItemDecoder =
         |> required "created_by" Json.Decode.string
         |> required "last_modified_by" (Json.Decode.nullable Json.Decode.string)
         |> required "tags" (Json.Decode.nullable (Json.Decode.list Json.Decode.string))
-        -- |> required "created_dt" (Json.Decode.map DateTime.fromPosix posix)
-        -- |> required "modified_dt" (Json.Decode.map DateTime.fromPosix posix)
-        -- |> required "last_read_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix posix))
-        |> required "created_dt" (Json.Decode.map DateTime.fromPosix Iso8601.decoder)
-        |> required "modified_dt" (Json.Decode.map DateTime.fromPosix Iso8601.decoder)
-        |> required "last_read_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
+        |> required "created_dt" Iso8601.decoder
+        |> required "modified_dt" Iso8601.decoder
+        |> required "last_read_dt" (Json.Decode.nullable Iso8601.decoder)
         |> required "text_section_count" Json.Decode.int
         |> required "text_sections_complete" (Json.Decode.nullable Json.Decode.int)
         |> required "questions_correct" (Json.Decode.nullable Utils.intTupleDecoder)

--- a/web/src/Text/Model.elm
+++ b/web/src/Text/Model.elm
@@ -8,10 +8,10 @@ module Text.Model exposing
     )
 
 import Array exposing (Array)
-import DateTime exposing (DateTime)
 import Dict
 import Text.Section.Model exposing (emptyTextSection)
 import Text.Translations exposing (..)
+import Time exposing (Posix)
 
 
 type alias TextDifficulty =
@@ -29,8 +29,8 @@ type alias Text =
     , created_by : Maybe String
     , last_modified_by : Maybe String
     , tags : Maybe (List String)
-    , created_dt : Maybe DateTime
-    , modified_dt : Maybe DateTime
+    , created_dt : Maybe Posix
+    , modified_dt : Maybe Posix
     , sections : Array Text.Section.Model.TextSection
     , write_locker : Maybe String
     , words : Words
@@ -45,9 +45,9 @@ type alias TextListItem =
     , created_by : String
     , last_modified_by : Maybe String
     , tags : Maybe (List String)
-    , created_dt : DateTime
-    , modified_dt : DateTime
-    , last_read_dt : Maybe DateTime
+    , created_dt : Posix
+    , modified_dt : Posix
+    , last_read_dt : Maybe Posix
     , text_section_count : Int
     , text_sections_complete : Maybe Int
     , questions_correct : Maybe ( Int, Int )

--- a/web/src/Text/View.elm
+++ b/web/src/Text/View.elm
@@ -22,12 +22,13 @@ import Text.Translations.Msg as TranslationsMsg
 import Text.Translations.View
 import Text.Update
 import TextEdit exposing (Mode(..), Tab(..), TextViewParams)
+import Time
 import User.Instructor.Profile as InstructorProfile
 import Utils.Date
 
 
-view_text_date : TextViewParams -> Html msg
-view_text_date params =
+view_text_date : Time.Zone -> TextViewParams -> Html msg
+view_text_date timezone params =
     div [ attribute "class" "text_dates" ] <|
         (case params.text.modified_dt of
             Just modified_dt ->
@@ -35,7 +36,11 @@ view_text_date params =
                     Just last_modified_by ->
                         [ span []
                             [ Html.text
-                                ("Last Modified by " ++ last_modified_by ++ " on " ++ Utils.Date.monthDayYearFormat modified_dt)
+                                ("Last Modified by "
+                                    ++ last_modified_by
+                                    ++ " on "
+                                    ++ Utils.Date.monthDayYearFormat timezone modified_dt
+                                )
                             ]
                         ]
 
@@ -51,7 +56,11 @@ view_text_date params =
                             Just created_by ->
                                 [ span []
                                     [ Html.text
-                                        ("Created by " ++ created_by ++ " on " ++ Utils.Date.monthDayYearFormat created_dt)
+                                        ("Created by "
+                                            ++ created_by
+                                            ++ " on "
+                                            ++ Utils.Date.monthDayYearFormat timezone created_dt
+                                        )
                                     ]
                                 ]
 
@@ -484,8 +493,9 @@ view_text_attributes :
         , onAddTagInput : String -> String -> msg
         , onDeleteTag : String -> msg
         }
+    -> Time.Zone
     -> Html msg
-view_text_attributes params messages =
+view_text_attributes params messages timezone =
     div [ attribute "id" "text_attributes" ]
         [ view_text_title
             params
@@ -517,7 +527,7 @@ view_text_attributes params messages =
             edit_source
             (Text.Field.source params.text_fields)
         , view_text_lock params messages.onToggleLock
-        , view_text_date params
+        , view_text_date timezone params
         , view_text_conclusion
             params
             messages.onUpdateTextAttributes
@@ -632,9 +642,10 @@ view_text_tab :
         , onAddTagInput : String -> String -> msg
         , onDeleteTag : String -> msg
         }
+    -> Time.Zone
     -> Int
     -> Html msg
-view_text_tab params messages answer_feedback_limit =
+view_text_tab params messages timezone answer_feedback_limit =
     div [ attribute "id" "text" ] <|
         [ view_text_attributes params
             { onToggleEditable = messages.onToggleEditable
@@ -643,6 +654,7 @@ view_text_tab params messages answer_feedback_limit =
             , onAddTagInput = messages.onAddTagInput
             , onDeleteTag = messages.onDeleteTag
             }
+            timezone
         , Text.Section.View.view_text_section_components messages.onTextComponentMsg
             (Text.Component.text_section_components params.text_component)
             answer_feedback_limit
@@ -685,12 +697,13 @@ view_tab_contents :
         , onDeleteTag : String -> msg
         }
     -> (TranslationsMsg.Msg -> msg)
+    -> Time.Zone
     -> Int
     -> Html msg
-view_tab_contents params messages onTextTranslationMsg answer_feedback_limit =
+view_tab_contents params messages onTextTranslationMsg timezone answer_feedback_limit =
     case params.selected_tab of
         TextTab ->
-            view_text_tab params messages answer_feedback_limit
+            view_text_tab params messages timezone answer_feedback_limit
 
         TranslationsTab ->
             view_translations_tab params onTextTranslationMsg
@@ -710,9 +723,10 @@ view_text :
         , onDeleteTag : String -> msg
         , onTextTranslationMsg : TranslationsMsg.Msg -> msg
         }
+    -> Time.Zone
     -> Int
     -> Html msg
-view_text params messages answer_feedback_limit =
+view_text params messages timezone answer_feedback_limit =
     div [ attribute "id" "tabs" ]
         [ view_tab_menu params messages.onToggleTab
         , div [ attribute "id" "tabs_contents" ]
@@ -727,6 +741,7 @@ view_text params messages answer_feedback_limit =
                 , onDeleteTag = messages.onDeleteTag
                 }
                 messages.onTextTranslationMsg
+                timezone
                 answer_feedback_limit
             ]
         ]

--- a/web/src/TextReader/Question/Decode.elm
+++ b/web/src/TextReader/Question/Decode.elm
@@ -1,7 +1,6 @@
 module TextReader.Question.Decode exposing (answersDecoder, questionsDecoder)
 
 import Array exposing (Array)
-import DateTime
 import Iso8601
 import Json.Decode
 import Json.Decode.Extra exposing (posix)
@@ -31,8 +30,8 @@ questionDecoder =
     Json.Decode.succeed Question
         |> required "id" Json.Decode.int
         |> required "text_section_id" Json.Decode.int
-        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
-        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
+        |> required "created_dt" (Json.Decode.nullable Iso8601.decoder)
+        |> required "modified_dt" (Json.Decode.nullable Iso8601.decoder)
         |> required "body" Json.Decode.string
         |> required "order" Json.Decode.int
         |> required "answers" answersDecoder

--- a/web/src/TextReader/Question/Model.elm
+++ b/web/src/TextReader/Question/Model.elm
@@ -9,16 +9,16 @@ module TextReader.Question.Model exposing
     )
 
 import Array exposing (Array)
-import DateTime exposing (DateTime)
 import Question.Field exposing (question)
 import TextReader.Answer.Model exposing (Answer, TextAnswer)
+import Time exposing (Posix)
 
 
 type alias Question =
     { id : Int
     , text_section_id : Int
-    , created_dt : Maybe DateTime
-    , modified_dt : Maybe DateTime
+    , created_dt : Maybe Posix
+    , modified_dt : Maybe Posix
     , body : String
     , order : Int
     , answers : Array Answer

--- a/web/src/TextReader/Text/Decode.elm
+++ b/web/src/TextReader/Text/Decode.elm
@@ -1,6 +1,5 @@
 module TextReader.Text.Decode exposing (textDecoder)
 
-import DateTime
 import Iso8601
 import Json.Decode
 import Json.Decode.Extra exposing (posix)
@@ -21,5 +20,5 @@ textDecoder =
         |> required "created_by" (Json.Decode.nullable Json.Decode.string)
         |> required "last_modified_by" (Json.Decode.nullable Json.Decode.string)
         |> required "tags" (Json.Decode.nullable (Json.Decode.list Json.Decode.string))
-        |> required "created_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
-        |> required "modified_dt" (Json.Decode.nullable (Json.Decode.map DateTime.fromPosix Iso8601.decoder))
+        |> required "created_dt" (Json.Decode.nullable Iso8601.decoder)
+        |> required "modified_dt" (Json.Decode.nullable Iso8601.decoder)

--- a/web/src/TextReader/Text/Model.elm
+++ b/web/src/TextReader/Text/Model.elm
@@ -1,7 +1,7 @@
 module TextReader.Text.Model exposing (Text, emptyText)
 
 import Array exposing (empty)
-import DateTime exposing (DateTime)
+import Time exposing (Posix)
 
 
 type alias Text =
@@ -15,8 +15,8 @@ type alias Text =
     , created_by : Maybe String
     , last_modified_by : Maybe String
     , tags : Maybe (List String)
-    , created_dt : Maybe DateTime
-    , modified_dt : Maybe DateTime
+    , created_dt : Maybe Posix
+    , modified_dt : Maybe Posix
     }
 
 

--- a/web/src/Utils/Date.elm
+++ b/web/src/Utils/Date.elm
@@ -1,16 +1,20 @@
 module Utils.Date exposing (monthDayYearFormat)
 
-import DateTime
 import Time
+import Time.Extra
 
 
-monthDayYearFormat : DateTime.DateTime -> String
-monthDayYearFormat date =
+monthDayYearFormat : Time.Zone -> Time.Posix -> String
+monthDayYearFormat zone posixTime =
+    let
+        parts =
+            Time.Extra.posixToParts zone posixTime
+    in
     String.join " "
-        [ toMonthString <| DateTime.getMonth date
-        , (String.fromInt <| DateTime.getDay date) ++ ","
-        , hourMinSecFormat date
-        , String.fromInt <| DateTime.getYear date
+        [ toMonthString <| parts.month
+        , (String.fromInt <| parts.day) ++ ","
+        , hourMinSecFormat parts
+        , String.fromInt <| parts.year
         ]
 
 
@@ -54,15 +58,15 @@ toMonthString month =
             "Dec"
 
 
-hourMinSecFormat : DateTime.DateTime -> String
-hourMinSecFormat date =
+hourMinSecFormat : Time.Extra.Parts -> String
+hourMinSecFormat parts =
     String.join " "
         [ String.join ":"
-            [ String.fromInt (toTwelveHourClock (DateTime.getHours date))
-            , padZero (DateTime.getMinutes date)
-            , padZero (DateTime.getSeconds date)
+            [ String.fromInt (toTwelveHourClock parts.hour)
+            , padZero parts.minute
+            , padZero parts.second
             ]
-        , amPMFormat date
+        , amPMFormat parts.hour
         ]
 
 
@@ -80,9 +84,9 @@ toTwelveHourClock hour =
     modBy 12 (hour + 11) + 1
 
 
-amPMFormat : DateTime.DateTime -> String
-amPMFormat date =
-    if DateTime.getHours date < 12 then
+amPMFormat : Int -> String
+amPMFormat hour =
+    if hour < 12 then
         "AM"
 
     else

--- a/web/tests/Tests/Date.elm
+++ b/web/tests/Tests/Date.elm
@@ -1,9 +1,10 @@
 module Tests.Date exposing (..)
 
-import DateTime
 import Expect
+import Json.Encode.Extra exposing (posix)
 import Test exposing (..)
 import Time
+import TimeZone exposing (america__los_angeles, asia__tokyo)
 import Utils.Date exposing (monthDayYearFormat)
 
 
@@ -14,64 +15,88 @@ suite =
             \_ ->
                 let
                     startPosix =
-                        DateTime.fromPosix (Time.millisToPosix 0)
+                        Time.millisToPosix 0
                 in
-                monthDayYearFormat startPosix
+                monthDayYearFormat Time.utc startPosix
                     |> Expect.equal "Jan 1, 12:00:00 AM 1970"
         , test "High noon on longest day of 2020" <|
             \_ ->
                 let
-                    startPosix =
-                        DateTime.fromPosix (Time.millisToPosix 1592654400000)
+                    highNoon =
+                        Time.millisToPosix 1592654400000
                 in
-                monthDayYearFormat startPosix
+                monthDayYearFormat Time.utc highNoon
                     |> Expect.equal "Jun 20, 12:00:00 PM 2020"
         , test "A morning time with a single digit hour" <|
             \_ ->
                 let
-                    startPosix =
-                        DateTime.fromPosix (Time.millisToPosix 1573546352000)
+                    posixTime =
+                        Time.millisToPosix 1573546352000
                 in
-                monthDayYearFormat startPosix
+                monthDayYearFormat Time.utc posixTime
                     |> Expect.equal "Nov 12, 8:12:32 AM 2019"
         , test "An afternoon time with a single digit hour" <|
             \_ ->
                 let
-                    startPosix =
-                        DateTime.fromPosix (Time.millisToPosix 1236007965000)
+                    posixTime =
+                        Time.millisToPosix 1236007965000
                 in
-                monthDayYearFormat startPosix
+                monthDayYearFormat Time.utc posixTime
                     |> Expect.equal "Mar 2, 3:32:45 PM 2009"
         , test "A morning time with a double digit hour" <|
             \_ ->
                 let
-                    startPosix =
-                        DateTime.fromPosix (Time.millisToPosix 990963165000)
+                    posixTime =
+                        Time.millisToPosix 990963165000
                 in
-                monthDayYearFormat startPosix
+                monthDayYearFormat Time.utc posixTime
                     |> Expect.equal "May 27, 11:32:45 AM 2001"
         , test "A afternoon time with a double digit hour" <|
             \_ ->
                 let
-                    startPosix =
-                        DateTime.fromPosix (Time.millisToPosix 1070319839000)
+                    posixTime =
+                        Time.millisToPosix 1070319839000
                 in
-                monthDayYearFormat startPosix
+                monthDayYearFormat Time.utc posixTime
                     |> Expect.equal "Dec 1, 11:03:59 PM 2003"
         , test "Minutes and seconds are padded with zeros, but not hours" <|
             \_ ->
                 let
-                    startPosix =
-                        DateTime.fromPosix (Time.millisToPosix 1373900582000)
+                    posixTime =
+                        Time.millisToPosix 1373900582000
                 in
-                monthDayYearFormat startPosix
+                monthDayYearFormat Time.utc posixTime
                     |> Expect.equal "Jul 15, 3:03:02 PM 2013"
         , test "Leap day 2020" <|
             \_ ->
                 let
-                    startPosix =
-                        DateTime.fromPosix (Time.millisToPosix 1582990200000)
+                    leapDay =
+                        Time.millisToPosix 1582990200000
                 in
-                monthDayYearFormat startPosix
+                monthDayYearFormat Time.utc leapDay
                     |> Expect.equal "Feb 29, 3:30:00 PM 2020"
+        , test "2020 Happy new year in Oregon" <|
+            \_ ->
+                let
+                    posixTime =
+                        Time.millisToPosix 946713600000
+                in
+                monthDayYearFormat (america__los_angeles ()) posixTime
+                    |> Expect.equal "Jan 1, 12:00:00 AM 2000"
+        , test "Start of POSIX time in Oregon" <|
+            \_ ->
+                let
+                    posixTime =
+                        Time.millisToPosix 0
+                in
+                monthDayYearFormat (america__los_angeles ()) posixTime
+                    |> Expect.equal "Dec 31, 4:00:00 PM 1969"
+        , test "Start of POSIX time in Tokyo" <|
+            \_ ->
+                let
+                    posixTime =
+                        Time.millisToPosix 0
+                in
+                monthDayYearFormat (asia__tokyo ()) posixTime
+                    |> Expect.equal "Jan 1, 9:00:00 AM 1970"
         ]


### PR DESCRIPTION
This PR adds localization to dates and times shown in the text search and text editing pages.

To test it:
- Log in as a student and read a text. Go back to the text search page and check that your last read time is correct for your timezone.
- Log in as an instructor, create a new text and check that the time created is correct for your timezone. Open the editor search page and check that the created time is correct for the entry in the list of texts.


