### PR TITLE
Upgrade/staging pinned

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ sqlparse
 requests
 pymorphy2[fast]
 pymorphy2-dicts-ru
-channels_redis=3.0.1
+channels_redis==3.0.1
 lxml
 pdfkit
 asynctest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,14 +6,14 @@ django-csp
 hypothesis[django]
 faker
 jsonschema
-channels
+channels==2.4.0
 python-statemachine
 django-sendgrid-v5
 sqlparse
 requests
 pymorphy2[fast]
 pymorphy2-dicts-ru
-channels_redis
+channels_redis=3.0.1
 lxml
 pdfkit
 asynctest


### PR DESCRIPTION
Pinning these versions of Channels and its dependency will keep it from breaking the app. Channels wants to jump to 3.0.x