### PR TITLE
Change read again to a link and take id from page

### DIFF
--- a/web/src/Pages/Text/Id_Int.elm
+++ b/web/src/Pages/Text/Id_Int.elm
@@ -137,7 +137,6 @@ type Msg
     | ViewFeedback Section TextQuestion TextAnswer Bool
     | PrevSection
     | NextSection
-    | StartOver
     | Gloss TextReaderWord
     | UnGloss TextReaderWord
     | ToggleGloss TextReaderWord
@@ -208,12 +207,6 @@ update msg (SafeModel model) =
         ViewFeedback _ _ _ _ ->
             ( SafeModel model
             , Cmd.none
-            )
-
-        StartOver ->
-            ( SafeModel model
-            , Browser.Navigation.replaceUrl model.navKey <|
-                Route.toString (Route.Text__Id_Int { id = model.text.id })
             )
 
         NextSection ->
@@ -608,7 +601,11 @@ viewTextComplete (SafeModel model) scores =
         , viewTextConclusion model.text
         , div [ id "nav" ]
             [ viewPreviousButton
-            , div [ onClick StartOver ] [ Html.text "Read Again" ]
+            , Html.a
+                [ attribute "href" (Route.toString (Route.Text__Id_Int { id = model.id }))
+                ]
+                [ span [] [ Html.text "Read Again" ]
+                ]
             , Html.a [ attribute "href" (Route.toString Route.Text__Search) ] [ span [] [ Html.text "Read Another Text" ] ]
             ]
         ]


### PR DESCRIPTION
This PR addresses the occasionally broken "Read Again" button in the text reader mentioned in #285. Sometimes, it would route the user to text 0 instead of the text they wished to start over. Likely, this was a race to get the ID from the text that sometimes got the ID of the default empty text instead.

To test this PR, read through a text and click Read Again to see if it starts you over. We will have to keep an eye on this one because it did not always happen, but hopefully this solves it.