### PR TITLE
New SendGrid token validation

### DIFF
--- a/ereadingtool/settings.py
+++ b/ereadingtool/settings.py
@@ -157,8 +157,8 @@ AUTH_USER_MODEL = 'user.ReaderUser'
 EMAIL_BACKEND = 'sendgrid_backend.SendgridBackend'
 
 SENDGRID_API_KEY = os.getenv('SENDGRID_API_KEY')
-# You must set DEBUG=False for sandbox_mode to be enabled
-SENDGRID_SANDBOX_MODE_IN_DEBUG = True
+# You must set also DEBUG=False for sandbox_mode to be enabled
+SENDGRID_SANDBOX_MODE_IN_DEBUG = False
 
 ASGI_APPLICATION = 'ereadingtool.routing.application'
 # CHANNEL_LAYERS = {}

--- a/user/urls/forgot_pass.py
+++ b/user/urls/forgot_pass.py
@@ -10,11 +10,12 @@ api_urlpatterns = [
     path('api/password/reset/confirm', PasswordResetConfirmAPIView.as_view(), name='api-password-reset-confirm'),
 ]
 
-# TODO: --------- These appear to never be hit -------------
 urlpatterns = [
+    # TODO: This can be removed.
     path('load_elm_unauth_pass_reset_confirm.js',
          ElmLoadPassResetConfirmView.as_view(), name='load-elm-unauth-pass-reset-confirm'),
 
+    # TODO: This can be removed.
     path('load_elm_unauth_pass_reset.js',
          ElmLoadPasswordResetView.as_view(), name='load-elm-unauth-pass-reset'),
 


### PR DESCRIPTION
Previously we'd get a link from SendGrid, open that link and fire off a
request to the backend including the uidb and token in the GET request.
Then the server would reply with a redirect to scrub the token from the
URL. The purpose of this is to remove the token so any additional pages
being loaded don't leak it in the `referer` field.

We've done away with the redirect and simply reply with a JSON error.
Unfortunately we've reopened a security hole since we allow for the
referer to leak the security token.

We also no longer redirect to a compiled Elm page if things went wrong.

Solutions to the referer bug:
* Upgrade to Django 3.0 and set SecurityMidddleware setting https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-SECURE_REFERRER_POLICY
* Nginx (maybe?)
  https://serverfault.com/questions/869463/nginx-rewrite-http-referer
* Go back to the exit page
  https://geekthis.net/post/hide-http-referer-headers/#exit-page-redirect