### PR TITLE
Feature/mobile styling

### DIFF
--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -197,7 +197,7 @@ body {
   margin-bottom: 15px;
 
   display: grid;
-  grid-template-columns: 225px auto auto auto;
+  grid-template-columns: 225px auto auto 1fr;
   grid-template-areas: 'logo content-nav . profile-nav';
   column-gap: 30px;
 
@@ -601,7 +601,7 @@ body {
 
     justify-content: center;
 
-    padding: 15px 10px 10px 10px;
+    padding: 15px 20px;
     font-size: 25px;
   }
 
@@ -646,6 +646,10 @@ body {
     padding: 15px 0 10px 10px;
   }
 
+  .infobar {
+    width: 75%;
+  }
+
   .menu-icon {
     display: grid;
     grid-area: menu-icon;
@@ -671,13 +675,6 @@ body {
     opacity: 1;
     transition: opacity 0.25s, height 0.4s;
   }
-
-}
-
-@media (max-width: 568px) {
-  .infobar {
-    width: 75%;
-  }
 }
 
 @media only screen and (max-width: 768px) {
@@ -695,7 +692,7 @@ body {
   #header {
     padding: 10px 15px;
 
-    grid-template-columns: 150px auto auto auto;
+    grid-template-columns: 150px auto auto 1fr;
     column-gap: 20px;
     font-size: 18px;
   }

--- a/web/public/css/user_profile.css
+++ b/web/public/css/user_profile.css
@@ -18,17 +18,16 @@ table th {
 }
 
 .profile {
-  display: grid;
+  /* display: grid; */
 
   grid-template-columns: 4% 10% [content] auto 15% 4%;
 }
 
 .profile-title {
-  grid-column: content;
-
   margin-top: 20px;
   font-family: 'EB Garamond';
   font-size: 2rem;
+  padding: 0 0 0 25px;
 }
 
 .profile_items {
@@ -109,8 +108,6 @@ table th {
   grid-row: 5;
   font-size: larger;
   grid-template-columns: auto;
-  grid-template-rows: 25px 35px;
-  margin: 20px 20px 20px 0;
 }
 
 .feedback a {
@@ -123,14 +120,14 @@ table th {
 }
 
 .feedback span {
-  padding: 5px;
+  padding: 0 0 5px 0;
 }
 
 #words {
   display: grid;
   grid-template-columns: auto;
   grid-template-rows: 20px 50px;
-  margin-bottom: 15px;
+  margin-bottom: 0px;
 }
 
 #research_consent {
@@ -266,6 +263,8 @@ table th {
   grid-template-columns: auto;
   grid-template-rows: 25px 35px;
   margin-bottom: 15px;
+
+  overflow: hidden;
 }
 
 .profile_item_title {

--- a/web/public/css/user_profile.css
+++ b/web/public/css/user_profile.css
@@ -138,9 +138,7 @@ table th {
   grid-row: 3;
   grid-column: 1 / 3;
   grid-template-columns: auto;
-  grid-template-rows: 35px 35px;
   grid-row-gap: 10px;
-  margin-bottom: 15px;
 }
 
 #research_consent a {
@@ -164,7 +162,7 @@ table th {
 #research_consent > .value > .check-box-text {
   display: inline-block;
   vertical-align: top;
-  padding-top: 4px;
+  padding-top: 1px;
   font-size: 18px;
 }
 
@@ -191,7 +189,7 @@ table th {
   display: inline-block;
   vertical-align: top;
   font-size: 18px;
-  padding-top: 4px;
+  padding-top: 1px;
 }
 
 .check-box-selected {

--- a/web/src/Pages/Profile/Student.elm
+++ b/web/src/Pages/Profile/Student.elm
@@ -767,8 +767,8 @@ viewResearchConsent (SafeModel model) =
             "You have not consented to be a part of a research study."
     in
     div [ id "research_consent" ]
-        [ span [ class "profile_item_title" ] [ Html.text "Research Consent" ]
-        , span []
+        [ div [ class "profile_item_title" ] [ Html.text "Research Consent" ]
+        , div []
             [ Html.text """
           From time to time, there maybe research projects related to this site.
           To read about those projects and to review and sign consent forms,
@@ -779,7 +779,7 @@ viewResearchConsent (SafeModel model) =
                 ]
             , Html.text "."
             ]
-        , span [ class "value" ]
+        , div [ class "value" ]
             [ div
                 [ classList [ ( "check-box", True ), ( "check-box-selected", consented ) ]
                 , onClick ToggleResearchConsent


### PR DESCRIPTION
This commit brings in the following CSS:
* Use `1fr` in the navbar for "Acknowledgements"
* Reduce unnecessary white space
* Undid unnecessary `grid` to make page fit on SE
* Removed redundant media query statement

These changes improve the student's mobile experience. Cypress tests
will need a new baseline.