### PR TITLE
Add close all websockets command

### DIFF
--- a/web/src/Api.elm
+++ b/web/src/Api.elm
@@ -22,6 +22,7 @@ port module Api exposing
     , viewerChanges
     , websocketConnect
     , websocketDisconnect
+    , websocketDisconnectAll
     , websocketReceive
     , websocketSend
     )
@@ -542,3 +543,9 @@ websocketDisconnect : String -> Cmd msg
 websocketDisconnect name =
     WebSocket.send sendSocketCommand <|
         WebSocket.Close { name = name }
+
+
+websocketDisconnectAll : Cmd msg
+websocketDisconnectAll =
+    WebSocket.send sendSocketCommand <|
+        WebSocket.CloseAll

--- a/web/src/Api/WebSocket.elm
+++ b/web/src/Api/WebSocket.elm
@@ -165,6 +165,7 @@ type WebSocketCmd
     = Connect { name : String, address : String, protocol : String }
     | Send { name : String, content : JE.Value }
     | Close { name : String }
+    | CloseAll
 
 
 {-| WebSocketMsgs are responses from javascript to elm after websocket operations.
@@ -200,6 +201,10 @@ encodeCmd wsc =
                 [ ( "cmd", JE.string "close" )
                 , ( "name", JE.string msg.name )
                 ]
+
+        CloseAll ->
+            JE.object
+                [ ( "cmd", JE.string "closeAll" ) ]
 
 
 {-| decode incoming messages from the websocket javascript.

--- a/web/src/Pages/Flashcards/Student.elm
+++ b/web/src/Pages/Flashcards/Student.elm
@@ -73,14 +73,17 @@ init shared { params } =
         }
     , case Session.viewer shared.session of
         Just viewer ->
-            Api.websocketConnect
-                { name = "flashcard"
-                , address =
-                    WebSocket.flashcards
-                        (Config.websocketBaseUrl shared.config)
-                        (Viewer.role viewer)
-                }
-                (Session.cred shared.session)
+            Cmd.batch
+                [ Api.websocketConnect
+                    { name = "flashcard"
+                    , address =
+                        WebSocket.flashcards
+                            (Config.websocketBaseUrl shared.config)
+                            (Viewer.role viewer)
+                    }
+                    (Session.cred shared.session)
+                , Api.websocketDisconnect "textreader"
+                ]
 
         Nothing ->
             Cmd.none

--- a/web/src/Pages/Profile/Instructor.elm
+++ b/web/src/Pages/Profile/Instructor.elm
@@ -71,7 +71,7 @@ init shared { params } =
         , newInviteEmail = Nothing
         , errors = Dict.empty
         }
-    , Cmd.none
+    , Api.websocketDisconnectAll
     )
 
 

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -110,7 +110,10 @@ init shared { params } =
         , errorMessage = ""
         , errors = Dict.empty
         }
-    , Help.scrollToFirstMsg help
+    , Cmd.batch
+        [ Help.scrollToFirstMsg help
+        , Api.websocketDisconnectAll
+        ]
     )
 
 

--- a/web/src/Pages/Text/Create.elm
+++ b/web/src/Pages/Text/Create.elm
@@ -107,7 +107,10 @@ init shared { params } =
         , selectedTab = TextTab
         , writeLocked = False
         }
-    , Task.perform (\_ -> InitTextFieldEditors) (Task.succeed Nothing)
+    , Cmd.batch
+        [ Task.perform (\_ -> InitTextFieldEditors) (Task.succeed Nothing)
+        , Api.websocketDisconnectAll
+        ]
     )
 
 

--- a/web/src/Pages/Text/Edit/Id_Int.elm
+++ b/web/src/Pages/Text/Edit/Id_Int.elm
@@ -116,6 +116,7 @@ init shared { params } =
     , Cmd.batch
         [ Task.perform (\_ -> InitTextFieldEditors) (Task.succeed Nothing)
         , getText shared.session shared.config params.id
+        , Api.websocketDisconnectAll
         ]
     )
 

--- a/web/src/Pages/Text/EditorSearch.elm
+++ b/web/src/Pages/Text/EditorSearch.elm
@@ -62,7 +62,10 @@ init shared { params } =
         , profile = shared.profile
         , loading = True
         }
-    , getTexts shared.session shared.config
+    , Cmd.batch
+        [ getTexts shared.session shared.config
+        , Api.websocketDisconnectAll
+        ]
     )
 
 

--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -127,7 +127,10 @@ init shared { params } =
         , help = textSearchHelp
         , errorMessage = Nothing
         }
-    , updateResults shared.session shared.config textSearch
+    , Cmd.batch
+        [ updateResults shared.session shared.config textSearch
+        , Api.websocketDisconnectAll
+        ]
     )
 
 

--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -250,7 +250,10 @@ update msg model =
 
         Logout ->
             ( model
-            , Api.logout ()
+            , Cmd.batch
+                [ Api.logout ()
+                , Api.websocketDisconnectAll
+                ]
             )
 
 

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,6 +1,7 @@
 // @ts-expect-error
 import { Elm } from './Main.elm';
 import jwtDecode, { JwtPayload } from "jwt-decode";
+import { Console } from 'console';
 
 type User = { user: { id: number; token: string; role: string } };
 type ShowHelp = { showHelp: boolean };
@@ -9,7 +10,7 @@ type Creds = { email: string; password: string; role: string };
 const restApiUrl: string = process.env.RESTAPIURL;
 const websocketBaseUrl: string = process.env.WEBSOCKETBASEURL;
 const authStoreKey: string = 'user';
-let mySockets = {};
+let sockets = {};
 
 // INIT
 
@@ -143,17 +144,14 @@ window.addEventListener(
 // WEBSOCKETS
 
 const sendSocketCommand = wat => {
-  // console.log('ssc: ' + JSON.stringify(wat, null, 4));
   if (wat.cmd == 'connect') {
-    // implicit disconnect on new socket connection, explicit would be better
-    if (mySockets[wat.name]) {
-      mySockets[wat.name].close();
+    // implicit disconnect on new socket connection with the same name
+    if (sockets[wat.name]) {
+      sockets[wat.name].close();
     }
 
-    // console.log("connecting!");
     let socket = new WebSocket(wat.address);
     socket.onmessage = function (event) {
-      // console.log("onmessage: " + JSON.stringify(event.data, null, 4));
       const data = JSON.parse(event.data);
       if (data.error && data.error == "Invalid JWT") {
         logout();
@@ -170,19 +168,21 @@ const sendSocketCommand = wat => {
         });
       }
     };
-    mySockets[wat.name] = socket;
+    sockets[wat.name] = socket;
   } else if (wat.cmd == 'send') {
-    // console.log('sending to socket: ' + wat.name);
-    mySockets[wat.name].send(JSON.stringify(wat.content));
+    sockets[wat.name].send(JSON.stringify(wat.content));
   } else if (wat.cmd == 'close') {
-    // console.log('closing socket: ' + wat.name);
-    mySockets[wat.name].close();
-    delete mySockets[wat.name];
+    sockets[wat.name].close();
+    delete sockets[wat.name];
+  } else if (wat.cmd == 'closeAll') {
+    Object.keys(sockets).forEach(name => {
+      sockets[name].close();
+      delete sockets[name];
+    });
   }
 };
 
 app.ports.sendSocketCommand.subscribe(config => {
-  console.log(config);
   sendSocketCommand(config);
 });
 


### PR DESCRIPTION
This PR adds a command to disconnect open websockets when we navigate to a new page. We don't have a teardown mechanism when we leave a page, so instead we clean up when we init the new page.

We are mainly doing this for the text reader websocket connection, but this implementation is more general because we may also need it for the flashcards websocket connection. 

To test this PR, start reading a text. Navigate to a new page from the navbar or at the end of the text by selecting "Read Again" or "Read Another Text".