### PR TITLE
Add ids to email and password inputs

### DIFF
--- a/web/src/User/Login.elm
+++ b/web/src/User/Login.elm
@@ -99,7 +99,8 @@ viewEmailInput { onEmailUpdate, errors } =
     in
     [ div [ class "input-container" ]
         [ Html.input
-            ([ class "email-input"
+            ([ id "email-input"
+             , class "email-input"
              , attribute "size" "25"
              , attribute "placeholder" "Email Address"
              , onInput onEmailUpdate
@@ -142,7 +143,8 @@ viewPasswordInput { onPasswordUpdate, onSubmittedForm, errors } =
     in
     [ div [ class "input-container" ]
         [ Html.input
-            ([ class "password-input"
+            ([ id "password-input"
+             , class "password-input"
              , attribute "size" "35"
              , attribute "type" "password"
              , attribute "placeholder" "Password"


### PR DESCRIPTION
This PR adds `id`s to the email and password login form fields. The `id's are a target for clearing the inputs when we go between the student and instructor login pages.

To test, run the frontend. Enter an email and password and go to the instructor login page. The fields should clear. Then, do the same, but going from the instructor login page to the student login page.