### PR TITLE
Add pointer on hover over logout link

### DIFF
--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -477,7 +477,7 @@ viewProfileHeader role toMsg =
             [ text "Profile" ]
         ]
     , div [ class "nav-item " ]
-        [ a [ onClick (toMsg Logout), class "nav-link" ]
+        [ a [ onClick (toMsg Logout), class "nav-link", class "cursor" ]
             [ text "Logout" ]
         ]
     ]


### PR DESCRIPTION
Tiny PR to change the cursor to show a pointer when hovering over the logout link in the navbar. To test it, hover over "Logout" as a student and as an instructor.