### PR TITLE
Feature/redis env setting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - VIRTUAL_PORT=8000
       - LETSENCRYPT_HOST=api.steps2ar.org
       - FRONTEND_HOST=steps2ar.org
+      - REDIS_ENDPOINT=redis
     expose:
       - "8000"
       - "6379"

--- a/ereadingtool/settings.py
+++ b/ereadingtool/settings.py
@@ -20,7 +20,7 @@ CHANNEL_LAYERS = {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
             # When the container spawns it's aliased to "redis" see docker insepct <redis_container> output
-            'hosts': [('localhost', 6379)], 
+            'hosts': [(os.getenv('REDIS_ENDPOINT'), 6379)], 
         },
     },
 }
@@ -105,7 +105,7 @@ LOGGING = {
 
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 
-DEBUG = False 
+DEBUG = True
 DEV = False
 
 ALLOWED_HOSTS = ['0.0.0.0',

--- a/ereadingtool/settings.py
+++ b/ereadingtool/settings.py
@@ -105,7 +105,7 @@ LOGGING = {
 
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 
-DEBUG = True
+DEBUG = False
 DEV = False
 
 ALLOWED_HOSTS = ['0.0.0.0',


### PR DESCRIPTION
To test this set an environment variable `REDIS_ENDPOINT=localhost`. Run the backend in the usual way and attempt to access a text. If redis is running on the same machine, and you can navigate texts, things are working accordingly.