### PR TITLE
Rename instructor to content creator

### DIFF
--- a/web/src/Pages/Login/ContentCreator.elm
+++ b/web/src/Pages/Login/ContentCreator.elm
@@ -1,4 +1,4 @@
-module Pages.Login.Instructor exposing
+module Pages.Login.ContentCreator exposing
     ( Model
     , Msg
     , Params
@@ -109,7 +109,7 @@ update msg model =
 
 view : Model -> Document Msg
 view model =
-    { title = "Instructor Login"
+    { title = "Content Creator Login"
     , body =
         [ div []
             [ viewContent model
@@ -126,8 +126,8 @@ viewContent model =
             , onEmailUpdate = UpdateEmail
             , onPasswordUpdate = UpdatePassword
             , onSubmittedForm = SubmittedLogin
-            , signUpRoute = Route.Signup__Instructor
-            , loginRole = "Content Editor Login"
+            , signUpRoute = Route.Signup__ContentCreator
+            , loginRole = "Content Creator Login"
             , otherLoginRole = "student"
             , otherLoginRoute = Route.Login__Student
             , maybeHelpMessage = Nothing

--- a/web/src/Pages/Login/Student.elm
+++ b/web/src/Pages/Login/Student.elm
@@ -128,8 +128,8 @@ viewContent model =
             , onSubmittedForm = SubmittedLogin
             , signUpRoute = Route.Signup__Student
             , loginRole = "Student Login"
-            , otherLoginRole = "content editor"
-            , otherLoginRoute = Route.Login__Instructor
+            , otherLoginRole = "content creator"
+            , otherLoginRoute = Route.Login__ContentCreator
             , maybeHelpMessage =
                 Just
                     """When signing in, please note that this website is not connected to your university’s user account.

--- a/web/src/Pages/NotFound.elm
+++ b/web/src/Pages/NotFound.elm
@@ -94,7 +94,7 @@ view model =
                             a [ href (Route.toString Route.Profile__Student) ] [ text "Return to your profile page" ]
 
                         Instructor ->
-                            a [ href (Route.toString Route.Profile__Instructor) ] [ text "Return to your profile page" ]
+                            a [ href (Route.toString Route.Profile__ContentCreator) ] [ text "Return to your profile page" ]
 
                 Nothing ->
                     a [ href (Route.toString Route.Top) ] [ text "Return to homepage" ]

--- a/web/src/Pages/Profile/ContentCreator.elm
+++ b/web/src/Pages/Profile/ContentCreator.elm
@@ -1,4 +1,4 @@
-module Pages.Profile.Instructor exposing (Model, Msg, Params, page)
+module Pages.Profile.ContentCreator exposing (Model, Msg, Params, page)
 
 import Api
 import Api.Config as Config exposing (Config)
@@ -203,7 +203,7 @@ newInviteResponseDecoder =
 
 view : SafeModel -> Document Msg
 view (SafeModel model) =
-    { title = "Instructor Profile"
+    { title = "Content Creator Profile"
     , body =
         [ div []
             [ viewContent (SafeModel model)
@@ -319,14 +319,15 @@ viewInstructorInviteMsg (SafeModel model) =
     div [ id "invite_msg" ]
         [ Html.text
             """
-                        After creating an invitation, send the new content creator the invite code and ask
-                        them to sign up at
-                        """
-        , Html.a [ href "https://stepstoadvancedreading.org/signup/instructor" ] [ text "https://stepstoadvancedreading.org/signup/instructor" ]
+            After creating an invitation, send the new content creator the invite code and ask
+            them to sign up at
+            """
+        , Html.a [ href "https://stepstoadvancedreading.org/signup/content-creator" ]
+            [ text "https://stepstoadvancedreading.org/signup/content-creator" ]
         , Html.text
-            """  before the expiration
-                        time. The content creator will not be emailed automatically.
-                        """
+            """ before the expiration
+            time. The content creator will not be emailed automatically.
+            """
         ]
 
 

--- a/web/src/Pages/Signup/ContentCreator.elm
+++ b/web/src/Pages/Signup/ContentCreator.elm
@@ -1,4 +1,4 @@
-module Pages.Signup.Instructor exposing
+module Pages.Signup.ContentCreator exposing
     ( Model
     , Msg
     , Params
@@ -147,7 +147,7 @@ update msg model =
 
         CompletedSignup (Ok resp) ->
             ( model
-            , Browser.Navigation.replaceUrl model.navKey (Route.toString Route.Login__Instructor)
+            , Browser.Navigation.replaceUrl model.navKey (Route.toString Route.Login__ContentCreator)
             )
 
         CompletedSignup (Err error) ->
@@ -263,12 +263,12 @@ errorBodyToDict body =
 
 view : Model -> Document Msg
 view model =
-    { title = "Instructor Signup"
+    { title = "Content Creator Signup"
     , body =
         [ div []
             [ div [ classList [ ( "signup", True ) ] ]
                 [ div [ classList [ ( "signup_box", True ) ] ] <|
-                    [ div [ class "signup_title" ] [ Html.text "Instructor Signup" ] ]
+                    [ div [ class "signup_title" ] [ Html.text "Content Creator Signup" ] ]
                         ++ SignUp.viewEmailInput
                             { errors = model.errors
                             , onEmailInput = UpdateEmail

--- a/web/src/Pages/Text/Create.elm
+++ b/web/src/Pages/Text/Create.elm
@@ -244,7 +244,7 @@ update msg (SafeModel model) =
 
         GotTextDeleted (Ok ( metadata, textDelete )) ->
             ( SafeModel model
-            , Browser.Navigation.load (Route.toString Route.Text__EditorSearch)
+            , Browser.Navigation.load (Route.toString Route.Text__CreatorSearch)
             )
 
         GotTextDeleted (Err error) ->

--- a/web/src/Pages/Text/CreatorSearch.elm
+++ b/web/src/Pages/Text/CreatorSearch.elm
@@ -1,4 +1,4 @@
-module Pages.Text.EditorSearch exposing (Model, Msg, Params, page)
+module Pages.Text.CreatorSearch exposing (Model, Msg, Params, page)
 
 import Api
 import Api.Config as Config exposing (Config)
@@ -112,7 +112,7 @@ getTexts session config =
 
 view : SafeModel -> Document Msg
 view (SafeModel model) =
-    { title = "Editor Search"
+    { title = "Content Creator Search"
     , body =
         [ div []
             [ viewTexts (SafeModel model)

--- a/web/src/Pages/Text/Edit/Id_Int.elm
+++ b/web/src/Pages/Text/Edit/Id_Int.elm
@@ -354,7 +354,7 @@ update msg (SafeModel model) =
 
         GotTextDeleted (Ok ( metadata, textDelete )) ->
             ( SafeModel model
-            , Browser.Navigation.load (Route.toString Route.Text__EditorSearch)
+            , Browser.Navigation.load (Route.toString Route.Text__CreatorSearch)
             )
 
         GotTextDeleted (Err error) ->

--- a/web/src/Shared.elm
+++ b/web/src/Shared.elm
@@ -108,7 +108,7 @@ init flags url key =
                     if List.any (\path -> url.path == path) publicPaths then
                         Cmd.batch
                             [ requestInstructorProfile session config (Viewer.id viewer)
-                            , Browser.Navigation.replaceUrl key (Route.toString Route.Profile__Instructor)
+                            , Browser.Navigation.replaceUrl key (Route.toString Route.Profile__ContentCreator)
                             , Task.attempt GotTimezone TimeZone.getZone
                             ]
 
@@ -183,7 +183,7 @@ update msg model =
                         Instructor ->
                             Cmd.batch
                                 [ requestInstructorProfile session model.config (Viewer.id viewer)
-                                , Browser.Navigation.replaceUrl model.key (Route.toString Route.Profile__Instructor)
+                                , Browser.Navigation.replaceUrl model.key (Route.toString Route.Profile__ContentCreator)
                                 ]
 
                 Nothing ->
@@ -397,7 +397,7 @@ viewLogo session =
                             Route.toString Route.Profile__Student
 
                         Instructor ->
-                            Route.toString Route.Profile__Instructor
+                            Route.toString Route.Profile__ContentCreator
 
                 Nothing ->
                     Route.toString Route.Top
@@ -438,7 +438,7 @@ viewContentHeader role =
                 [ class "nav-item" ]
                 [ a
                     [ class "nav-link"
-                    , href (Route.toString Route.Text__EditorSearch)
+                    , href (Route.toString Route.Text__CreatorSearch)
                     ]
                     [ text "Edit" ]
                 ]
@@ -464,7 +464,7 @@ viewProfileHeader role toMsg =
                         Route.toString Route.Profile__Student
 
                     Instructor ->
-                        Route.toString Route.Profile__Instructor
+                        Route.toString Route.Profile__ContentCreator
             ]
             [ text "Profile" ]
         ]

--- a/web/src/Spa/Page.elm
+++ b/web/src/Spa/Page.elm
@@ -183,7 +183,7 @@ protectedStudentApplication page =
 
                         Instructor ->
                             ( Nothing
-                            , Nav.pushUrl url.key (Route.toString Route.Login__Instructor)
+                            , Nav.pushUrl url.key (Route.toString Route.Login__ContentCreator)
                             )
 
                 Nothing ->


### PR DESCRIPTION
This PR renames "instructor" in browser tab titles, links, text, and routes across the site. To test it, open all pages that a content creator might use and check that instructor has been replaced with content creator. 