### PR TITLE
Bugfix/pin pyjwt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ jobs:
   build:
     docker:
       # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
-      - image: circleci/python:3.6.7
+      - image: circleci/python:3.9.1
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:
       - checkout
       - run: sudo chown -R circleci:circleci /usr/local/bin
-      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.9/site-packages
       - restore_cache:
       # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
@@ -23,10 +23,10 @@ jobs:
           paths:
             - ".venv"
             - "/usr/local/bin"
-            - "/usr/local/lib/python3.6/site-packages"
-      - run:
+            - "/usr/local/lib/python3.9/site-packages"
+      - run: #sudo pip3 install -r requirements.txt --upgrade # removed upgrade because it trampled pinned dependencies
           command: |
-            sudo pip3 install -r requirements.txt --upgrade
+            sudo pip3 install -r requirements.txt
       - run:
           command: |
             pipenv run python3 manage.py test

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ pytz
 webstack-django-jwt-auth
 django-cors-headers
 # this is new
-PyJWT
+PyJWT==1.7.1

--- a/user/views/instructor.py
+++ b/user/views/instructor.py
@@ -146,7 +146,7 @@ class InstructorLoginAPIView(APIView):
 
         # manually add the field `[id]` to the jwt payload
         jwt_payload['id'] = reader_user.instructor.pk
-
+            
         # return to the dispatcher to send out an HTTP response
         return JsonResponse(jwt_payload)
 


### PR DESCRIPTION
Pinned pyJWT at 1.7.1 because there are changes at 2.0.0 that make django-jwt-auth unusable. Would like to see django-jwt-auth adapted to use pyJWT 2.0.0 but that's outside of this project scope.

Oddly enough there was still need to decode a bytes object to utf-8 even after roll back. That's unsolved at the moment but the tests now pass and there is no longer an exception thrown in `user/views/instructor.py` or `user/views/user.py`