### PR TITLE
Feature/remove debug stmts

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -17,7 +17,7 @@ RUN apt update -y \
     && cd web \
     && npm install -g parcel-bundler \
     && npm install \
-    && npm run build:staging \
+    && npm run build \
     && apt-get install -y nginx \
     && mkdir -p /var/www/steps2ar.org/html \
     && chown -R $USER:$USER /var/www/steps2ar.org/html \

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Frontend for the ereadingtool",
   "scripts": {
-    "start": "npm install && npm run build:dev && npm run dev",
+    "start": "npm install && npm run build && npm run",
     "test": "elm-test",
     "test:watch": "elm-test --watch",
     "build": "run-s build:elm-spa build:elm",

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Frontend for the ereadingtool",
   "scripts": {
-    "start": "npm install && npm run build && npm run",
+    "start": "npm install && npm run build:dev && npm run dev",
     "test": "elm-test",
     "test:watch": "elm-test --watch",
     "build": "run-s build:elm-spa build:elm",

--- a/web/src/Pages/Flashcards/Student.elm
+++ b/web/src/Pages/Flashcards/Student.elm
@@ -214,10 +214,6 @@ decodeWebSocketResp safeModel str =
 
 webSocketError : SafeModel -> String -> String -> ( SafeModel, Cmd Msg )
 webSocketError model errorType error =
-    let
-        _ =
-            Debug.log errorType error
-    in
     ( model, Cmd.none )
 
 

--- a/web/src/Pages/Text/Id_Int.elm
+++ b/web/src/Pages/Text/Id_Int.elm
@@ -262,17 +262,9 @@ handleWebsocketResponse (SafeModel model) message =
                     routeCommandResponse (SafeModel model) commandResponse
 
                 Err err ->
-                    let
-                        _ =
-                            Debug.log "websocket decode error" err
-                    in
                     ( SafeModel model, Cmd.none )
 
         WebSocket.Error err ->
-            let
-                _ =
-                    Debug.log "server error response" err
-            in
             ( SafeModel model, Cmd.none )
 
 

--- a/web/src/Text/Component.elm
+++ b/web/src/Text/Component.elm
@@ -205,9 +205,6 @@ reinitialize_ck_editors text_component =
 update_text_errors : TextComponent -> Dict String String -> TextComponent
 update_text_errors (TextComponent txt fields text_tags components) errors =
     let
-        _ =
-            Debug.log "text errors" errors
-
         new_text_component =
             TextComponent
                 txt

--- a/web/src/Text/Translations/Update.elm
+++ b/web/src/Text/Translations/Update.elm
@@ -56,17 +56,9 @@ update parentMsg msg model =
             )
 
         UpdatedTextWords (Err err) ->
-            let
-                _ =
-                    Debug.log "error updating text words" err
-            in
             ( model, Cmd.none )
 
         UpdatedTextWord (Err err) ->
-            let
-                _ =
-                    Debug.log "error updating text word" err
-            in
             ( model, Cmd.none )
 
         MergeWords wordInstances ->
@@ -84,17 +76,9 @@ update parentMsg msg model =
                 )
 
             else
-                let
-                    _ =
-                        Debug.log "error merging text words" mergeResp.error
-                in
                 ( Text.Translations.Model.clearMerge model, Cmd.none )
 
         MergedWords (Err err) ->
-            let
-                _ =
-                    Debug.log "error merging text words" err
-            in
             ( model, Cmd.none )
 
         AddToMergeWords wordInstance ->
@@ -130,10 +114,6 @@ update parentMsg msg model =
             )
 
         MergeFail err ->
-            let
-                _ =
-                    Debug.log "merge failure" err
-            in
             ( setGlobalEditLock model False, Cmd.none )
 
         DeleteTextWord _ ->
@@ -163,10 +143,6 @@ update parentMsg msg model =
 
         -- handle user-friendly msgs
         UpdateTextTranslation (Err err) ->
-            let
-                _ =
-                    Debug.log "error decoding text translation" err
-            in
             ( model, Cmd.none )
 
         UpdateTextTranslations (Ok words) ->
@@ -174,10 +150,6 @@ update parentMsg msg model =
 
         -- handle user-friendly msgs
         UpdateTextTranslations (Err err) ->
-            let
-                _ =
-                    Debug.log "error decoding text translations" err
-            in
             ( model, Cmd.none )
 
         UpdateNewTranslationForTextWord textWord translationTxt ->
@@ -207,10 +179,6 @@ update parentMsg msg model =
 
         -- handle user-friendly msgs
         SubmittedTextTranslation (Err err) ->
-            let
-                _ =
-                    Debug.log "error decoding adding text translations" err
-            in
             ( model, Cmd.none )
 
         DeleteTranslation textWord textTranslation ->
@@ -225,12 +193,8 @@ update parentMsg msg model =
 
         -- handle user-friendly msgs
         DeletedTranslation (Err err) ->
-            let
-                _ =
-                    Debug.log "error deleting text translations" err
-            in
             ( model, Cmd.none )
-
+                
         SelectGrammemeForEditing _ grammemeName ->
             ( Text.Translations.Model.selectGrammemeForEditing model grammemeName
             , Cmd.none


### PR DESCRIPTION
This branch would have been more appropriately named `feature/optimized-build`.  The Dockerfile has the correct command to build more compact code, which is then copied over to the webserver's directory. `Debug` statements needed to be removed so that this could happen. 

If this needed to be tested, I'd say having two versions of the container system, one with 
```
    && npm run build:staging \
``` 
and one with
```
    && npm run build \
```
in `Dockerfile.node` would do the trick. One would then ssh into the server, exec onto the container, and check the file sizes of each build for comparison.