### PR TITLE
Fix forgot password submit button styling

### DIFF
--- a/web/src/Pages/User/ForgotPassword.elm
+++ b/web/src/Pages/User/ForgotPassword.elm
@@ -241,8 +241,9 @@ viewSubmit model =
             else
                 [ onClick Submit, class "cursor" ]
     in
-    [ loginLabel (class "button" :: buttonDisabled)
-        (div [ class "login_submit" ] [ span [] [ Html.text "Forgot Password" ] ])
+    [ div (class "button" :: buttonDisabled)
+        [ div [ class "login_submit" ] [ span [] [ Html.text "Forgot Password" ] ]
+        ]
     ]
 
 
@@ -269,7 +270,7 @@ viewResponse forgotPasswordResponse =
 
 loginLabel : List (Html.Attribute Msg) -> Html Msg -> Html Msg
 loginLabel attributes html =
-    div (attribute "class" "login_label" :: attributes)
+    div (class "login_label" :: attributes)
         [ html
         ]
 


### PR DESCRIPTION
When first navigating to the forgot password page, the button was not displayed correctly as a button. This PR fixes that.

To test, navigate to the forgot password button and check that the button looks like the buttons on the login pages.