### PR TITLE
Navbar on mobile

### DIFF
--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -632,7 +632,7 @@ body {
     grid-area: content-nav;
     grid-column: 1/3;
 
-    grid-template-columns: 225px 1fr;
+    grid-template-columns: 1fr 1fr;
     grid-template-rows: auto auto auto auto;
     justify-content: left;
     align-items: center;


### PR DESCRIPTION
PR brings in changes to the navbar on mobile devices. Rather than 225px, which scrunches things on mobile devices (we've got more in the navbar now), lets use 1fr! This splits the entries evenly.

Bringing this one in because it's styling and it's still Thursday.