### PR TITLE
Change restart text button copy

### DIFF
--- a/web/src/Pages/Text/Id_Int.elm
+++ b/web/src/Pages/Text/Id_Int.elm
@@ -608,7 +608,7 @@ viewTextComplete (SafeModel model) scores =
         , viewTextConclusion model.text
         , div [ id "nav" ]
             [ viewPreviousButton
-            , div [ onClick StartOver ] [ Html.text "Start Over" ]
+            , div [ onClick StartOver ] [ Html.text "Read Again" ]
             , Html.a [ attribute "href" (Route.toString Route.Text__Search) ] [ span [] [ Html.text "Read Another Text" ] ]
             ]
         ]


### PR DESCRIPTION
Change button to say "Read Again" instead of "Start Over".

To test, log in as a student or instructor and read a text through to the end. Check that the button to start over says "Read Again".