### PR TITLE
Student profile improvements

### DIFF
--- a/user/urls/student.py
+++ b/user/urls/student.py
@@ -31,9 +31,9 @@ elm_load_urlpatterns = [
 urlpatterns = [
     path('profile/student/<int:pk>/performance_report.pdf', StudentPerformancePDFView.as_view(),
          name='student-performance-pdf-link'),
-    path('profile/student/<int:pk>/flashcards.pdf', StudentFlashcardsPDFView.as_view(),
+    path('profile/student/<int:pk>/words.pdf', StudentFlashcardsPDFView.as_view(),
          name='student-flashcards-pdf-link'),
-    path('profile/student/<int:pk>/flashcards.csv', StudentFlashcardsCSVView.as_view(),
+    path('profile/student/<int:pk>/words.csv', StudentFlashcardsCSVView.as_view(),
          name='student-flashcards-csv-link'),
     path('signup/student', StudentSignUpView.as_view(), name='student-signup'),
     path('login/student', StudentLoginView.as_view(), name='student-login'),

--- a/user/views/student_flashcards.py
+++ b/user/views/student_flashcards.py
@@ -30,7 +30,7 @@ class StudentFlashcardsPDFView(View):
 
         today = dt.now()
 
-        pdf_filename = f'my_ereader_flashcards_{today.day}_{today.month}_{today.year}.pdf'
+        pdf_filename = f'words_{today.day}_{today.month}_{today.year}.pdf'
 
         flashcards_report_html = loader.render_to_string('student_flashcards_report.html',
                                                          {'texts': student.flashcards_report.to_dict()})
@@ -61,7 +61,7 @@ class StudentFlashcardsCSVView(View):
 
         today = dt.now()
 
-        csv_filename = f'my_ereader_flashcards_{today.day}_{today.month}_{today.year}.csv'
+        csv_filename = f'words_{today.day}_{today.month}_{today.year}.csv'
 
         flashcard_list = student.flashcards_csv.to_list()
         csv_data = io.StringIO(newline='')

--- a/web/public/css/user_profile.css
+++ b/web/public/css/user_profile.css
@@ -126,7 +126,7 @@ table th {
   padding: 5px;
 }
 
-#flashcards {
+#words {
   display: grid;
   grid-template-columns: auto;
   grid-template-rows: 20px 50px;
@@ -228,18 +228,18 @@ table th {
 }
 
 .performance_download_link,
-.flashcards-download-link {
+.words-download-link {
   margin-top: 10px;
 }
 
 .performance_download_link a,
-.flashcards-download-link a {
+.words-download-link a {
   color: #00478f;
   text-decoration: none;
 }
 
 .performance_download_link a:hover,
-.flashcards-download-link a:hover {
+.words-download-link a:hover {
   text-decoration: underline;
 }
 

--- a/web/public/css/user_profile.css
+++ b/web/public/css/user_profile.css
@@ -129,7 +129,7 @@ table th {
 #flashcards {
   display: grid;
   grid-template-columns: auto;
-  grid-template-rows: 25px 150px;
+  grid-template-rows: 20px 50px;
   margin-bottom: 15px;
 }
 
@@ -138,7 +138,7 @@ table th {
   grid-row: 3;
   grid-column: 1 / 3;
   grid-template-columns: auto;
-  grid-template-rows: auto 35px 60px;
+  grid-template-rows: 35px 35px;
   grid-row-gap: 10px;
   margin-bottom: 15px;
 }
@@ -164,7 +164,8 @@ table th {
 #research_consent > .value > .check-box-text {
   display: inline-block;
   vertical-align: top;
-  font-size: larger;
+  padding-top: 4px;
+  font-size: 18px;
 }
 
 #show-help {
@@ -172,7 +173,7 @@ table th {
   grid-row: 3;
   grid-column: 3 / 4;
   grid-template-columns: auto;
-  grid-template-rows: auto 35px 60px;
+  grid-template-rows: 30px 35px;
   grid-row-gap: 10px;
   margin-bottom: 15px;
 }
@@ -189,7 +190,8 @@ table th {
 #show-help > .value > .check-box-text {
   display: inline-block;
   vertical-align: top;
-  font-size: larger;
+  font-size: 18px;
+  padding-top: 4px;
 }
 
 .check-box-selected {
@@ -279,7 +281,21 @@ table th {
 
 .update_username {
   margin-top: 10px;
-  font-size: smaller;
+  font-size: 12px;
+  color: #00478f;
+}
+
+.update_username:hover {
+  text-decoration: underline;
+}
+
+.username-update-cancel {
+  margin-top: 10px;
+  color: #00478f;
+}
+
+.username-update-cancel:hover {
+  text-decoration: underline;
 }
 
 .valid_username:after {
@@ -324,10 +340,14 @@ table th {
 
 .username_submit {
   margin-top: 5px;
+  color: #00478f;
 }
 
 .username_submit > span {
-  margin-left: 5px;
+  margin-right: 7px;
+}
+
+.username_submit > span:hover {
   text-decoration: underline;
 }
 
@@ -371,7 +391,6 @@ table th {
     flex-direction: column;
 
     margin-top: 15px;
-    grid-template-columns: 50% 50%;
   }
 
   .menu {

--- a/web/src/Api.elm
+++ b/web/src/Api.elm
@@ -8,8 +8,6 @@ port module Api exposing
     , authSuccessMessage
     , delete
     , deleteDetailed
-    , flashcardsCsvLink
-    , flashcardsPdfLink
     , get
     , getDetailed
     , login
@@ -27,6 +25,8 @@ port module Api exposing
     , websocketDisconnectAll
     , websocketReceive
     , websocketSend
+    , wordsCsvLink
+    , wordsPdfLink
     )
 
 import Api.Config as Config exposing (Config)
@@ -502,9 +502,9 @@ performanceReportLink baseUrl maybeCred id =
                 ""
 
 
-flashcardsPdfLink : String -> Maybe Cred -> Int -> String
-flashcardsPdfLink baseUrl maybeCred id =
-    Endpoint.flashcardsPdfLink baseUrl id <|
+wordsPdfLink : String -> Maybe Cred -> Int -> String
+wordsPdfLink baseUrl maybeCred id =
+    Endpoint.wordsPdfLink baseUrl id <|
         case maybeCred of
             Just (Cred cred) ->
                 cred
@@ -513,9 +513,9 @@ flashcardsPdfLink baseUrl maybeCred id =
                 ""
 
 
-flashcardsCsvLink : String -> Maybe Cred -> Int -> String
-flashcardsCsvLink baseUrl maybeCred id =
-    Endpoint.flashcardsCsvLink baseUrl id <|
+wordsCsvLink : String -> Maybe Cred -> Int -> String
+wordsCsvLink baseUrl maybeCred id =
+    Endpoint.wordsCsvLink baseUrl id <|
         case maybeCred of
             Just (Cred cred) ->
                 cred

--- a/web/src/Api/Endpoint.elm
+++ b/web/src/Api/Endpoint.elm
@@ -5,8 +5,6 @@ module Api.Endpoint exposing
     , createTranslation
     , createWord
     , filterToStringQueryParam
-    , flashcardsCsvLink
-    , flashcardsPdfLink
     , forgotPassword
     , instructorProfile
     , instructorSignup
@@ -26,6 +24,8 @@ module Api.Endpoint exposing
     , unmergeWord
     , validateUsername
     , word
+    , wordsCsvLink
+    , wordsPdfLink
     )
 
 import Http
@@ -267,24 +267,24 @@ performanceReportLink baseUrl id token =
         [ Url.Builder.string "token" token ]
 
 
-flashcardsPdfLink : String -> Int -> String -> String
-flashcardsPdfLink baseUrl id token =
+wordsPdfLink : String -> Int -> String -> String
+wordsPdfLink baseUrl id token =
     Url.Builder.crossOrigin baseUrl
         [ "profile"
         , "student"
         , String.fromInt id
-        , "flashcards.pdf"
+        , "words.pdf"
         ]
         [ Url.Builder.string "token" token ]
 
 
-flashcardsCsvLink : String -> Int -> String -> String
-flashcardsCsvLink baseUrl id token =
+wordsCsvLink : String -> Int -> String -> String
+wordsCsvLink baseUrl id token =
     Url.Builder.crossOrigin baseUrl
         [ "profile"
         , "student"
         , String.fromInt id
-        , "flashcards.csv"
+        , "words.csv"
         ]
         [ Url.Builder.string "token" token ]
 

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -12,7 +12,7 @@ import Browser.Navigation exposing (Key)
 import Dict exposing (Dict)
 import Help.View exposing (ArrowPlacement(..), ArrowPosition(..))
 import Html exposing (..)
-import Html.Attributes exposing (attribute, class, classList, id, href)
+import Html.Attributes exposing (attribute, class, classList, href, id)
 import Html.Events exposing (onClick, onInput)
 import Http exposing (..)
 import Http.Detailed
@@ -498,11 +498,11 @@ viewContent (SafeModel model) =
                     [ viewPreferredDifficulty (SafeModel model)
                     , viewUsername (SafeModel model)
                     , viewUserEmail (SafeModel model)
-                    , viewStudentPerformance (SafeModel model)
-                    , viewFeedbackLinks
-                    , viewFlashcards (SafeModel model)
-                    , viewResearchConsent (SafeModel model)
                     , viewShowHelp (SafeModel model)
+                    , viewStudentPerformance (SafeModel model)
+                    , viewResearchConsent (SafeModel model)
+                    , viewFlashcards (SafeModel model)
+                    , viewFeedbackLinks
                     , if not (String.isEmpty model.errorMessage) then
                         span [ attribute "class" "error" ] [ Html.text "error: ", Html.text model.errorMessage ]
 
@@ -523,7 +523,7 @@ viewWelcomeBanner =
             , Html.b [] [ Html.text "Show Hints" ]
             , Html.text " section below. "
             , Html.text "For more details please see the "
-            , Html.a [href (Route.toString (Route.About))] [ Html.text "About page."]
+            , Html.a [ href (Route.toString Route.About) ] [ Html.text "About page." ]
             ]
         ]
 
@@ -641,7 +641,12 @@ viewUsernameSubmit username =
                 []
 
         Nothing ->
-            [ span [ class "cursor", onClick CancelUsernameUpdate ] [ Html.text "Cancel" ]
+            [ span
+                [ class "cursor"
+                , class "username-update-cancel"
+                , onClick CancelUsernameUpdate
+                ]
+                [ Html.text "Cancel" ]
             ]
 
 

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -501,7 +501,7 @@ viewContent (SafeModel model) =
                     , viewShowHelp (SafeModel model)
                     , viewStudentPerformance (SafeModel model)
                     , viewResearchConsent (SafeModel model)
-                    , viewFlashcards (SafeModel model)
+                    , viewMyWords (SafeModel model)
                     , viewFeedbackLinks
                     , if not (String.isEmpty model.errorMessage) then
                         span [ attribute "class" "error" ] [ Html.text "error: ", Html.text model.errorMessage ]
@@ -696,17 +696,17 @@ viewStudentPerformance (SafeModel model) =
                ]
 
 
-viewFlashcards : SafeModel -> Html Msg
-viewFlashcards (SafeModel model) =
-    div [ id "flashcards", class "profile_item" ]
-        [ span [ class "profile_item_title" ] [ Html.text "Flashcard Words" ]
+viewMyWords : SafeModel -> Html Msg
+viewMyWords (SafeModel model) =
+    div [ id "words", class "profile_item" ]
+        [ span [ class "profile_item_title" ] [ Html.text "My Words" ]
         , span [ class "profile_item_value" ]
-            [ div [ class "flashcards-download-link" ]
+            [ div [ class "words-download-link" ]
                 [ Html.a
                     [ attribute "href" <|
                         case StudentProfile.studentID model.profile of
                             Just id ->
-                                Api.flashcardsCsvLink
+                                Api.wordsCsvLink
                                     (Config.restApiUrl model.config)
                                     (Session.cred model.session)
                                     id
@@ -714,15 +714,15 @@ viewFlashcards (SafeModel model) =
                             Nothing ->
                                 ""
                     ]
-                    [ Html.text "Download your flashcard words as a CSV file"
+                    [ Html.text "Download your words as a CSV file"
                     ]
                 ]
-            , div [ class "flashcards-download-link" ]
+            , div [ class "words-download-link" ]
                 [ Html.a
                     [ attribute "href" <|
                         case StudentProfile.studentID model.profile of
                             Just id ->
-                                Api.flashcardsPdfLink
+                                Api.wordsPdfLink
                                     (Config.restApiUrl model.config)
                                     (Session.cred model.session)
                                     id
@@ -730,7 +730,7 @@ viewFlashcards (SafeModel model) =
                             Nothing ->
                                 ""
                     ]
-                    [ Html.text "Download your flashcard words as a PDF"
+                    [ Html.text "Download your words as a PDF"
                     ]
                 ]
             ]

--- a/web/src/Pages/Text/Id_Int.elm
+++ b/web/src/Pages/Text/Id_Int.elm
@@ -772,14 +772,24 @@ viewFlashcardOptions (SafeModel model) reader_word =
         remove =
             div [ class "cursor", onClick (RemoveFromFlashcards reader_word) ] [ Html.text "Remove from My Words" ]
     in
-    case translations of
-        Just ts ->
-            div [ class "gloss-flashcard-options" ] <|
-                if Dict.member phrase flashcards then
-                    [ remove ]
+    case Session.viewer model.session of
+        Just viewer ->
+            case Viewer.role viewer of
+                Student ->
+                    case translations of
+                        Just ts ->
+                            div [ class "gloss-flashcard-options" ] <|
+                                if Dict.member phrase flashcards then
+                                    [ remove ]
 
-                else
-                    [ add ]
+                                else
+                                    [ add ]
+
+                        Nothing ->
+                            Html.text ""
+
+                Instructor ->
+                    Html.text ""
 
         Nothing ->
             Html.text ""

--- a/web/src/Pages/Text/Id_Int.elm
+++ b/web/src/Pages/Text/Id_Int.elm
@@ -763,17 +763,14 @@ viewFlashcardOptions (SafeModel model) reader_word =
                 TextReader.TextWord.translations
                 (TextReader.Model.textWord reader_word)
 
-        dbg =
-            Debug.log "translations" translations
-
         flashcards =
             Maybe.withDefault Dict.empty (User.Profile.TextReader.Flashcards.flashcards model.flashcard)
 
         add =
-            div [ class "cursor", onClick (AddToFlashcards reader_word) ] [ Html.text "Add to Flashcards" ]
+            div [ class "cursor", onClick (AddToFlashcards reader_word) ] [ Html.text "Add to My Words" ]
 
         remove =
-            div [ class "cursor", onClick (RemoveFromFlashcards reader_word) ] [ Html.text "Remove from Flashcards" ]
+            div [ class "cursor", onClick (RemoveFromFlashcards reader_word) ] [ Html.text "Remove from My Words" ]
     in
     case translations of
         Just ts ->


### PR DESCRIPTION
This PR makes the following changes:

- Rename "Flashcard words" to "My words"
- Update endpoints and downloads to download "words" instead of "flashcards"
- Swap the positions of my words and show hints sections in the student profile page
- Add styling to the update username controls
- Hide add and remove my words for instructors in the text reader

To test this PR, check the student profile to see that styling changes and the swap look good. Open a text as a student and check that the options for adding and removing words say "My Words" instead of "Flashcards" when glossing a word. Open a text as an instructor and check that you do not have an option to add to or remove from my words.
