### PR TITLE
DB persistence between starts and stops

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -13,8 +13,6 @@ RUN apt update -y \
     && git checkout upgrade/staging \
     && pip install -r requirements.txt
 
-COPY ./db.sqlite3 /app/ereadingtool/
-
 CMD ["python", "/app/ereadingtool/manage.py", "runserver", "0.0.0.0:8000"]
 
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - "8000"
       - "6379"
     restart: always
+    volumes:
+      - ./db.sqlite3:/app/ereadingtool/db.sqlite3
 
   node_frontend:
     build:


### PR DESCRIPTION
Previously we were copying the file onto the container from the VM.
That's silly, changes made to the DB on the container won't affect the
copy on the VM. Now the host shares the file with the container. This 
concludes the upgrade to containerization of the site. It was a bug, so
additional changes that aren't bug related should be filed as features.