### PR TITLE
Feature/enable gzip

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -26,6 +26,10 @@ RUN apt update -y \
 
 COPY steps2ar.org /etc/nginx/sites-available/
 
+# Overwrite the default nginx.conf to gzip more files. If nginx needs to be reloaded:
+# nginx -s reload
+COPY nginx.conf /etc/nginx/
+
 RUN ln -s /etc/nginx/sites-available/steps2ar.org /etc/nginx/sites-enabled/ \
     && rm /etc/nginx/sites-enabled/default
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,64 @@
+user www-data;                                                                                                                                                   
+worker_processes auto;                                                                                                                                           
+pid /run/nginx.pid;                                                                                                                                              
+include /etc/nginx/modules-enabled/*.conf;                                                                                                                       
+                                                                                                                                                                 
+events {                                                                                                                                                         
+        worker_connections 768;                                                                                                                                  
+        # multi_accept on;                                                                                                                                       
+}                                                                                                                                                                
+                                                                                                                                                                 
+http {                                                                                                                                                           
+                                                                                                                                                                 
+        ##                                                                                                                                                       
+        # Basic Settings                                                                                                                                         
+        ##                                                                                                                                                       
+                                                                                                                                                                 
+        sendfile on;                                                                                                                                             
+        tcp_nopush on;                                                                                                                                           
+        tcp_nodelay on;
+        keepalive_timeout 65;
+        types_hash_max_size 2048;
+        # server_tokens off;
+
+        # server_names_hash_bucket_size 64;
+        # server_name_in_redirect off;
+
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+
+        ##
+        # SSL Settings
+        ##
+
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+        ssl_prefer_server_ciphers on;
+
+        ##
+        # Logging Settings
+        ##
+
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log;
+
+        ##
+        # Gzip Settings
+        ##
+
+        gzip on;
+        gzip_disable "msie6";
+
+        gzip_vary on;
+        gzip_proxied any;
+        gzip_comp_level 6;
+        gzip_buffers 16 8k;
+        gzip_http_version 1.1;
+        gzip_types font/ttf image/svg+xml text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+        ##
+        # Virtual Host Configs
+        ##
+
+        include /etc/nginx/conf.d/*.conf;
+        include /etc/nginx/sites-enabled/*;
+}


### PR DESCRIPTION
This might do the trick, but we'll have to see when we tear down and build the site back up. The conf file was modified, confirmed to work, then copied and stored here in Git. The conf file is `nginx.conf` and resides on the `node_frontend` container at `/etc/nginx/nginx.conf`. The new settings enable gzip for more filetypes than just the default HTML. 

Here's an example to show that it works:

Before:
```
$ curl -H "Accept-Encoding: gzip" -I https://steps2advancedreading.org/public/img/menu.svg
HTTP/2 200 
server: nginx/1.19.7
date: Thu, 04 Mar 2021 18:20:37 GMT
content-type: image/svg+xml
content-length: 3584
last-modified: Wed, 03 Mar 2021 22:57:33 GMT
etag: "6040145d-e00"
accept-ranges: bytes
strict-transport-security: max-age=31536000
```

After:
```
$ curl -H "Accept-Encoding: gzip" -I https://steps2advancedreading.org/public/img/menu.svg
HTTP/2 200 
server: nginx/1.19.7
date: Thu, 04 Mar 2021 18:46:14 GMT
content-type: image/svg+xml
last-modified: Wed, 03 Mar 2021 22:57:33 GMT
vary: Accept-Encoding
etag: W/"6040145d-e00"
content-encoding: gzip
strict-transport-security: max-age=31536000
```