### PR TITLE
Difficulty styling

### DIFF
--- a/text/ui/TextSearch.elm
+++ b/text/ui/TextSearch.elm
@@ -345,6 +345,16 @@ view_search_results textListItems =
     let
         view_search_result textItem =
             let
+                difficultyCategory = 
+                    case textItem.difficulty of
+                        "intermediate_mid" -> 
+                            "Intermediate-Mid"
+                        "intermediate_high" -> 
+                            "Intermediate-High"
+                        "advanced_low" ->
+                            "Advanced-Low"
+                        "advanced_mid" ->
+                            "Advanced-Mid"
                 commaDelimitedTags =
                     case textItem.tags of
                         Just tags ->
@@ -383,7 +393,7 @@ view_search_results textListItems =
                     , div [ class "sub_description" ] [ Html.text "Title" ]
                     ]
                 , div [ class "result_item" ]
-                    [ div [ class "result_item_title" ] [ Html.text textItem.difficulty ]
+                    [ div [ class "result_item_title" ] [ Html.text difficultyCategory ]
                     , div [ class "sub_description" ] [ Html.text "Difficulty" ]
                     ]
                 , div [ class "result_item" ]

--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -360,17 +360,20 @@ viewSearchResults timezone textListItems =
         viewSearchResult textItem =
             let
                 difficultyCategory = 
-                    case textItem.difficulty of
-                        "intermediate_mid" -> 
-                            "Intermediate-Mid"
-                        "intermediate_high" -> 
-                            "Intermediate-High"
-                        "advanced_low" ->
-                            "Advanced-Low"
-                        "advanced_mid" ->
-                            "Advanced-Mid"
-                        _ -> 
+                    case 
+                        List.head <|
+                            List.filter
+                                (\difficulty ->
+                                    Tuple.first difficulty == textItem.difficulty
+                                )
+                                Shared.difficulties
+                    of
+                        Just difficulty ->
+                            Tuple.second difficulty
+
+                        Nothing ->
                             ""
+
                 commaDelimitedTags =
                     case textItem.tags of
                         Just tags ->

--- a/web/src/Pages/Text/Search.elm
+++ b/web/src/Pages/Text/Search.elm
@@ -359,6 +359,18 @@ viewSearchResults timezone textListItems =
     let
         viewSearchResult textItem =
             let
+                difficultyCategory = 
+                    case textItem.difficulty of
+                        "intermediate_mid" -> 
+                            "Intermediate-Mid"
+                        "intermediate_high" -> 
+                            "Intermediate-High"
+                        "advanced_low" ->
+                            "Advanced-Low"
+                        "advanced_mid" ->
+                            "Advanced-Mid"
+                        _ -> 
+                            ""
                 commaDelimitedTags =
                     case textItem.tags of
                         Just tags ->
@@ -401,7 +413,7 @@ viewSearchResults timezone textListItems =
                     , div [ class "sub_description" ] [ Html.text "Title" ]
                     ]
                 , div [ class "result_item" ]
-                    [ div [ class "result_item_title" ] [ Html.text textItem.difficulty ]
+                    [ div [ class "result_item_title" ] [ Html.text difficultyCategory ]
                     , div [ class "sub_description" ] [ Html.text "Difficulty" ]
                     ]
                 , div [ class "result_item" ]


### PR DESCRIPTION
These changes make the difficulty more human readable in a text card on the search page.

"intermediate_mid" -> "Intermediate-Mid"

Was unable to see how this could be done without string comparison in the `case` statement.