### PR TITLE
Add expired token handling to the frontend

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1729,6 +1729,11 @@
         "verror": "1.10.0"
       }
     },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -38,5 +38,8 @@
       "staticOutDir": "public"
     },
     "watcherGlob": "**"
+  },
+  "dependencies": {
+    "jwt-decode": "^3.1.2"
   }
 }

--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -393,3 +393,39 @@ body {
   user-select: none; /* Non-prefixed version, currently
                                   supported by Chrome and Opera */
 }
+
+.infobar {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+
+  padding: 15px;
+
+  border-radius: 5px;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
+
+  color: #ffffff;
+  font-size: 18px;
+}
+
+.infobar-bottom {
+  bottom: 30px;
+}
+
+.infobar-top {
+  top: 10px;
+}
+
+.infobar-success {
+  background-color: #0054a6;
+}
+
+.infobar-error {
+  background-color: #bd0f15;
+}
+
+@media (max-width: 568px) {
+  .infobar {
+    width: 75%;
+  }
+}

--- a/web/src/Infobar.elm
+++ b/web/src/Infobar.elm
@@ -1,0 +1,75 @@
+module Infobar exposing (Infobar, errorBottom, successBottom, view)
+
+import Html exposing (..)
+import Html.Attributes exposing (classList)
+
+
+type alias Infobar =
+    { status : Status
+    , message : String
+    , position : Position
+    }
+
+
+type Status
+    = Success
+    | Error
+
+
+type Position
+    = Top
+    | Bottom
+
+
+successBottom : String -> Infobar
+successBottom message =
+    { status = Success
+    , message = message
+    , position = Bottom
+    }
+
+
+errorBottom : String -> Infobar
+errorBottom message =
+    { status = Error
+    , message = message
+    , position = Bottom
+    }
+
+
+view : Infobar -> Html msg
+view infobar =
+    case infobar.position of
+        Top ->
+            div []
+                [ div
+                    [ classList
+                        [ ( "infobar", True )
+                        , ( "infobar-top", True )
+                        , statusClass infobar.status
+                        ]
+                    ]
+                    [ text infobar.message ]
+                ]
+
+        Bottom ->
+            div []
+                [ div
+                    [ classList
+                        [ ( "infobar", True )
+                        , ( "infobar-bottom", True )
+                        , statusClass infobar.status
+                        ]
+                    ]
+                    [ text infobar.message ]
+                ]
+
+
+statusClass : Status -> ( String, Bool )
+statusClass status =
+    case status of
+        Success ->
+            ( "infobar-success", True )
+
+        Error ->
+            ( "infobar-error", True )

--- a/web/src/Pages/Profile/Instructor.elm
+++ b/web/src/Pages/Profile/Instructor.elm
@@ -110,9 +110,15 @@ update msg (SafeModel model) =
         GotNewInvite (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    ( SafeModel { model | errors = errorBodyToDict body }
-                    , Cmd.none
-                    )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
+
+                    else
+                        ( SafeModel { model | errors = errorBodyToDict body }
+                        , Cmd.none
+                        )
 
                 _ ->
                     ( SafeModel

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -151,9 +151,15 @@ update msg (SafeModel model) =
         GotProfile (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    ( SafeModel { model | errors = errorBodyToDict body }
-                    , Cmd.none
-                    )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
+
+                    else
+                        ( SafeModel { model | errors = errorBodyToDict body }
+                        , Cmd.none
+                        )
 
                 _ ->
                     ( SafeModel
@@ -187,9 +193,15 @@ update msg (SafeModel model) =
         GotUsernameValidation (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    ( SafeModel { model | errors = errorBodyToDict body }
-                    , Cmd.none
-                    )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
+
+                    else
+                        ( SafeModel { model | errors = errorBodyToDict body }
+                        , Cmd.none
+                        )
 
                 _ ->
                     ( SafeModel
@@ -245,9 +257,15 @@ update msg (SafeModel model) =
         GotResearchConsent (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    ( SafeModel { model | errors = errorBodyToDict body }
-                    , Cmd.none
-                    )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
+
+                    else
+                        ( SafeModel { model | errors = errorBodyToDict body }
+                        , Cmd.none
+                        )
 
                 _ ->
                     ( SafeModel

--- a/web/src/Pages/Text/Create.elm
+++ b/web/src/Pages/Text/Create.elm
@@ -178,14 +178,20 @@ update msg (SafeModel model) =
         GotTextCreated (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    case Text.Decode.decodeRespErrors body of
-                        Ok errors ->
-                            ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
 
-                        Err _ ->
-                            ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
-                            , Cmd.none
-                            )
+                    else
+                        case Text.Decode.decodeRespErrors body of
+                            Ok errors ->
+                                ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+
+                            Err _ ->
+                                ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
+                                , Cmd.none
+                                )
 
                 _ ->
                     ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
@@ -209,14 +215,20 @@ update msg (SafeModel model) =
         GotTextUpdated (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    case Text.Decode.decodeRespErrors body of
-                        Ok errors ->
-                            ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
 
-                        Err _ ->
-                            ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
-                            , Cmd.none
-                            )
+                    else
+                        case Text.Decode.decodeRespErrors body of
+                            Ok errors ->
+                                ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+
+                            Err _ ->
+                                ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
+                                , Cmd.none
+                                )
 
                 _ ->
                     ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
@@ -236,18 +248,24 @@ update msg (SafeModel model) =
         GotTextDeleted (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    case Text.Decode.decodeRespErrors body of
-                        Ok errors ->
-                            let
-                                errorsStr =
-                                    String.join " and " (Dict.values errors)
-                            in
-                            ( SafeModel { model | errorMessage = Just <| "Error trying to delete the text: " ++ errorsStr }, Cmd.none )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
 
-                        Err _ ->
-                            ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
-                            , Cmd.none
-                            )
+                    else
+                        case Text.Decode.decodeRespErrors body of
+                            Ok errors ->
+                                let
+                                    errorsStr =
+                                        String.join " and " (Dict.values errors)
+                                in
+                                ( SafeModel { model | errorMessage = Just <| "Error trying to delete the text: " ++ errorsStr }, Cmd.none )
+
+                            Err _ ->
+                                ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
+                                , Cmd.none
+                                )
 
                 _ ->
                     ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
@@ -376,22 +394,28 @@ update msg (SafeModel model) =
         TextLocked (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    case Text.Decode.decodeRespErrors body of
-                        Ok errors ->
-                            ( SafeModel
-                                { model
-                                    | errorMessage =
-                                        Just <|
-                                            "Error trying to lock the text: "
-                                                ++ String.join " and " (Dict.values errors)
-                                }
-                            , Cmd.none
-                            )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
 
-                        Err _ ->
-                            ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
-                            , Cmd.none
-                            )
+                    else
+                        case Text.Decode.decodeRespErrors body of
+                            Ok errors ->
+                                ( SafeModel
+                                    { model
+                                        | errorMessage =
+                                            Just <|
+                                                "Error trying to lock the text: "
+                                                    ++ String.join " and " (Dict.values errors)
+                                    }
+                                , Cmd.none
+                                )
+
+                            Err _ ->
+                                ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
+                                , Cmd.none
+                                )
 
                 _ ->
                     ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
@@ -411,22 +435,28 @@ update msg (SafeModel model) =
         TextUnlocked (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    case Text.Decode.decodeRespErrors body of
-                        Ok errors ->
-                            ( SafeModel
-                                { model
-                                    | errorMessage =
-                                        Just <|
-                                            "Error trying to unlock the text: "
-                                                ++ String.join " and " (Dict.values errors)
-                                }
-                            , Cmd.none
-                            )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
 
-                        Err _ ->
-                            ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
-                            , Cmd.none
-                            )
+                    else
+                        case Text.Decode.decodeRespErrors body of
+                            Ok errors ->
+                                ( SafeModel
+                                    { model
+                                        | errorMessage =
+                                            Just <|
+                                                "Error trying to unlock the text: "
+                                                    ++ String.join " and " (Dict.values errors)
+                                    }
+                                , Cmd.none
+                                )
+
+                            Err _ ->
+                                ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
+                                , Cmd.none
+                                )
 
                 _ ->
                     ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }

--- a/web/src/Pages/Text/Edit/Id_Int.elm
+++ b/web/src/Pages/Text/Edit/Id_Int.elm
@@ -240,22 +240,28 @@ update msg (SafeModel model) =
         GotText (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    case Text.Decode.decodeRespErrors body of
-                        Ok errors ->
-                            ( SafeModel
-                                { model
-                                    | errorMessage =
-                                        Just <|
-                                            "Could not retrieve text: "
-                                                ++ String.join " and " (Dict.values errors)
-                                }
-                            , Cmd.none
-                            )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
 
-                        Err _ ->
-                            ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
-                            , Cmd.none
-                            )
+                    else
+                        case Text.Decode.decodeRespErrors body of
+                            Ok errors ->
+                                ( SafeModel
+                                    { model
+                                        | errorMessage =
+                                            Just <|
+                                                "Could not retrieve text: "
+                                                    ++ String.join " and " (Dict.values errors)
+                                    }
+                                , Cmd.none
+                                )
+
+                            Err _ ->
+                                ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
+                                , Cmd.none
+                                )
 
                 _ ->
                     ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
@@ -280,14 +286,20 @@ update msg (SafeModel model) =
         GotTextCreated (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    case Text.Decode.decodeRespErrors body of
-                        Ok errors ->
-                            ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
 
-                        Err _ ->
-                            ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
-                            , Cmd.none
-                            )
+                    else
+                        case Text.Decode.decodeRespErrors body of
+                            Ok errors ->
+                                ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+
+                            Err _ ->
+                                ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
+                                , Cmd.none
+                                )
 
                 _ ->
                     ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
@@ -311,14 +323,20 @@ update msg (SafeModel model) =
         GotTextUpdated (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    case Text.Decode.decodeRespErrors body of
-                        Ok errors ->
-                            ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
 
-                        Err _ ->
-                            ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
-                            , Cmd.none
-                            )
+                    else
+                        case Text.Decode.decodeRespErrors body of
+                            Ok errors ->
+                                ( SafeModel { model | text_component = Text.Component.update_text_errors model.text_component errors }, Cmd.none )
+
+                            Err _ ->
+                                ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
+                                , Cmd.none
+                                )
 
                 _ ->
                     ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
@@ -338,18 +356,24 @@ update msg (SafeModel model) =
         GotTextDeleted (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    case Text.Decode.decodeRespErrors body of
-                        Ok errors ->
-                            let
-                                errorsStr =
-                                    String.join " and " (Dict.values errors)
-                            in
-                            ( SafeModel { model | errorMessage = Just <| "Error trying to delete the text: " ++ errorsStr }, Cmd.none )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
 
-                        Err _ ->
-                            ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
-                            , Cmd.none
-                            )
+                    else
+                        case Text.Decode.decodeRespErrors body of
+                            Ok errors ->
+                                let
+                                    errorsStr =
+                                        String.join " and " (Dict.values errors)
+                                in
+                                ( SafeModel { model | errorMessage = Just <| "Error trying to delete the text: " ++ errorsStr }, Cmd.none )
+
+                            Err _ ->
+                                ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
+                                , Cmd.none
+                                )
 
                 _ ->
                     ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
@@ -478,22 +502,28 @@ update msg (SafeModel model) =
         TextLocked (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    case Text.Decode.decodeRespErrors body of
-                        Ok errors ->
-                            ( SafeModel
-                                { model
-                                    | errorMessage =
-                                        Just <|
-                                            "Error trying to lock the text: "
-                                                ++ String.join " and " (Dict.values errors)
-                                }
-                            , Cmd.none
-                            )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
 
-                        Err _ ->
-                            ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
-                            , Cmd.none
-                            )
+                    else
+                        case Text.Decode.decodeRespErrors body of
+                            Ok errors ->
+                                ( SafeModel
+                                    { model
+                                        | errorMessage =
+                                            Just <|
+                                                "Error trying to lock the text: "
+                                                    ++ String.join " and " (Dict.values errors)
+                                    }
+                                , Cmd.none
+                                )
+
+                            Err _ ->
+                                ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
+                                , Cmd.none
+                                )
 
                 _ ->
                     ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
@@ -513,22 +543,28 @@ update msg (SafeModel model) =
         TextUnlocked (Err error) ->
             case error of
                 Http.Detailed.BadStatus metadata body ->
-                    case Text.Decode.decodeRespErrors body of
-                        Ok errors ->
-                            ( SafeModel
-                                { model
-                                    | errorMessage =
-                                        Just <|
-                                            "Error trying to unlock the text: "
-                                                ++ String.join " and " (Dict.values errors)
-                                }
-                            , Cmd.none
-                            )
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
 
-                        Err _ ->
-                            ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
-                            , Cmd.none
-                            )
+                    else
+                        case Text.Decode.decodeRespErrors body of
+                            Ok errors ->
+                                ( SafeModel
+                                    { model
+                                        | errorMessage =
+                                            Just <|
+                                                "Error trying to unlock the text: "
+                                                    ++ String.join " and " (Dict.values errors)
+                                    }
+                                , Cmd.none
+                                )
+
+                            Err _ ->
+                                ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }
+                                , Cmd.none
+                                )
 
                 _ ->
                     ( SafeModel { model | errorMessage = Just "An internal error occured. Please contact the developers." }

--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -10,6 +10,7 @@ import Html exposing (..)
 import Html.Attributes exposing (attribute, class, classList, href, id)
 import Html.Events exposing (onClick)
 import Http
+import Http.Detailed
 import InstructorAdmin.Admin.Text as AdminText
 import Ports exposing (clearInputText)
 import Session exposing (Session)
@@ -138,7 +139,8 @@ type Msg
     = AddDifficulty String Bool
     | SelectTag String Bool
     | SelectStatus TextReadStatus Bool
-    | TextSearch (Result Http.Error (List Text.Model.TextListItem))
+      -- | TextSearch (Result Http.Error (List Text.Model.TextListItem))
+    | TextSearch (Result (Http.Detailed.Error String) ( Http.Metadata, List Text.Model.TextListItem ))
       -- help messages
     | CloseHint TextSearch.Help.TextHelp
     | PreviousHint
@@ -195,17 +197,28 @@ update msg (SafeModel model) =
                 ]
             )
 
-        TextSearch result ->
-            case result of
-                Ok texts ->
-                    ( SafeModel { model | results = texts }, Cmd.none )
+        TextSearch (Ok ( metadata, texts )) ->
+            ( SafeModel { model | results = texts }
+            , Cmd.none
+            )
 
-                Err err ->
-                    let
-                        _ =
-                            Debug.log "error retrieving results" err
-                    in
-                    ( SafeModel { model | errorMessage = Just "An error occurred.  Please contact an administrator." }, Cmd.none )
+        TextSearch (Err error) ->
+            case error of
+                Http.Detailed.BadStatus metadata body ->
+                    if metadata.statusCode == 403 then
+                        ( SafeModel model
+                        , Api.logout ()
+                        )
+
+                    else
+                        ( SafeModel { model | errorMessage = Just "An error occurred.  Please contact an administrator." }
+                        , Cmd.none
+                        )
+
+                _ ->
+                    ( SafeModel { model | errorMessage = Just "An error occurred.  Please contact an administrator." }
+                    , Cmd.none
+                    )
 
         CloseHint helpMessage ->
             ( SafeModel { model | help = TextSearch.Help.setVisible model.help helpMessage False }
@@ -238,7 +251,7 @@ updateResults session config textSearch =
             List.map Endpoint.filterToStringQueryParam filterParams
     in
     if List.length filterParams > 0 then
-        Api.get
+        Api.getDetailed
             (Endpoint.textSearch (Config.restApiUrl config) queryParameters)
             (Session.cred session)
             TextSearch

--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -139,7 +139,6 @@ type Msg
     = AddDifficulty String Bool
     | SelectTag String Bool
     | SelectStatus TextReadStatus Bool
-      -- | TextSearch (Result Http.Error (List Text.Model.TextListItem))
     | TextSearch (Result (Http.Detailed.Error String) ( Http.Metadata, List Text.Model.TextListItem ))
       -- help messages
     | CloseHint TextSearch.Help.TextHelp

--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -158,14 +158,14 @@ update msg model =
             ( { model
                 | infobar = Just <| Infobar.successBottom (Api.authSuccessMessage authSuccess)
               }
-            , Task.perform (\_ -> ClearInfobar) <| Process.sleep 2500
+            , Task.perform (\_ -> ClearInfobar) <| Process.sleep 3000
             )
 
         GotAuthResult (Err authError) ->
             ( { model
                 | infobar = Just <| Infobar.errorBottom (Api.authErrorMessage authError)
               }
-            , Task.perform (\_ -> ClearInfobar) <| Process.sleep 2500
+            , Task.perform (\_ -> ClearInfobar) <| Process.sleep 3000
             )
 
         GotSession session ->

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -115,10 +115,18 @@ app.ports.login.subscribe(async (creds: Creds) => {
 // LOGOUT
 
 app.ports.logout.subscribe(async () => {
-  app.ports.onAuthStoreChange.send(null);
-  localStorage.removeItem(authStoreKey);
+  logout();
 });
 
+const logout = () => {
+  app.ports.onAuthStoreChange.send(null);
+  localStorage.removeItem(authStoreKey);
+  window.scrollTo(0, 0);
+  app.ports.onAuthResponse.send({
+    result: 'success',
+    message: 'Logging you out. Please login again to continue using the STAR site.'
+  });
+}
 
 // Notify inactive tabs when user changes
 window.addEventListener(
@@ -148,8 +156,7 @@ const sendSocketCommand = wat => {
       // console.log("onmessage: " + JSON.stringify(event.data, null, 4));
       const data = JSON.parse(event.data);
       if (data.error && data.error == "Invalid JWT") {
-        app.ports.onAuthStoreChange.send(null);
-        localStorage.removeItem(authStoreKey);
+        logout();
       } else {
         app.ports.receiveSocketMsg.send({
           name: wat.name,

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,5 +1,6 @@
 // @ts-expect-error
 import { Elm } from './Main.elm';
+import jwtDecode, { JwtPayload } from "jwt-decode";
 
 type User = { user: { id: number; token: string; role: string } };
 type ShowHelp = { showHelp: boolean };
@@ -12,9 +13,21 @@ let mySockets = {};
 
 // INIT
 
-const user: User = JSON.parse(localStorage.getItem(authStoreKey));
+let user: User = JSON.parse(localStorage.getItem(authStoreKey));
 let showHelp: ShowHelp = JSON.parse(localStorage.getItem('showHelp'));
 
+if (user) {
+  const decodedToken = jwtDecode<JwtPayload>(user.user.token);
+  const now = new Date().getTime() / 1000;
+
+  // nullify user and remove token if token expired
+  if (decodedToken.exp <= now) {
+    localStorage.removeItem(authStoreKey);
+    user = null;
+  }
+}
+
+// initialize show help for new users
 if (showHelp === null) {
   showHelp = { showHelp: true };
   localStorage.setItem('showHelp', JSON.stringify(showHelp));
@@ -25,11 +38,13 @@ const app = Elm.Main.init({
   flags: { restApiUrl, websocketBaseUrl, ...showHelp, ...user }
 });
 
+
 // HELP
 
 app.ports.toggleShowHelp.subscribe(showHelp => {
   localStorage.setItem('showHelp', JSON.stringify(showHelp));
 });
+
 
 // LOGIN
 
@@ -54,7 +69,7 @@ app.ports.login.subscribe(async (creds: Creds) => {
     method: 'POST',
     body: JSON.stringify(creds)
   });
-  const jsonResponse = await response.json(); // { token: "JWTToken"}
+  const jsonResponse = await response.json()
 
   if (response.ok) {
     const user: User = {
@@ -96,23 +111,14 @@ app.ports.login.subscribe(async (creds: Creds) => {
   }
 });
 
+
 // LOGOUT
 
 app.ports.logout.subscribe(async () => {
-  // const response = await fetch(restApiUrl + 'logout', {
-  //   headers: {
-  //     'Accept': 'application/json',
-  //     'Content-Type': 'application/json'
-  //   },
-  //   method: 'POST',
-  //   body: ""
-  // });
-  // const jsonResponse = await response.json(); // { message: "logged out"}
-  // console.log('logout response', jsonResponse)
-
-  localStorage.removeItem(authStoreKey);
   app.ports.onAuthStoreChange.send(null);
+  localStorage.removeItem(authStoreKey);
 });
+
 
 // Notify inactive tabs when user changes
 window.addEventListener(
@@ -140,11 +146,17 @@ const sendSocketCommand = wat => {
     let socket = new WebSocket(wat.address);
     socket.onmessage = function (event) {
       // console.log("onmessage: " + JSON.stringify(event.data, null, 4));
-      app.ports.receiveSocketMsg.send({
-        name: wat.name,
-        msg: 'data',
-        data: event.data
-      });
+      const data = JSON.parse(event.data);
+      if (data.error && data.error == "Invalid JWT") {
+        app.ports.onAuthStoreChange.send(null);
+        localStorage.removeItem(authStoreKey);
+      } else {
+        app.ports.receiveSocketMsg.send({
+          name: wat.name,
+          msg: 'data',
+          data: event.data
+        });
+      }
     };
     mySockets[wat.name] = socket;
   } else if (wat.cmd == 'send') {


### PR DESCRIPTION
This PR updates HTTP and WebSocket error handling to log the user out when their token has expired. In addition, a check has been added to make sure the user's JWT is valid on a return visit before logging them in automatically.

An infobar implementation has also been added to show user's a meaningful message when they are logged out automatically. The infobar displays auth error messages, such as when a user attempts to log in with the wrong credentials.