### PR TITLE
Add difficulty info to sign up page

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,3 +4,209 @@ The image for our 404 page was posted by Cdd20 on Pixabay and is free for
 commercial use. Although attribution is not required, we do so here in 
 appreciation and acknowledgement. The image was downloaded from: 
 https://pixabay.com/illustrations/person-book-cane-blind-painting-5946234/
+
+
+** Google Material icons (copright section left blank by author) **
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -354,7 +354,8 @@ body {
   margin-left: 5px;
 }
 
-#show-password-button {
+#show-password-button,
+#show-diffculty-info-button {
   grid-row-start: inherit;
   cursor: pointer;
 }
@@ -363,6 +364,12 @@ body {
   position: absolute;
   padding-top: 12px;
   padding-left: 5px;
+}
+
+#info-image {
+  position: absolute;
+  padding-top: 9px;
+  padding-left: 10px;
 }
 
 .hidden {
@@ -558,6 +565,7 @@ body {
 }
 
 .signup_box select {
+  height: 40px;
   border: 1px solid lightgray;
   border-radius: 2px;
 }

--- a/web/public/css/user.css
+++ b/web/public/css/user.css
@@ -89,9 +89,11 @@ select {
 
 .welcome_msg {
   display: grid;
+  width: 60%;
+
   margin-bottom: 10px;
   margin-top: 15px;
-  font-size: larger;
+  font-size: 18px;
 }
 
 .welcome_msg > .headline {
@@ -103,6 +105,11 @@ select {
 
   grid-column: 1;
   grid-row: 2;
+}
+
+.difficulty-info {
+  width: 60%;
+  font-size: 18px;
 }
 
 #acknowledgements-and-about {
@@ -123,7 +130,7 @@ select {
   .signup_submit,
   select,
   input {
-    width: 100%;
+    width: 95%;
   }
 
   .button {
@@ -144,7 +151,12 @@ select {
     font-size: 32px;
   }
 
-  .headline {
+  .welcome_msg,
+  .difficulty-info {
+    width: 100%;
+  }
+
+  .welcome-headline {
     padding-top: 25px;
   }
 
@@ -182,6 +194,21 @@ select {
 
     align-items: center;
     justify-items: center;
+  }
+}
+
+@media only screen and (min-width: 768px) and (max-width: 1025px) {
+  .help_msgs,
+  .button,
+  .signup_submit,
+  select,
+  input {
+    width: 95%;
+  }
+
+  .welcome_msg,
+  .difficulty-info {
+    width: 100%;
   }
 }
 

--- a/web/public/img/info-black.svg
+++ b/web/public/img/info-black.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="24px" height="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg>

--- a/web/public/img/info-gray.svg
+++ b/web/public/img/info-gray.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
+   fill="black"
+   width="24px"
+   height="24px"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="info-gray.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1677"
+     inkscape:window-height="906"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="29.384766"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <path
+     d="M0 0h24v24H0V0z"
+     fill="none"
+     id="path2" />
+  <path
+     d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+     id="path4" />
+  <path
+     style="fill:#666666;fill-opacity:1;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 10.846421,21.917674 C 8.5809821,21.643139 6.5479153,20.65379 4.9478093,19.047239 4.0254956,18.12121 3.3545741,17.143775 2.8549815,15.998295 2.2492583,14.609475 1.9874904,13.239694 2.0328236,11.696101 2.0605334,10.752584 2.1660706,10.067678 2.4171205,9.2021261 3.4489928,5.6445115 6.4408098,2.9136738 10.087444,2.2008934 c 1.214038,-0.2372988 2.665528,-0.2315748 3.897075,0.015368 1.456763,0.2921024 2.874009,0.9394556 4.107402,1.8761323 0.437184,0.332011 1.431649,1.3181891 1.762639,1.7479516 1.03528,1.3442217 1.714459,2.8790626 1.987799,4.4921237 0.178057,1.050772 0.178057,2.28429 0,3.335062 -0.27334,1.613061 -0.952519,3.147902 -1.987799,4.492123 -0.351232,0.456046 -1.332904,1.423292 -1.803806,1.7773 -1.476633,1.110085 -3.130187,1.774026 -4.934529,1.981332 -0.563678,0.06476 -1.732941,0.06445 -2.269804,-6.12e-4 z m 2.17727,-1.975266 c 1.700563,-0.201013 3.366727,-1.018063 4.624633,-2.267817 1.278474,-1.270188 2.062469,-2.871466 2.311778,-4.721716 C 20.024083,12.47804 20.01409,11.425953 19.940708,10.911 19.399073,7.110138 16.30149,4.2418341 12.484105,4.0063271 8.5163346,3.7615424 4.9590379,6.4878938 4.1472296,10.3958 c -0.2017503,0.971192 -0.2017503,2.237208 0,3.2084 0.4429676,2.13237 1.7350269,3.995896 3.5920592,5.180796 0.4297935,0.274235 1.2285264,0.651159 1.7243204,0.813712 1.1901718,0.390213 2.2780598,0.495241 3.5600818,0.3437 z"
+     id="path822"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#666666;fill-opacity:1;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+     d="m 11.006288,13.990828 v -2.977734 h 0.986906 0.986906 v 2.977734 2.977733 h -0.986906 -0.986906 z"
+     id="path824"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#666666;fill-opacity:1;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 11.006288,8.0013293 V 7.031439 h 0.986906 0.986906 v 0.9698903 0.9698904 h -0.986906 -0.986906 z"
+     id="path826"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/web/src/Pages/Signup/Student.elm
+++ b/web/src/Pages/Signup/Student.elm
@@ -5,28 +5,27 @@ module Pages.Signup.Student exposing
     , page
     )
 
-import Api exposing (post)
+import Api exposing (postDetailed)
 import Api.Config as Config exposing (Config)
 import Api.Endpoint as Endpoint
 import Browser.Navigation exposing (Key)
 import Dict exposing (Dict)
 import Email exposing (EmailAddress)
 import Html exposing (Html, div, span)
-import Html.Attributes exposing (attribute, class, classList)
+import Html.Attributes exposing (attribute, class, classList, id)
 import Html.Events exposing (onClick, onInput)
 import Http exposing (..)
 import Http.Detailed
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline exposing (required)
 import Json.Encode as Encode
-import Menu.Msg as MenuMsg
+import Markdown
 import Session exposing (Session)
 import Shared
 import Spa.Document exposing (Document)
 import Spa.Generated.Route as Route
 import Spa.Page as Page exposing (Page)
 import Spa.Url exposing (Url)
-import Text.Model exposing (TextDifficulty)
 import User.SignUp as SignUp
 import Utils exposing (isValidEmail)
 import Views
@@ -71,6 +70,7 @@ type alias Model =
     , difficulties : List ( String, String )
     , signupParams : SignUpParams
     , showPasswords : Bool
+    , showDifficultyInfo : Bool
     , errors : Dict String String
     }
 
@@ -94,6 +94,7 @@ init shared { params } =
                         ""
             }
       , showPasswords = False
+      , showDifficultyInfo = False
       , errors = Dict.empty
       }
     , Cmd.none
@@ -106,6 +107,7 @@ init shared { params } =
 
 type Msg
     = ToggleShowPassword
+    | ToggleShowDifficultyInfo
     | UpdateEmail String
     | UpdatePassword String
     | UpdateConfirmPassword String
@@ -119,6 +121,11 @@ update msg model =
     case msg of
         ToggleShowPassword ->
             ( { model | showPasswords = not model.showPasswords }
+            , Cmd.none
+            )
+
+        ToggleShowDifficultyInfo ->
+            ( { model | showDifficultyInfo = not model.showDifficultyInfo }
             , Cmd.none
             )
 
@@ -259,8 +266,8 @@ viewContent : Model -> Html Msg
 viewContent model =
     div [ classList [ ( "signup", True ) ] ]
         [ div [ classList [ ( "signup_box", True ) ] ] <|
-            [ div [ class "signup_title" ] [ Html.text "Student Signup" ] ]
-                ++ [ viewStudentWelcomeMsg ]
+            div [ class "signup_title" ] [ Html.text "Student Signup" ]
+                :: viewStudentWelcomeMsg
                 ++ SignUp.viewEmailInput
                     { errors = model.errors
                     , onEmailInput = UpdateEmail
@@ -273,6 +280,7 @@ viewContent model =
                     , onConfirmPasswordInput = UpdateConfirmPassword
                     }
                 ++ viewDifficultyChoices model
+                ++ viewDifficultyInfo model
                 ++ SignUp.viewInternalErrorMessage model.errors
                 ++ [ Html.div
                         [ attribute "class" "signup_label" ]
@@ -295,14 +303,14 @@ viewContent model =
         ]
 
 
-viewStudentWelcomeMsg : Html Msg
+viewStudentWelcomeMsg : List (Html Msg)
 viewStudentWelcomeMsg =
     let
         welcomeTitle =
             """Welcome to The Language Flagship’s Steps To Advanced Reading (STAR) website."""
     in
-    div [ class "welcome_msg" ]
-        [ span [ class "headline" ] [ Html.text welcomeTitle ]
+    [ div [ class "welcome_msg" ]
+        [ span [ class "welcome-headline" ] [ Html.text welcomeTitle ]
         , div [ class "welcome-msg-text" ]
             [ Html.p []
                 [ Html.text
@@ -327,31 +335,93 @@ viewStudentWelcomeMsg =
                 ]
             ]
         ]
+    ]
 
 
 viewDifficultyChoices : Model -> List (Html Msg)
 viewDifficultyChoices model =
-    [ Html.select
-        [ onInput UpdateDifficulty
-        ]
-        [ Html.optgroup [] <|
-            Html.option [ attribute "disabled" "", attribute "selected" "" ] [ Html.text "Choose a preferred difficulty:" ]
-                :: List.map
-                    (\( k, v ) ->
-                        Html.option
-                            (attribute "value" k
-                                :: (if v == model.signupParams.difficulty then
-                                        [ attribute "selected" "" ]
+    [ div [ class "input-container" ]
+        [ Html.select
+            [ onInput UpdateDifficulty
+            ]
+            [ Html.optgroup [] <|
+                Html.option [ attribute "disabled" "", attribute "selected" "" ] [ Html.text "Choose a preferred difficulty:" ]
+                    :: List.map
+                        (\( k, v ) ->
+                            Html.option
+                                (attribute "value" k
+                                    :: (if v == model.signupParams.difficulty then
+                                            [ attribute "selected" "" ]
 
-                                    else
-                                        []
-                                   )
-                            )
-                            [ Html.text v ]
-                    )
-                    model.difficulties
+                                        else
+                                            []
+                                       )
+                                )
+                                [ Html.text v ]
+                        )
+                        model.difficulties
+            ]
+        , Html.span
+            [ onClick ToggleShowDifficultyInfo
+            , id "show-difficulty-info-button"
+            ]
+            [ if model.showDifficultyInfo then
+                Html.img [ id "info-image", attribute "src" "/public/img/info-black.svg" ] []
+
+              else
+                Html.img [ id "info-image", attribute "src" "/public/img/info-gray.svg" ] []
+            ]
         ]
     ]
+
+
+viewDifficultyInfo : Model -> List (Html Msg)
+viewDifficultyInfo model =
+    if model.showDifficultyInfo then
+        case model.signupParams.difficulty of
+            "intermediate_mid" ->
+                [ Markdown.toHtml [ class "difficulty-info" ] """**Texts at the Intermediate Mid level** tend to be short public announcements,
+            selections from personal correspondence, clearly organized texts in very recognizable genres with clear
+            structure (like a biography, public opinion survey, etc.). Questions will focus on your ability to recognize
+            the main ideas of the text. Typically, students in second year Russian can attempt texts at this level. """
+                ]
+
+            "intermediate_high" ->
+                [ Markdown.toHtml [ class "difficulty-info" ] """**Texts at the Intermediate High level** will tend to be several paragraphs in length,
+            touching on topics of personal and/or public interest.  The texts will tell a story, give a description or
+            explanation of something related to the topic. At the intermediate high level, you may be able to get the main
+            idea of the text, but the supporting details may be elusive. Typically, students in third year Russian can
+            attempt texts at this level."""
+                ]
+
+            "advanced_low" ->
+                [ Markdown.toHtml [ class "difficulty-info" ] """**Texts at the Advanced Low level** will be multiple paragraphs in length, touching on
+            topics of public interest. They may be excerpts from straightforward literary texts, from newspapers relating
+            the circumstances related to an event of public interest.  Texts may related to present, past or future time
+            frames. Advanced Low texts will show a strong degree of internal cohesion and organization.  The paragraphs
+            cannot be rearranged without doing damage to the comprehensibility of the passage. At the Advanced low level,
+            you should be able to understand the main ideas of the passage as well as the supporting details.
+            Readers at the Advanced Low level can efficiently balance the use of background knowledge WITH linguistic
+            knowledge to determine the meaning of a text, although complicated word order may interfere with the reader’s
+            comprehension. Typically, students in fourth year Russian can attempt these texts. """
+                ]
+
+            "advanced_mid" ->
+                [ Markdown.toHtml [ class "difficulty-info" ] """**Texts at the Advanced Mid level** will be even longer than at the Advanced Low level.
+            They will address issues of public interest, and they may contain narratives, descriptions, explanations, and
+            some argumentation, laying out and justifying a particular point of view. At the Advanced Mid level, texts
+            contain cultural references that are important for following the author’s point of view and argumentation.
+            Texts may contain unusual plot twists and unexpected turns of events, but they do not confuse readers because
+            readers have a strong command of the vocabulary, syntax, rhetorical devices that organize texts. Readers at the
+            Advanced Mid level can handle the main ideas and the factual details of texts. Typically, strong students in
+            4th year Russian or in 5th year Russian can attempt texts at this level. """
+                ]
+
+            _ ->
+                []
+
+    else
+        []
 
 
 

--- a/web/src/User/SignUp.elm
+++ b/web/src/User/SignUp.elm
@@ -9,9 +9,7 @@ import Dict exposing (Dict)
 import Html exposing (Html, div)
 import Html.Attributes exposing (attribute, class, classList, id)
 import Html.Events exposing (onClick, onInput)
-import Menu.Msg as MenuMsg
 import Utils exposing (isValidEmail)
-import Views
 
 
 viewEmailInput :
@@ -36,12 +34,12 @@ viewEmailInput { errors, onEmailInput } =
             else
                 [ attribute "class" "input_valid" ]
     in
-    [ div [ class "input-container" ] [
-            Html.input ([ id "email-input", onInput onEmailInput, attribute "size" "25", attribute "placeholder" "Email Address" ] ++ errorClass) []
+    [ div [ class "input-container" ]
+        [ Html.input ([ id "email-input", onInput onEmailInput, attribute "size" "25", attribute "placeholder" "Email Address" ] ++ errorClass) []
         ]
     ]
-    ++ errorMessage
- 
+        ++ errorMessage
+
 
 viewPasswordInputs :
     { showPasswords : Bool
@@ -78,7 +76,7 @@ viewPasswordInputs options =
                         [ attribute "class" "input_error" ]
 
                     else
-                        [ attribute "class" "input_valid"]
+                        [ attribute "class" "input_valid" ]
                    )
                 ++ (if options.showPasswords then
                         [ attribute "type" "text" ]
@@ -87,20 +85,20 @@ viewPasswordInputs options =
                         [ attribute "type" "password" ]
                    )
     in
-    [ div [ class "input-container" ] [
-        Html.input (onInput options.onPasswordInput :: attributes ++ [ id "password-input", attribute "placeholder" "Password"]) []
-        , (if options.showPasswords then
+    [ div [ class "input-container" ]
+        [ Html.input (onInput options.onPasswordInput :: attributes ++ [ id "password-input", attribute "placeholder" "Password" ]) []
+        , if options.showPasswords then
             Html.span [ onClick options.onShowPasswordToggle, id "show-password-button" ]
                 [ Html.img [ id "visibility-image", attribute "src" "/public/img/visibility_off-24px.svg" ] [] ]
-            else
+
+          else
             Html.span [ onClick options.onShowPasswordToggle, id "show-password-button" ]
                 [ Html.img [ id "visibility-image", attribute "src" "/public/img/visibility-24px.svg" ] [] ]
-        )
         ]
     , passwordErrorMessage
-    , div [ class "input-container" ][ 
-        Html.input (onInput options.onConfirmPasswordInput :: attributes ++ [ id "password-input", attribute "placeholder" "Confirm Password" ]) []
-    ]
+    , div [ class "input-container" ]
+        [ Html.input (onInput options.onConfirmPasswordInput :: attributes ++ [ id "password-input", attribute "placeholder" "Confirm Password" ]) []
+        ]
     , confirmErrorMessage
     ]
 


### PR DESCRIPTION
This PR adds an info toggle to the student signup page to show students information about the selected difficulty. It also reduces the width of the text on the sign up page to line it up with the form fields, and it fixes a bug where the show password eyeball was falling to the line below the password input on mobile.

To test, open the student signup page and click on the info icon. Try out each difficulty and check for the correct text. Check out the form on mobile and make sure things are generally looking good.