### PR TITLE
Add lemmas

### DIFF
--- a/web/src/Pages/Text/Id_Int.elm
+++ b/web/src/Pages/Text/Id_Int.elm
@@ -693,13 +693,19 @@ viewWordAndGrammemes reader_word text_word =
 
             else
                 TextReader.Model.phrase reader_word
+
+        grammemes =
+            TextReader.TextWord.grammemesToString text_word
     in
     div []
         [ Html.text <|
             displayedWord
-                ++ " ("
-                ++ TextReader.TextWord.grammemesToString text_word
-                ++ ")"
+                ++ (if not (String.isEmpty grammemes) then
+                        " (" ++ grammemes ++ ")"
+
+                    else
+                        ""
+                   )
         ]
 
 

--- a/web/src/Pages/Text/Id_Int.elm
+++ b/web/src/Pages/Text/Id_Int.elm
@@ -686,8 +686,23 @@ viewGloss (SafeModel model) reader_word text_word =
 
 viewWordAndGrammemes : TextReaderWord -> TextReader.TextWord.TextWord -> Html Msg
 viewWordAndGrammemes reader_word text_word =
+    let
+        lemma =
+            TextReader.TextWord.lemma text_word
+
+        displayedWord =
+            if not (String.isEmpty lemma) then
+                lemma
+
+            else
+                TextReader.Model.phrase reader_word
+    in
     div []
-        [ Html.text <| TextReader.Model.phrase reader_word ++ " (" ++ TextReader.TextWord.grammemesToString text_word ++ ")"
+        [ Html.text <|
+            displayedWord
+                ++ " ("
+                ++ TextReader.TextWord.grammemesToString text_word
+                ++ ")"
         ]
 
 

--- a/web/src/Text/Translations.elm
+++ b/web/src/Text/Translations.elm
@@ -178,7 +178,8 @@ mergeTextWordEndpointToString endpoint =
 expectedGrammemeKeys : Set String
 expectedGrammemeKeys =
     Set.fromList
-        [ "pos"
+        [ "lemma"
+        , "pos"
         , "tense"
         , "aspect"
         , "form"

--- a/web/src/Text/Translations/Model.elm
+++ b/web/src/Text/Translations/Model.elm
@@ -96,7 +96,7 @@ editingGrammeme : Model -> String
 editingGrammeme model =
     let
         firstGrammemeName =
-            "aspect"
+            "lemma"
     in
     Maybe.withDefault firstGrammemeName model.editing_grammeme
 

--- a/web/src/Text/Translations/View.elm
+++ b/web/src/Text/Translations/View.elm
@@ -345,9 +345,16 @@ view_instance_word model msg wordInstance =
 
             else
                 word wordInstance
+
+        lemma =
+            Text.Translations.Word.Instance.lemma wordInstance
     in
     div [ class "word" ]
-        [ Html.text wordTxt
+        [ if not (String.isEmpty lemma) then
+            Html.text lemma
+
+          else
+            Html.text wordTxt
         , view_grammemes model msg wordInstance
         ]
 
@@ -396,13 +403,21 @@ view_add_grammemes model msg wordInstance =
     let
         grammemeKeys =
             Set.toList Text.Translations.Word.Instance.grammemeKeys
+                -- make "lemma" the first option in the dropdown
+                |> List.filter (\key -> key /= "lemma")
+                |> (::) "lemma"
 
         grammemeValue =
             Text.Translations.Model.editingGrammemeValue model wordInstance
     in
     div [ class "add" ]
         [ select [ onInput (SelectGrammemeForEditing wordInstance >> msg) ]
-            (List.map (\grammeme -> option [ value grammeme ] [ Html.text grammeme ]) grammemeKeys)
+            (List.map
+                (\grammeme ->
+                    option [ value grammeme ] [ Html.text grammeme ]
+                )
+                grammemeKeys
+            )
         , div [ onInput (InputGrammeme wordInstance >> msg) ]
             [ Html.input
                 [ class "text-translation-input"
@@ -429,7 +444,9 @@ view_grammemes model msg wordInstance =
     div [ class "grammemes" ] <|
         (case Text.Translations.Word.Instance.grammemes wordInstance of
             Just grammemes ->
-                List.map view_grammeme <| Dict.toList grammemes
+                Dict.toList grammemes
+                    |> List.filter (\( k, v ) -> k /= "lemma")
+                    |> List.map view_grammeme
 
             Nothing ->
                 []

--- a/web/src/Text/Translations/Word/Instance.elm
+++ b/web/src/Text/Translations/Word/Instance.elm
@@ -7,6 +7,7 @@ module Text.Translations.Word.Instance exposing
     , hasTextWord
     , id
     , instance
+    , lemma
     , new
     , sectionNumber
     , setTextWord
@@ -16,6 +17,7 @@ module Text.Translations.Word.Instance exposing
     , wordInstanceSectionNumberToInt
     )
 
+import Dict
 import Set exposing (Set)
 import Text.Translations exposing (Grammemes, Id, Instance, SectionNumber, Token)
 import Text.Translations.TextWord exposing (TextWord)
@@ -60,6 +62,25 @@ grammemes : WordInstance -> Maybe Grammemes
 grammemes wordInstance =
     textWord wordInstance
         |> Maybe.andThen Text.Translations.TextWord.grammemes
+
+
+lemma : WordInstance -> String
+lemma wordInstance =
+    textWord wordInstance
+        |> Maybe.andThen Text.Translations.TextWord.grammemes
+        |> (\maybeGrammemes ->
+                case maybeGrammemes of
+                    Just grs ->
+                        case Dict.get "lemma" grs of
+                            Just lmma ->
+                                lmma
+
+                            Nothing ->
+                                ""
+
+                    Nothing ->
+                        ""
+           )
 
 
 sectionNumber : WordInstance -> SectionNumber

--- a/web/src/TextReader/TextWord.elm
+++ b/web/src/TextReader/TextWord.elm
@@ -5,6 +5,7 @@ module TextReader.TextWord exposing
     , grammemesToString
     , group
     , hasTranslations
+    , lemma
     , new
     , newFromParams
     , phrase
@@ -75,9 +76,25 @@ grammemesToString : TextWord -> String
 grammemesToString text_word =
     case grammemes text_word of
         Just grs ->
-            String.join ", " <|
-                List.map (\( g, v ) -> g ++ ": " ++ v) <|
-                    Dict.toList grs
+            Dict.toList grs
+                |> List.filter (\( g, v ) -> g /= "lemma")
+                |> List.map (\( g, v ) -> g ++ ": " ++ v)
+                |> String.join ", "
+
+        Nothing ->
+            ""
+
+
+lemma : TextWord -> String
+lemma (TextWord _ _ phrs maybeGrammemes _ _) =
+    case maybeGrammemes of
+        Just grs ->
+            case Dict.get "lemma" grs of
+                Just lmma ->
+                    lmma
+
+                Nothing ->
+                    ""
 
         Nothing ->
             ""


### PR DESCRIPTION
This PR adds lemmas to the frontend. The lemmas are displayed in the text reader glosses and in the translations tab glosses as the main word form. The phrase is used as a fallback if the lemma is missing.

The lemma was also added to the grammemes dropdown as the first option, and it is saved when you save the other grammemes.

To test this PR, start off as an instructor and create a new text. Use the sample text "Это испытание". After the text is created, go to the translations tab on the edit page for the text. Add one of the words as a text word.  At this point, the displayed word should be the highlighted phrase. 

Log in as a student and find the text you just made. Check that the main displayed word matches the highlighted phrase.

Log back in as an instructor. Go to the edit page for the text. In the grammemes, enter some text for the lemma that is different from the highlighted text (doesn't have to be the real lemma! this is just to see the difference). Save the grammemes. The displayed word should be the lemma.

Log in as a student and find the text again. Check that the main displayed word matches the lemma you saved.