### PR TITLE
Save for all working

### DIFF
--- a/text/views/api/translations.py
+++ b/text/views/api/translations.py
@@ -37,6 +37,14 @@ class TextTranslationMatchAPIView(APIView):
             text_phrases = []
 
             for text_phrase in translation_merge_params['words']:
+
+                # There is a notion "word_type" that comes from the frontend but causes an error on the back.
+                # Since it's not actually a part of a TextPhrase it throws an exception. If one were to implement
+                # "Save for All" they'd need to send "multiple" or something from the frontend. They they would
+                # need to do something similar with the grouped words table- in particular change the textptr to
+                # the new TextPhrase and have the translation point to that new TextPhrase too -- I think.
+                del(text_phrase['word_type'])
+
                 text_phrase = TextPhrase.objects.get(**text_phrase)
 
                 with transaction.atomic():

--- a/web/src/Text/Translations/Model.elm
+++ b/web/src/Text/Translations/Model.elm
@@ -28,6 +28,7 @@ module Text.Translations.Model exposing
     , setGlobalEditLock
     , setTextWord
     , setTextWords
+    , uneditAllWords
     , uneditWord
     , updateTextTranslation
     , updateTranslationsForWord

--- a/web/src/Text/Translations/Update.elm
+++ b/web/src/Text/Translations/Update.elm
@@ -26,7 +26,9 @@ update : (Msg -> msg) -> Msg -> Model -> ( Model, Cmd msg )
 update parentMsg msg model =
     case msg of
         MatchTranslations wordInstance ->
-            ( model, matchTranslations parentMsg model wordInstance )
+            ( Text.Translations.Model.uneditAllWords model
+            , matchTranslations parentMsg model wordInstance
+            )
 
         UpdatedTextWords (Ok textWords) ->
             ( Text.Translations.Model.setTextWords model textWords, Cmd.none )


### PR DESCRIPTION
Severing the potential to save merged words for now. We used to have an
error on the PUT endpoint since we were looking for a single/multiple
words attribute in TextPhrases that doesn't exist. We'll treat all words
hitting this endpoint as single for now.