### PR TITLE
Feature/update homepage links

### DIFF
--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -445,3 +445,30 @@ body {
     width: 75%;
   }
 }
+
+.login_options a {
+  color: #00478f;
+  text-decoration: none
+}
+
+.login_options a:hover {
+  text-decoration: underline;
+}
+
+#acknowledgements-and-about a {
+  color: #00478f;
+  text-decoration: none
+}
+
+#acknowledgements-and-about a:hover {
+  text-decoration: underline;
+}
+
+#acknowledgements a {
+  color: #00478f;
+  text-decoration: none
+}
+
+#acknowledgements a:hover {
+  text-decoration: underline;
+}

--- a/web/src/User/Login.elm
+++ b/web/src/User/Login.elm
@@ -2,7 +2,7 @@ module User.Login exposing (LoginParams, login, viewLoginForm)
 
 import Api
 import Dict exposing (Dict)
-import Html exposing (Html, div, span)
+import Html exposing (Html, div, span, text)
 import Html.Attributes exposing (attribute, class, classList, id)
 import Html.Events exposing (onClick, onInput, onSubmit)
 import Http exposing (..)
@@ -244,12 +244,12 @@ viewLinks =
     [ div [ id "acknowledgements-and-about" ]
         [ div []
             [ Html.a [ attribute "href" (Route.toString Route.About) ]
-                [ Html.text "About This Website"
+                [ text "About This Website"
                 ]
             ]
         , div []
             [ Html.a [ attribute "href" (Route.toString Route.Acknowledgments) ]
-                [ Html.text "Acknowledgements"
+                [ text "Acknowledgements"
                 ]
             ]
         ]


### PR DESCRIPTION
Updated CSS. On my journeys I also changed some Elm to be more consistent with other files (we now `import HTML text` rather than explicitly call out it's member `HTML.text`. 

Thought it would be simplest to put the changes in `ereader.css`. I couldn't tell if there is a CSS file specifically for the login or acknowledgment pages.