### PR TITLE
Add and delete questions

### DIFF
--- a/text/models.py
+++ b/text/models.py
@@ -139,6 +139,9 @@ class Text(Taggable, WriteLockable, Timestamped, models.Model):
                 text_section.update_definitions_if_new(
                     old_body=section_params['text_section_form'].cleaned_data['body'])
 
+            # Need to freshen up the answers. Delete them all and re-add them.
+            text_section.questions.all().delete()
+
             for i, question in enumerate(section_params['questions']):
                 question_obj = question['form'].save(commit=False)
 


### PR DESCRIPTION
These modifications allow us to add and delete questions from a text
section. Oddly enough adding a question failed when trying to access the
new question before it had been put in the database. There's no way it
could ever work, since it had yet to be validated in the first place.
There is some light verification of the data sent from the frontend.

Shortly after fixing the Add Question feature I realized that delete a
question doesn't work either. That was fixed by deleting all questions
from the text section and re-adding them from an existing copy (which
didn't include the ones to be deleted!).

To test these changes try the following, being sure to read the text
between each test.
* Add Question -> Save Text
* Delete Question -> Save Text
* Add Question -> Add Question -> Save Text
* Delete Question -> Delete Question -> Save Text
* Add three questions and delete the middle one -> Save Text

So you should be able to do multiple adds or deletes in any order.