### PR TITLE
DELETE header added to cors configuration

### DIFF
--- a/cors.conf
+++ b/cors.conf
@@ -3,6 +3,6 @@ if ($request_method = OPTIONS) {
 }
 
 add_header 'Access-Control-Allow-Origin' '$http_origin' 'always';
-add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT' 'always';
+add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE' 'always';
 add_header 'Access-Control-Allow-Headers' 'User-Agent,Keep-Alive,Content-Type,Authorization' 'always';
 add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' 'always';


### PR DESCRIPTION
There's a file at the top level called cors.conf It's copy pasted onto
the reverse proxy via `volumes` in the docker-compose file. Adding
DELETE to this list should allow us to run DELETE http requests in the
few places in which they're done. Namely, deleting an entire text and
deleting the lock on editing a file.

Not sure how to test this PR on localhost. We won't get any CORS
conflicts until attempting to access resources from a subdomain.