### PR TITLE
Text editor improvements

### DIFF
--- a/web/public/css/create_text.css
+++ b/web/public/css/create_text.css
@@ -304,6 +304,10 @@ body {
   margin-bottom: 15px;
 }
 
+.editable {
+  background-color: #ffffff;
+}
+
 .editable:hover {
   background-color: #d1e1ed;
 }

--- a/web/src/Pages/Text/Edit/Id_Int.elm
+++ b/web/src/Pages/Text/Edit/Id_Int.elm
@@ -115,8 +115,7 @@ init shared { params } =
         , translationServiceProcessed = False
         }
     , Cmd.batch
-        [ Task.perform (\_ -> InitTextFieldEditors) (Task.succeed Nothing)
-        , getText shared.session shared.config params.id
+        [ getText shared.session shared.config params.id
         , Api.websocketDisconnectAll
         ]
     )
@@ -134,7 +133,6 @@ type Msg
     | SubmittedTextDelete
     | ConfirmedTextDelete Bool
     | GotTextDeleted (Result (Http.Detailed.Error String) ( Http.Metadata, Text.Decode.TextDeleteResp ))
-    | InitTextFieldEditors
     | ToggleEditable TextField Bool
     | UpdateTextAttributes String String
     | UpdateTextCkEditors ( String, String )
@@ -398,11 +396,6 @@ update msg (SafeModel model) =
 
             else
                 ( SafeModel model, Cmd.none )
-
-        InitTextFieldEditors ->
-            ( SafeModel model
-            , Text.Component.initialize_text_field_ck_editors model.text_component
-            )
 
         ToggleEditable textField editable ->
             let

--- a/web/src/Question/View.elm
+++ b/web/src/Question/View.elm
@@ -204,7 +204,7 @@ view_delete_selected msg text_component =
             , attribute "width" "20px"
             ]
             []
-        , Html.text "Delete Selected Question"
+        , Html.text "Delete Selected Questions"
         ]
 
 

--- a/web/src/Question/View.elm
+++ b/web/src/Question/View.elm
@@ -55,15 +55,14 @@ view_question params question_field =
         , toggle_editable onClick params question_field
         ]
     <|
-        [ Html.text
+        Html.text
             (if String.isEmpty params.question.body then
                 "Click to write the question text."
 
              else
                 params.question.body
             )
-        ]
-            ++ (if question_field_attrs.error then
+            :: (if question_field_attrs.error then
                     [ div []
                         [ Html.text question_field_attrs.error_string
                         ]
@@ -161,13 +160,13 @@ view_editable_question msg text_section_component answer_feedback_limit field =
             [ Html.input [ attribute "type" "checkbox", onCheck <| SelectQuestion text_section_component field >> msg ] []
             ]
         , div [ classList [ ( "question", True ) ] ] <|
-            [ if Question.Field.editable field then
+            (if Question.Field.editable field then
                 edit_question question_params field
 
-              else
+             else
                 view_question question_params field
-            ]
-                ++ (Array.toList <|
+            )
+                :: (Array.toList <|
                         Array.map (Answer.View.view_editable_answer answer_params num_of_answers) (Question.Field.answers field)
                    )
         , view_question_menu question_params field

--- a/web/src/Text/Section/View.elm
+++ b/web/src/Text/Section/View.elm
@@ -47,8 +47,8 @@ view_body params =
         , attribute "class" "text_property"
         ]
     <|
-        [ div [ attribute "class" "editable" ] [ Html.text params.text_section.body ] ]
-            ++ (if params.field.error then
+        div [ attribute "class" "editable" ] [ Html.text params.text_section.body ]
+            :: (if params.field.error then
                     [ div [ class "error" ] [ Html.text params.field.error_string ] ]
 
                 else
@@ -98,22 +98,21 @@ view_text_section_component msg text_difficulties answer_feedback_limit text_sec
                 , view_editable (params body_field) view_body edit_body
                 ]
             ]
+        , Question.View.view_questions msg
+            text_section_component
+            (Text.Section.Component.question_fields text_section_component)
+            answer_feedback_limit
+        , Question.View.view_question_buttons msg text_section_component
+        , div [ class "cursor", onClick (msg <| DeleteTextSection text_section_component) ]
+            [ Html.img
+                [ attribute "src" "/public/img/delete.svg"
+                , attribute "height" "18px"
+                , attribute "width" "18px"
+                ]
+                []
+            , Html.text " Delete Text Section"
+            ]
         ]
-            ++ [ Question.View.view_questions msg
-                    text_section_component
-                    (Text.Section.Component.question_fields text_section_component)
-                    answer_feedback_limit
-               , Question.View.view_question_buttons msg text_section_component
-               , div [ class "cursor", onClick (msg <| DeleteTextSection text_section_component) ]
-                    [ Html.img
-                        [ attribute "src" "/public/img/delete.svg"
-                        , attribute "height" "18px"
-                        , attribute "width" "18px"
-                        ]
-                        []
-                    , Html.text " Delete Text Section"
-                    ]
-               ]
     ]
 
 

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -230,13 +230,11 @@ app.ports.ckEditor.subscribe(id => {
   // wrap call in requestAnimationFrame to ensure that Elm has time to finish refreshing the view
   window.requestAnimationFrame(() => {
     if (window.CKEDITOR) {
-      // implicit detach
       if (window.CKEDITOR.instances[id]) {
         window.CKEDITOR.instances[id].destroy();
       }
 
       window.CKEDITOR.inline(id).on('change', function (evt) {
-        console.log(evt.editor.getData());
         app.ports.ckEditorUpdate.send([id, evt.editor.getData()]);
       });
     }
@@ -260,11 +258,14 @@ app.ports.ckEditor.subscribe(id => {
 app.ports.ckEditorSetHtml.subscribe(([id, html]) => {
   // wrap call in requestAnimationFrame to ensure that Elm has time to finish refreshing the view
   window.requestAnimationFrame(function (timestamp) {
-    if (window.CKEDITOR) {
+    if (window.CKEDITOR && window.CKEDITOR.instances[id]) {
       window.CKEDITOR.instances[id].setData(html);
     }
   });
 });
+
+
+// ALERT BEFORE TEXT DELETE
 
 app.ports.confirm.subscribe(msg => {
   // wrap call in requestAnimationFrame to ensure that Elm has time to finish refreshing the view


### PR DESCRIPTION
This PR stabilizes CKEditor by removing an unneeded initialization call, adds a white background to text inputs, and updates the label for deleting selected questions. It also does a small bit of clean up based on suggestions from the linter.

To test this PR, open a couple of texts as an editor and check that the introduction, conclusion, and source text sections initialize to show the right text, and you can click on them to edit text. Also, check that the other inputs have a white background and the label for deleting selected questions is updated to be plural (question -> questions).