### PR TITLE
Add em dash (U+2014) as trailing punctuation

### DIFF
--- a/web/src/Text/Section/Words/Tag.elm
+++ b/web/src/Text/Section/Words/Tag.elm
@@ -379,7 +379,7 @@ isTrailingPunctuation char =
         || (char == ':' || char == ';')
         || (char == '»' || char == '"' || char == '“' || char == '”')
         || (char == ')' || char == ']' || char == '}' || char == '>')
-        || (char == '…')
+        || (char == '…' || char == '—')
 
 
 isValidChar : Char -> Bool

--- a/web/tests/Word/Tests.elm
+++ b/web/tests/Word/Tests.elm
@@ -136,6 +136,10 @@ all =
                 \_ ->
                     run parse "Голливуда»."
                         |> Expect.equal (Ok <| WordRecord "" (ValidWord "Голливуда") "».")
+            , test "Removes trailing »,—" <|
+                \_ ->
+                    run parse "отходов»,—"
+                        |> Expect.equal (Ok <| WordRecord "" (ValidWord "отходов") "»,—")
             ]
         , describe
             "Removes complex enclosing punctuation"


### PR DESCRIPTION
This PR adds the em dash (U+2014) as valid trailing punctuation. To test it, open text 55 as a content creator and attempt to gloss phrases where the `—` character follows other instances of trailing punctuation.