### PR TITLE
Feature/text reader styling

### DIFF
--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -89,7 +89,6 @@ body {
 
 
 .creator-guide {
-  width: 800px;
   padding: 10px 20px;
   margin: 0 auto;
 }

--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -577,7 +577,7 @@ body {
   font-family: 'Open Sans';
 
   grid-template-columns: 4% auto 4%;
-  grid-auto-rows: 110px;
+  grid-auto-rows:  minmax(150px, auto);
 }
 
 .text_tag {
@@ -624,6 +624,18 @@ body {
 .welcome-msg-text a {
   color: #00478f;
   text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  .invites {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .invites > .list {
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 @media (max-width: 880px) {
@@ -705,6 +717,10 @@ body {
     width: 75%;
   }
 
+  #invite_msg {
+    overflow: auto;
+  }
+
   .menu-icon {
     display: grid;
     grid-area: menu-icon;
@@ -727,5 +743,21 @@ body {
 
     opacity: 1;
     transition: opacity 0.25s, height 0.4s;
+  }
+}
+
+@media (max-width: 1400px) {
+  .text_item {
+    display: flex;
+    flex-direction: column;
+    grid-column: 2;
+  }
+
+  .text_items {
+    grid-auto-rows: auto;
+  }
+
+  .tag {
+    font-size: 23px;
   }
 }

--- a/web/public/css/instructor_profile.css
+++ b/web/public/css/instructor_profile.css
@@ -1,6 +1,7 @@
 #create_invite {
   margin-top: 15px;
   margin-bottom: 15px;
+  display: grid;
 }
 
 #create_invite > #submit {

--- a/web/public/css/text.css
+++ b/web/public/css/text.css
@@ -109,10 +109,11 @@
   display: grid;
 
   padding-top: 25px;
+  padding-bottom: 50px;
 
   grid-template-columns: repeat(auto-fit, minmax(175px, 1fr));
 
-  grid-template-rows: minmax(25px, 50px);
+  /* grid-template-rows: minmax(25px, 50px); */
   align-items: center;
 }
 
@@ -198,7 +199,7 @@
   display: grid;
 
   grid-template-columns: 10% [body-col] auto 10%;
-  grid-template-rows: 10% [body-row] auto 10%;
+  grid-template-rows: auto [body-row] auto 10%;
 
   font-family: 'Open Sans';
   font-size: 20px;
@@ -305,6 +306,6 @@
   #nav {
     grid-template-columns: repeat(auto-fit, minmax(275px, 1fr));
 
-    row-gap: 20px;
+    row-gap: 15px;
   }
 }

--- a/web/public/css/text.css
+++ b/web/public/css/text.css
@@ -114,6 +114,7 @@
   grid-template-columns: repeat(auto-fit, minmax(175px, 1fr));
 
   /* grid-template-rows: minmax(25px, 50px); */
+  row-gap: 15px;
   align-items: center;
 }
 
@@ -199,7 +200,7 @@
   display: grid;
 
   grid-template-columns: 10% [body-col] auto 10%;
-  grid-template-rows: auto [body-row] auto 10%;
+  grid-template-rows: auto [body-row] auto;
 
   font-family: 'Open Sans';
   font-size: 20px;
@@ -300,6 +301,7 @@
   }
 
   #text-section {
+    grid-template-columns: 7% [body-col] auto 7%;
     padding-top: 0;
   }
 


### PR DESCRIPTION
**What it does**
Fixes styling on the text reader pages. The whitespace above the text where an exception goes is hidden until the exception occurs. The positioning and distance between navigation buttons at the bottom of a text is now fixed. For future reference, overuse of min/max and percentages can cause these problems. For truly responsive design it seems best to let the contents decide the size of container when possible.
 
**Things to test for**
Pop open Chrome and switch to responsive mode. Grab the corner and drag between a desktop size and 320px. Then check steps2advancedreading.org where this branch is deployed to confirm it is working on real mobile devices.

**Affected files**
`web/public/css/ereader.css`
`web/public/css/text.css`
