### PR TITLE
Fix hidden navbar overhang

### DIFF
--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -138,6 +138,18 @@ body {
     transition: opacity 0s, height 0.4s, padding 0.25s;
   }
 
+  #header > .hidden-menu > .nav-item {
+    height: 0;
+    padding: 0;
+    transition: opacity 0s, height 0.4s, padding 0.25s;
+  }
+
+  #header > .hidden-menu > .nav-item > .nav-link {
+    height: 0;
+    padding: 0;
+    transition: opacity 0s, height 0.4s, padding 0.25s;
+  }
+
   #header * a:hover {
     text-decoration: none;
   }


### PR DESCRIPTION
This PR fixes a bug where the navbar was hidden, but its contents were still in the DOM. On some devices, users were unable to use the login form because of the hidden overhang.

To test this PR, open the app as a small mobile device in portrait mode in the developer tools. Inspect the elements in the `div` with the class `hidden-menu` and make check that have no height.