### PR TITLE
Make text search difficulty selection mutually exclusive

### DIFF
--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -124,8 +124,6 @@ init shared { params } =
         , textApiEndpoint = textApiEndpoint
         , help = textSearchHelp
         , errorMessage = Nothing
-
-        -- , welcome = Config.showHelp shared.config
         }
     , updateResults shared.session shared.config textSearch
     )

--- a/web/src/Text/Search/Difficulty.elm
+++ b/web/src/Text/Search/Difficulty.elm
@@ -50,7 +50,7 @@ selectDifficulty ((DifficultySearch id _ err) as difficulty_search) difficulty s
                         Text.Search.Option.setSelected opt selected
 
                     else
-                        opt
+                        Text.Search.Option.setSelected opt False
                 )
                 (options difficulty_search)
             )


### PR DESCRIPTION
This PR changes the difficulty selection on the text search to only permit one option to be selected at a time. For reference, see #53. 

To test this PR, log in as a student and navigate to the text search page. Select a difficulty and verify it is the only one selected. Check that the texts displayed all match the selected difficulty. Repeat for each difficulty level. 

(Note that we have an ordering problem that should be addressed separately where the first request when landing on the page comes in after filtering. To test this one, wait until the initial search results come in, then test.)