### PR TITLE
Opacity bugfix

### DIFF
--- a/web/public/css/homepage.css
+++ b/web/public/css/homepage.css
@@ -25,7 +25,7 @@
 
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
 
-  opacity: 80%;
+  opacity: .8;
 }
 
 #home-wrapper > .description {


### PR DESCRIPTION
Somewhere in our production build there is use of cssnano, which has a
bug that reduces opacity to 1% from whatever other setting. The fix to
this is either to use cssnano@nightly, or simply change the opacity to a
decimal rather than percentage. So it was converted to a decimal and the
problem has been averted.

https://github.com/NMFR/optimize-css-assets-webpack-plugin/issues/118