### PR TITLE
PyJWT and webstack-django-jwt-auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ pytz
 webstack-django-jwt-auth
 django-cors-headers
 # this is new
-PyJWT==1.7.1
+PyJWT


### PR DESCRIPTION
PyJWT changed to 2.0.0 and the changes just rippled down to webstack.
Since they are no longer breaking `webstack-django-jwt-auth` and we'd
have to pin that too, we're going along with `latest` versions for
both.