### PR TITLE
Feature/guide reading strats

### DIFF
--- a/web/public/css/ereader-unauth.css
+++ b/web/public/css/ereader-unauth.css
@@ -3,11 +3,11 @@
     font-size: 18px;
     grid-auto-rows: minmax(65px, auto);
     margin-bottom: 0;
-    grid-template-columns: 7% 13% [content] auto 13% 7%;
+    grid-template-columns: 8% auto 8%;
 }
 
 #about-box {
-    grid-column: 3;
+    grid-column: 2;
     display: grid;
     grid-template-columns: auto;
     grid-auto-rows: minmax(50px, auto);
@@ -58,12 +58,12 @@
     max-width: 45%;
 }
 
-
-@media (max-width: 460px) {
+@media (max-width: 880px) {
     #about {
         font-size: 15px;
-        grid-template-columns: auto;
-        margin-left: 15px;
-        margin-right: 15px;
+    }
+    
+    .guide-tabs{
+        grid-template-columns: repeat(auto-fill, 134px);
     }
 }

--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -214,6 +214,8 @@ body {
 .guide-tab > .guide-link {
   color: #000000;
   text-decoration: none;
+  display: flex;
+  height: inherit;
 }
 
 .guide-tabs {

--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -207,7 +207,7 @@ body {
 .guide-tab {
   display: inline-block;
   padding: 7px;
-  height: 24px;
+  height: 40px;
   border: 1px solid #999999;
 }
 
@@ -218,8 +218,8 @@ body {
 
 .guide-tabs {
   display: grid;
-  max-width: 564px;
-  grid-template-columns: auto auto auto auto 1fr;
+  max-width: 745px;
+  grid-template-columns: repeat(auto-fill, 149px);
 }
 
 
@@ -652,6 +652,12 @@ body {
 
     opacity: 1;
     transition: opacity 0.25s, height 0.4s;
+  }
+
+  .guide-tabs {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 134px);
+    max-width: none;
   }
 
   #header {

--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -207,9 +207,8 @@ body {
 .guide-tab {
   display: inline-block;
   padding: 7px;
-
+  height: 24px;
   border: 1px solid #999999;
-  border-left: none;
 }
 
 .guide-tab > .guide-link {
@@ -219,9 +218,8 @@ body {
 
 .guide-tabs {
   display: grid;
-  height: 20px;
-  max-width: 450px;
-  grid-template-columns: auto auto auto 1fr;
+  max-width: 564px;
+  grid-template-columns: auto auto auto auto 1fr;
 }
 
 

--- a/web/src/Pages/Guide/Comprehension.elm
+++ b/web/src/Pages/Guide/Comprehension.elm
@@ -43,7 +43,8 @@ view { params } =
                     [ div [ id "title" ] [ text "Comprehension" ]
                     , viewTabs
                     , viewFirstSection
-                    , viewFirstSectionImage
+                    , viewSecondSection
+                    , viewThirdSection
                     ]
                 ]
             ]
@@ -92,6 +93,7 @@ viewTabs =
                 [ text "Progress" ]
             ]
         , div [ class "guide-tab" 
+            , class "selected-guide-tab"
             ]
             [ a
                 [ href (Route.toString Route.Guide__Strategies)
@@ -130,28 +132,53 @@ viewTabs =
 viewFirstSection : Html Msg
 viewFirstSection =
     Markdown.toHtml [ attribute "class" "markdown-link" ] """
+### Focus on Comprehension: Reading through unknown words
 
+Even in your first language there will be texts that you can read and comprehend where you do not know every word in the text. Sometimes, 
+you can figure out the meaning of the unfamiliar word from context; other times, you can look up the unfamiliar word if it seems important; 
+most times, the unfamiliar word may not keep you from understanding the basic meaning of the passage.
+
+Try these reading strategies for yourself on the text below where 30% of the words have been replaced with non-sense words.
+
+#### Pre-reading Work:
+The paragraph below starts a chapter of an English novel published in the 1860s. The title of the chapter is: A Boat on the River 
+
+**Activity 1**. Before reading, stop and brainstorming about what might be in such a chapter. Make hypotheses. Try to visualize the possible 
+scene. What does a 19th century boat on a river look like? How might people be dressed? What might be visible on the banks of the river?
+
+**Activity 2**. After you've completed your brainstorming, go on to read the text below. You won’t know every word, but keep on reading to 
+the end, and make as much sense out of the passage as you can.
 """
-
-
-viewFirstSectionImage : Html Msg
-viewFirstSectionImage =
-    div [ class "guide-image-container" ]
-        [
-        -- [ img
-            -- [ class "guide-image"
-            -- , src "/public/img/tutorial/student/14.png"
-            -- , alt (viewAltText "13" altTexts)
-            -- , title (viewAltText "13" altTexts)
-            -- ]
-            -- []
-        ]
 
 
 viewSecondSection : Html Msg
 viewSecondSection =
     Markdown.toHtml [] """
+*A Boat on the River*
 
+The gapels in this boat were those of a foslaint man with nabelked amboned hair and a trathmollated face, and a finlact girl of nineteen or twenty, 
+nabbastly like him to be sorbicable as his fornoy. The girl zarred, pulling a pair of sculls very easily; the man, with the rudder-lines slack in 
+his dispers, and his dispers loose in his waistband, kept an eager look out. He had no net, galeaft, or line, and he could not be a paplil; his boat 
+had no exbain for a sitter, no paint, no debilk, no bepult beyond a rusty calben and a lanop of rope, and he could not be a waterman; his boat was too 
+anem and too divey to take in besder for delivery, and he could not be a river-carrier; there was no paff to what he looked for, sar he looked for 
+something, with a most nagril and searching profar. The befin, which had turned an hour before, was melucting zopt, and his eyes hasteled every little 
+furan and gaist in its broad sweep, as the boat made bilp ducasp against it, or drove stern foremost before it, according as he calbained his fornoy by 
+a calput of his head. She hasteled his face as parnly as he hasteled the river. But, in the astortant of her look there was a touch of bazad or fisd.
+"""
+
+
+viewThirdSection : Html Msg
+viewThirdSection =
+    Markdown.toHtml [] """
+### Learning to read through unfamiliar words
+
+How many of the comprehension questions were you able to answer correctly? Did the presence of so many unfamiliar words keep you from forming a general impression of what is going on in this passage? 
+
+Which ones of your hypotheses about the text were accurate? Which ones did you need to abandon? Did trying to visualize what the scene might look like help you in reading the text?
+
+How can you apply this strategy when you are reading a text in Russian?
+
+In the next section of this strategy instruction, you will work on using context to guess the meaning of unfamiliar words.
 """
 
 

--- a/web/src/Pages/Guide/Comprehension.elm
+++ b/web/src/Pages/Guide/Comprehension.elm
@@ -1,4 +1,4 @@
-module Pages.Guide.Progress exposing (..)
+module Pages.Guide.Comprehension exposing (..)
 
 import Dict exposing (Dict)
 import Html exposing (..)
@@ -35,12 +35,12 @@ type alias Params =
 
 view : Url Params -> Document Msg
 view { params } =
-    { title = "Guide | Progress"
+    { title = "Guide | Comprehension"
     , body =
         [ div [ id "body" ]
             [ div [ id "about" ]
                 [ div [ id "about-box" ]
-                    [ div [ id "title" ] [ text "Progress" ]
+                    [ div [ id "title" ] [ text "Comprehension" ]
                     , viewTabs
                     , viewFirstSection
                     , viewFirstSectionImage
@@ -84,7 +84,6 @@ viewTabs =
             ]
         , div
             [ class "guide-tab"
-            , class "selected-guide-tab"
             ]
             [ a
                 [ href (Route.toString Route.Guide__Progress)
@@ -92,12 +91,38 @@ viewTabs =
                 ]
                 [ text "Progress" ]
             ]
-        , div [ class "guide-tab" ]
+        , div [ class "guide-tab" 
+            ]
             [ a
                 [ href (Route.toString Route.Guide__Strategies)
                 , class "guide-link"
                 ]
                 [ text "Strategies" ]
+            ]
+        , div [ class "guide-tab" 
+            , class "selected-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Comprehension)
+                , class "guide-link"
+                ]
+                [ text "Comprehension" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Context)
+                , class "guide-link"
+                ]
+                [ text "Context" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Priority)
+                , class "guide-link"
+                ]
+                [ text "Priority" ]
             ]
         ]
 
@@ -105,55 +130,28 @@ viewTabs =
 viewFirstSection : Html Msg
 viewFirstSection =
     Markdown.toHtml [ attribute "class" "markdown-link" ] """
-**1\\.**
-**My Words.** In this section, you can access the words that you have saved from when you 
-were reading texts and looking up words. You can download these words either as a PDF 
-(to review visually), or as a plain comma-separated text file, which you can paste in a 
-flashcards program like [Quizlet](https://quizlet.com/), [Anki](https://apps.ankiweb.net/),
-or [Kommit](https://kommit.rosano.ca/). For each word you’ve saved, you’ll get the dictionary 
-form of the word, part of the text’s sentence that includes the word from the text you were 
-reading and an English equivalent appropriate for that context.
 
-**2\\.**
-**My Performance.** 
-This section gives you two tables: the “Completion” table shows you how much you’ve been 
-reading, by proficiency levels, over the current month (today and the previous 30 days), 
-the previous month (31 to 60 days ago), and cumulatively. The “First Time Comprehension” 
-table will show you how many comprehension questions you’ve answered correctly the first 
-time that you tried them, and what % that represents from all the questions you’ve tried 
-at that level.
 """
 
 
 viewFirstSectionImage : Html Msg
 viewFirstSectionImage =
     div [ class "guide-image-container" ]
-        [ img
-            [ class "guide-image"
-            , src "/public/img/tutorial/student/14.png"
-            , alt (viewAltText "13" altTexts)
-            , title (viewAltText "13" altTexts)
-            ]
-            []
+        [
+        -- [ img
+            -- [ class "guide-image"
+            -- , src "/public/img/tutorial/student/14.png"
+            -- , alt (viewAltText "13" altTexts)
+            -- , title (viewAltText "13" altTexts)
+            -- ]
+            -- []
         ]
 
 
 viewSecondSection : Html Msg
 viewSecondSection =
     Markdown.toHtml [] """
-**3\\.**
-This “first time correct” number is a good indicator of how well you will probably read in a 
-testing situation.
 
-
-You can download the “My Performance” tables as a PDF document if you want or need to share 
-your progress with a teacher or an advisor.
-
-
-**4\\.**
-**Contact.**
-These links allow you to report any problems that you encounter when using the site, or to 
-give a general evaluation of the site, its layout and functionality.
 """
 
 
@@ -170,4 +168,4 @@ viewAltText id texts =
 altTexts : Dict String String
 altTexts =
     Dict.fromList
-        [ ( "14", "Performance report indicating first time correct, completed, and in-progress texts over time" ) ]
+        [ ]

--- a/web/src/Pages/Guide/Context.elm
+++ b/web/src/Pages/Guide/Context.elm
@@ -43,7 +43,8 @@ view { params } =
                     [ div [ id "title" ] [ text "Context" ]
                     , viewTabs
                     , viewFirstSection
-                    , viewFirstSectionImage
+                    , viewSecondSection
+                    , viewThirdSection
                     ]
                 ]
             ]
@@ -92,6 +93,7 @@ viewTabs =
                 [ text "Progress" ]
             ]
         , div [ class "guide-tab" 
+            , class "selected-guide-tab"
             ]
             [ a
                 [ href (Route.toString Route.Guide__Strategies)
@@ -130,28 +132,44 @@ viewTabs =
 viewFirstSection : Html Msg
 viewFirstSection =
     Markdown.toHtml [ attribute "class" "markdown-link" ] """
+### Using context to guess unknown words
 
+While you may not be able to guess the meaning of every unfamiliar word from context, you should be able to narrow the possible range of meanings of specific words.  
+Use context and these questions to help you narrow down the possible meaning of key words. 
+1. If the unknown word seems to be a noun, does it refer to a person? To a place? To a thing? To a concept? Does it seem to be a synonym for something already mentioned in the text?
+2. If it’s an adjective, what word does it modify? Does it seem to suggest a positive or a negative quality? Does it refer to time? Or place? 
+3. If it’s a verb, who seems to be the doer of the action? Is there a direct object of the action? Does it suggest motion (into/to/towards) a person or place? Does it suggest 
+communication (to someone or with someone)? Is it present/future tense? Or past?
 """
-
-
-viewFirstSectionImage : Html Msg
-viewFirstSectionImage =
-    div [ class "guide-image-container" ]
-        [
-        -- [ img
-            -- [ class "guide-image"
-            -- , src "/public/img/tutorial/student/14.png"
-            -- , alt (viewAltText "13" altTexts)
-            -- , title (viewAltText "13" altTexts)
-            -- ]
-            -- []
-        ]
 
 
 viewSecondSection : Html Msg
 viewSecondSection =
     Markdown.toHtml [] """
+*A Boat on the River*
 
+The **gapels** in this boat were those of a foslaint man with nabelked amboned hair and a trathmollated face, and a finlact girl of nineteen or twenty, nabbastly like him to be 
+sorbicable as his fornoy. The girl zarred, pulling a pair of sculls very easily; the man, with the rudder-lines slack in his **dispers**, and his **dispers** loose in his waistband, 
+kept an eager look out. He had no net, galeaft, or line, and he could not be a paplil; his boat had no exbain for a sitter, no paint, no debilk, no bepult beyond a rusty calben and a 
+lanop of rope, and he could not be a waterman; his boat was too **anem** and too **divey** to take in besder for delivery, and he could not be a river-carrier; there was no paff to 
+what he looked for, sar he looked for something, with a most nagril and searching **profar**. The befin, which had turned an hour before, was melucting zopt, and his eyes **hasteled** 
+every little furan and gaist in its broad sweep, as the boat made bilp ducasp against it, or drove stern foremost before it, according as he calbained his fornoy by a calput of his head. 
+She **hasteled** his face as parnly as he **hasteled** the river. But, in the astortant of her look there was a touch of bazad or fisd.
+"""
+
+
+viewThirdSection : Html Msg
+viewThirdSection =
+    Markdown.toHtml [] """
+### Continuing from a guess
+
+Guessing from background knowledge is a risky strategy, especially if you don't know a large number of words in the text.   Be sure to look up the word after guessing to confirm your hypothesis.
+
+You may be able to enhance your ability to guess from background knowledge if you can combine that strategy with some word recognition strategies. For example, in this text, if you knew that **pap** 
+meant "**fish**," and the suffix lin often signified the doer of an action, then you'd have stronger justification to guess that **paplin** means "fisherman." Such word formation clues can be powerful 
+tools in guessing the meaning of unknown words.
+
+In the next section of this strategy instruction, you will work on deciding how to prioritize which unfamiliar words you would look up in a dictionary.
 """
 
 

--- a/web/src/Pages/Guide/Context.elm
+++ b/web/src/Pages/Guide/Context.elm
@@ -1,4 +1,4 @@
-module Pages.Guide.Progress exposing (..)
+module Pages.Guide.Context exposing (..)
 
 import Dict exposing (Dict)
 import Html exposing (..)
@@ -35,12 +35,12 @@ type alias Params =
 
 view : Url Params -> Document Msg
 view { params } =
-    { title = "Guide | Progress"
+    { title = "Guide | Context"
     , body =
         [ div [ id "body" ]
             [ div [ id "about" ]
                 [ div [ id "about-box" ]
-                    [ div [ id "title" ] [ text "Progress" ]
+                    [ div [ id "title" ] [ text "Context" ]
                     , viewTabs
                     , viewFirstSection
                     , viewFirstSectionImage
@@ -84,7 +84,6 @@ viewTabs =
             ]
         , div
             [ class "guide-tab"
-            , class "selected-guide-tab"
             ]
             [ a
                 [ href (Route.toString Route.Guide__Progress)
@@ -92,12 +91,38 @@ viewTabs =
                 ]
                 [ text "Progress" ]
             ]
-        , div [ class "guide-tab" ]
+        , div [ class "guide-tab" 
+            ]
             [ a
                 [ href (Route.toString Route.Guide__Strategies)
                 , class "guide-link"
                 ]
                 [ text "Strategies" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Comprehension)
+                , class "guide-link"
+                ]
+                [ text "Comprehension" ]
+            ]
+        , div [ class "guide-tab" 
+            , class "selected-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Context)
+                , class "guide-link"
+                ]
+                [ text "Context" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Priority)
+                , class "guide-link"
+                ]
+                [ text "Priority" ]
             ]
         ]
 
@@ -105,55 +130,28 @@ viewTabs =
 viewFirstSection : Html Msg
 viewFirstSection =
     Markdown.toHtml [ attribute "class" "markdown-link" ] """
-**1\\.**
-**My Words.** In this section, you can access the words that you have saved from when you 
-were reading texts and looking up words. You can download these words either as a PDF 
-(to review visually), or as a plain comma-separated text file, which you can paste in a 
-flashcards program like [Quizlet](https://quizlet.com/), [Anki](https://apps.ankiweb.net/),
-or [Kommit](https://kommit.rosano.ca/). For each word you’ve saved, you’ll get the dictionary 
-form of the word, part of the text’s sentence that includes the word from the text you were 
-reading and an English equivalent appropriate for that context.
 
-**2\\.**
-**My Performance.** 
-This section gives you two tables: the “Completion” table shows you how much you’ve been 
-reading, by proficiency levels, over the current month (today and the previous 30 days), 
-the previous month (31 to 60 days ago), and cumulatively. The “First Time Comprehension” 
-table will show you how many comprehension questions you’ve answered correctly the first 
-time that you tried them, and what % that represents from all the questions you’ve tried 
-at that level.
 """
 
 
 viewFirstSectionImage : Html Msg
 viewFirstSectionImage =
     div [ class "guide-image-container" ]
-        [ img
-            [ class "guide-image"
-            , src "/public/img/tutorial/student/14.png"
-            , alt (viewAltText "13" altTexts)
-            , title (viewAltText "13" altTexts)
-            ]
-            []
+        [
+        -- [ img
+            -- [ class "guide-image"
+            -- , src "/public/img/tutorial/student/14.png"
+            -- , alt (viewAltText "13" altTexts)
+            -- , title (viewAltText "13" altTexts)
+            -- ]
+            -- []
         ]
 
 
 viewSecondSection : Html Msg
 viewSecondSection =
     Markdown.toHtml [] """
-**3\\.**
-This “first time correct” number is a good indicator of how well you will probably read in a 
-testing situation.
 
-
-You can download the “My Performance” tables as a PDF document if you want or need to share 
-your progress with a teacher or an advisor.
-
-
-**4\\.**
-**Contact.**
-These links allow you to report any problems that you encounter when using the site, or to 
-give a general evaluation of the site, its layout and functionality.
 """
 
 
@@ -170,4 +168,4 @@ viewAltText id texts =
 altTexts : Dict String String
 altTexts =
     Dict.fromList
-        [ ( "14", "Performance report indicating first time correct, completed, and in-progress texts over time" ) ]
+        [ ]

--- a/web/src/Pages/Guide/GettingStarted.elm
+++ b/web/src/Pages/Guide/GettingStarted.elm
@@ -262,6 +262,13 @@ viewTabs =
                 ]
                 [ text "Progress" ]
             ]
+        , div [ class "guide-tab" ]
+            [ a
+                [ href (Route.toString Route.Guide__Strategies)
+                , class "guide-link"
+                ]
+                [ text "Strategies" ]
+            ]
         ]
 
 

--- a/web/src/Pages/Guide/Priority.elm
+++ b/web/src/Pages/Guide/Priority.elm
@@ -43,7 +43,10 @@ view { params } =
                     [ div [ id "title" ] [ text "Priority" ]
                     , viewTabs
                     , viewFirstSection
-                    , viewFirstSectionImage
+                    , viewSecondSection
+                    , viewThirdSection
+                    , viewFourthSection
+                    , viewFifthSection
                     ]
                 ]
             ]
@@ -92,6 +95,7 @@ viewTabs =
                 [ text "Progress" ]
             ]
         , div [ class "guide-tab" 
+            , class "selected-guide-tab"
             ]
             [ a
                 [ href (Route.toString Route.Guide__Strategies)
@@ -130,28 +134,105 @@ viewTabs =
 viewFirstSection : Html Msg
 viewFirstSection =
     Markdown.toHtml [ attribute "class" "markdown-link" ] """
+### Prioritizing words
 
+It is usually not practical to try to look up every word that you don’t know in a text. It can take far too much time, and the process of looking 
+may distract you from trying to get any meaning out of what you do understand. So, you need to develop a sense of what words to prioritize for looking up. 
+
+
+1. **Notice the frequency of unfamiliar words**
+The first thing to prioritize are unknown words that appear multiple times in a text or passage. Understanding repeated words will help you stretch your understanding of the text.
 """
-
-
-viewFirstSectionImage : Html Msg
-viewFirstSectionImage =
-    div [ class "guide-image-container" ]
-        [
-        -- [ img
-            -- [ class "guide-image"
-            -- , src "/public/img/tutorial/student/14.png"
-            -- , alt (viewAltText "13" altTexts)
-            -- , title (viewAltText "13" altTexts)
-            -- ]
-            -- []
-        ]
 
 
 viewSecondSection : Html Msg
 viewSecondSection =
     Markdown.toHtml [] """
+*A Boat on the River*
 
+The gapels in this boat were those of a foslaint man with nabelked amboned hair and a trathmollated face, and a finlact girl of nineteen or twenty, nabbastly like him to be sorbicable 
+as his **fornoy**. The girl zarred, pulling a pair of sculls very easily; the man, with the rudder-lines slack in his dispers, and his dispers loose in his waistband, kept an eager 
+look out. He had no net, galeaft, or line, and he could not be a paplil; his boat had no **exbain** for a sitter, no paint, no debilk, no bepult beyond a rusty calben and a lanop of rope, 
+and he could not be a waterman; his boat was too anem and too divey to take in besder for delivery, and he could not be a river-carrier; there was no paff to what he looked for, sar he 
+looked for something, with a most nagril and searching profar. The befin, which had turned an hour before, was melucting zopt, and his eyes **hasteled** every little furan and gaist in 
+its broad sweep, as the boat made bilp ducasp against it, or drove stern foremost before it, according as he calbained his **fornoy** by a **calput** of his head. She **hasteled** his face 
+as parnly as he **hasteled** the river. But, in the astortant of her look there was a touch of bazad or fisd.
+"""
+
+
+viewThirdSection : Html Msg
+viewThirdSection =
+    Markdown.toHtml [] """
+### Prioritize words to look up strategically
+What next to prioritize will depend on what your motivation for reading is. If you’re trying to follow the basic plot of a story, then look up nouns and verbs, so you know where, when, 
+who and what. If you’re trying to understand a character, then look up adjectives and phrases that are applied to that character. If you are trying to follow motivations of characters, then 
+looking up words in the clause that starts with the word “because….” might be most helpful. If you are reading a text for class, the comprehension questions your teacher has assigned can help 
+you prioritize what parts of the text you need to focus on.
+
+#### Unfamiliar words and their part of speech
+Part of prioritizing what words to look up is recognizing or having a strong sense as to the part of speech of the unfamiliar word. Using the grammar of the surrounding text, you can often 
+tell an unfamiliar word’s part of speech. The nonsense words in this text also all use regular English grammatical endings, so those can help you as well. Be sure to determine the part of 
+speech based on how the word is used in the sentence and not just on its grammatical ending.
+
+*A Boat on the River*
+
+The gapels in this boat were those of a foslaint man with nabelked amboned hair and a **trathmollated** face, and a finlact girl of nineteen or twenty, nabbastly like him to be sorbicable 
+as his fornoy. The girl **zarred**, pulling a pair of sculls very easily; the man, with the rudder-lines slack in his dispers, and his dispers loose in his waistband, kept an eager look out. 
+He had no net, galeaft, or line, and he could not be a **paplil**; his boat had no exbain for a sitter, no paint, no debilk, no bepult beyond a rusty calben and a lanop of rope, and he could 
+not be a waterman; his boat was too anem and too divey to take in besder for delivery, and he could not be a river-carrier; there was no paff to what he looked for, **sar** he looked for 
+something, with a most **nagril** and searching profar. The befin, which had turned an hour before, was melucting zopt, and his eyes hasteled every little furan and gaist in its broad sweep, 
+as the boat made bilp ducasp against it, or drove stern foremost before it, according as he calbained his fornoy by a calput of his head. She hasteled his face as **parnly** as he hasteled 
+the river. But, in the astortant of her look there was a touch of bazad or fisd.
+"""
+
+
+viewFourthSection : Html Msg
+viewFourthSection =
+    Markdown.toHtml [] """
+### Unfamiliar words and their importance to your tasks
+
+If you are reading a text for class, the comprehension questions your teacher has assigned can help you prioritize what parts of the text you need to focus on. For example, your teacher 
+included a question that asked about the emotional relationship between the man and the girl in the boat. You will need to locate the part of the text that contains that information, and to 
+prioritize those descriptive words that will help you understand that relationship.
+
+
+*A Boat on the River*
+
+The gapels in this boat were those of a **foslaint** man with nabelked amboned hair and a trathmollated face, and a finlact girl of nineteen or twenty, nabbastly like him to be sorbicable as his 
+**fornoy**. The girl zarred, pulling a pair of sculls very easily; the man, with the rudder-lines slack in his dispers, and his dispers loose in his waistband, kept an eager look out. He had no net, 
+galeaft, or line, and he could not be a paplil; his boat had no exbain for a sitter, no paint, no debilk, no bepult beyond a rusty calben and a lanop of rope, and he could not be a waterman; his boat 
+was too anem and too **divey** to take in besder for delivery, and he could not be a river-carrier; there was no paff to what he looked for, sar he looked for something, with a most nagril and 
+searching profar. The befin, which had turned an hour before, was melucting zopt, and his eyes hasteled every little furan and gaist in its broad sweep, as the boat made bilp ducasp against it, or 
+drove stern foremost before it, according as he **calbained** his **fornoy** by a calput of his head. She hasteled his face as parnly as he hasteled the river. But, in the astortant of her look there 
+was a touch of **bazad** or **fisd**.
+"""
+
+
+viewFifthSection : Html Msg
+viewFifthSection =
+    Markdown.toHtml [] """
+#### When looking up words
+Once you’ve prioritized a word for look up, be sure you make a guess about its English equivalent before you actually look it up. If your guess is right (or a very close synonym to the right answer), 
+then you are probably understanding the passage well.  If your guess is very far from the right answer, be sure to re-read the passage to understand how that changes your sense of what the passage is 
+about. If your guess is very far from the answer you find, check to make certain that the word doesn't have other meanings that might fight the context. There aren't an enormous number of homonyms in 
+Russian, but many Russian words can be used in different senses or contexts. Be sure that you've got the right sense for your context.
+
+#### Homonyms
+Homonyms to look out for:
+
+есть -- can be an infinitive "to eat," and it can be the third person of the verb быть meaning "there is/there are." 
+
+стали -- can be the past tense of стать = to become, begin OR the genitive/dative/prepositional of the noun сталь = steel
+
+Words that are similar, but have different stress
+
+за́мок - (noun) castle
+
+замо́к - (noun) lock
+
+мука́ - (noun) flour
+
+му́ка - (noun) torment
 """
 
 

--- a/web/src/Pages/Guide/Priority.elm
+++ b/web/src/Pages/Guide/Priority.elm
@@ -1,4 +1,4 @@
-module Pages.Guide.Progress exposing (..)
+module Pages.Guide.Priority exposing (..)
 
 import Dict exposing (Dict)
 import Html exposing (..)
@@ -35,12 +35,12 @@ type alias Params =
 
 view : Url Params -> Document Msg
 view { params } =
-    { title = "Guide | Progress"
+    { title = "Guide | Priority"
     , body =
         [ div [ id "body" ]
             [ div [ id "about" ]
                 [ div [ id "about-box" ]
-                    [ div [ id "title" ] [ text "Progress" ]
+                    [ div [ id "title" ] [ text "Priority" ]
                     , viewTabs
                     , viewFirstSection
                     , viewFirstSectionImage
@@ -84,7 +84,6 @@ viewTabs =
             ]
         , div
             [ class "guide-tab"
-            , class "selected-guide-tab"
             ]
             [ a
                 [ href (Route.toString Route.Guide__Progress)
@@ -92,12 +91,38 @@ viewTabs =
                 ]
                 [ text "Progress" ]
             ]
-        , div [ class "guide-tab" ]
+        , div [ class "guide-tab" 
+            ]
             [ a
                 [ href (Route.toString Route.Guide__Strategies)
                 , class "guide-link"
                 ]
                 [ text "Strategies" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Comprehension)
+                , class "guide-link"
+                ]
+                [ text "Comprehension" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Context)
+                , class "guide-link"
+                ]
+                [ text "Context" ]
+            ]
+        , div [ class "guide-tab" 
+            , class "selected-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Priority)
+                , class "guide-link"
+                ]
+                [ text "Priority" ]
             ]
         ]
 
@@ -105,55 +130,28 @@ viewTabs =
 viewFirstSection : Html Msg
 viewFirstSection =
     Markdown.toHtml [ attribute "class" "markdown-link" ] """
-**1\\.**
-**My Words.** In this section, you can access the words that you have saved from when you 
-were reading texts and looking up words. You can download these words either as a PDF 
-(to review visually), or as a plain comma-separated text file, which you can paste in a 
-flashcards program like [Quizlet](https://quizlet.com/), [Anki](https://apps.ankiweb.net/),
-or [Kommit](https://kommit.rosano.ca/). For each word you’ve saved, you’ll get the dictionary 
-form of the word, part of the text’s sentence that includes the word from the text you were 
-reading and an English equivalent appropriate for that context.
 
-**2\\.**
-**My Performance.** 
-This section gives you two tables: the “Completion” table shows you how much you’ve been 
-reading, by proficiency levels, over the current month (today and the previous 30 days), 
-the previous month (31 to 60 days ago), and cumulatively. The “First Time Comprehension” 
-table will show you how many comprehension questions you’ve answered correctly the first 
-time that you tried them, and what % that represents from all the questions you’ve tried 
-at that level.
 """
 
 
 viewFirstSectionImage : Html Msg
 viewFirstSectionImage =
     div [ class "guide-image-container" ]
-        [ img
-            [ class "guide-image"
-            , src "/public/img/tutorial/student/14.png"
-            , alt (viewAltText "13" altTexts)
-            , title (viewAltText "13" altTexts)
-            ]
-            []
+        [
+        -- [ img
+            -- [ class "guide-image"
+            -- , src "/public/img/tutorial/student/14.png"
+            -- , alt (viewAltText "13" altTexts)
+            -- , title (viewAltText "13" altTexts)
+            -- ]
+            -- []
         ]
 
 
 viewSecondSection : Html Msg
 viewSecondSection =
     Markdown.toHtml [] """
-**3\\.**
-This “first time correct” number is a good indicator of how well you will probably read in a 
-testing situation.
 
-
-You can download the “My Performance” tables as a PDF document if you want or need to share 
-your progress with a teacher or an advisor.
-
-
-**4\\.**
-**Contact.**
-These links allow you to report any problems that you encounter when using the site, or to 
-give a general evaluation of the site, its layout and functionality.
 """
 
 
@@ -170,4 +168,4 @@ viewAltText id texts =
 altTexts : Dict String String
 altTexts =
     Dict.fromList
-        [ ( "14", "Performance report indicating first time correct, completed, and in-progress texts over time" ) ]
+        [ ]

--- a/web/src/Pages/Guide/ReadingTexts.elm
+++ b/web/src/Pages/Guide/ReadingTexts.elm
@@ -98,6 +98,13 @@ viewTabs =
                 ]
                 [ text "Progress" ]
             ]
+        , div [ class "guide-tab" ]
+            [ a
+                [ href (Route.toString Route.Guide__Strategies)
+                , class "guide-link"
+                ]
+                [ text "Strategies" ]
+            ]
         ]
 
 

--- a/web/src/Pages/Guide/Settings.elm
+++ b/web/src/Pages/Guide/Settings.elm
@@ -90,6 +90,13 @@ viewTabs =
                 ]
                 [ text "Progress" ]
             ]
+        , div [ class "guide-tab" ]
+            [ a
+                [ href (Route.toString Route.Guide__Strategies)
+                , class "guide-link"
+                ]
+                [ text "Strategies" ]
+            ]
         ]
 
 

--- a/web/src/Pages/Guide/Strategies.elm
+++ b/web/src/Pages/Guide/Strategies.elm
@@ -35,15 +35,17 @@ type alias Params =
 
 view : Url Params -> Document Msg
 view { params } =
-    { title = "Guide | Techniques"
+    { title = "Guide | Strategies"
     , body =
         [ div [ id "body" ]
             [ div [ id "about" ]
                 [ div [ id "about-box" ]
-                    [ div [ id "title" ] [ text "Techniques" ]
+                    [ div [ id "title" ] [ text "Strategies" ]
                     , viewTabs
                     , viewFirstSection
-                    , viewFirstSectionImage
+                    , viewSecondSection
+                    , viewThirdSection
+                    , viewFourthSection
                     ]
                 ]
             ]
@@ -130,28 +132,59 @@ viewTabs =
 viewFirstSection : Html Msg
 viewFirstSection =
     Markdown.toHtml [ attribute "class" "markdown-link" ] """
+### How to approach a text
 
+#### Preview and get ready to read.
+If you know the general topic of the text (from the teacher, or the title, or an illustration), take a minute to formulate some ideas that you think are likely to be referenced in a text on that topic.
+
+Then approach the text to see if any of your initial assumptions are referenced in it. It’s also useful when you realize that your initial assumptions are NOT mentioned in the text. Keep an open mind 
+as you read the text for the first time.
+
+Take stock of your first reading and how it lined up with your assumptions. 
 """
-
-
-viewFirstSectionImage : Html Msg
-viewFirstSectionImage =
-    div [ class "guide-image-container" ]
-        [
-        -- [ img
-            -- [ class "guide-image"
-            -- , src "/public/img/tutorial/student/14.png"
-            -- , alt (viewAltText "13" altTexts)
-            -- , title (viewAltText "13" altTexts)
-            -- ]
-            -- []
-        ]
 
 
 viewSecondSection : Html Msg
 viewSecondSection =
     Markdown.toHtml [] """
+#### Reading for deeper comprehension.
 
+Now read the text (sentence, paragraph) again. This time around try to get as much as possible out of the text without drawing on your assumptions.
+
+When you’ve gotten to the end of this reading, try to summarize for yourself the main points by seeing how many questions like these you can answer: What happened? Who did it? When? Where? Why? How?
+
+Don’t worry if you can’t answer all those questions on the first deep reading. Go back and read again. Confirm your answers to the main points that you did get.  Add details or connections to those points. 
+If you’ve been having trouble reading to the end of the text (or paragraph or sentence), keep on reading even if you may lose the thread of what’s happening for a while.
+
+Now summarize the fuller picture you’ve gotten of the text (or sentence or paragraph).
+"""
+
+
+viewThirdSection : Html Msg
+viewThirdSection =
+    Markdown.toHtml [] """
+#### Confirming details and prioritizing words to look up.
+
+
+After reading through a text twice or three times, you probably have a good idea of what words you need to check to make sure your hypotheses about the text are correct.
+
+Prioritize the words that you look up by picking key nouns or verbs first. They will give you more of the bones or the skeleton of the sentence. If you’ve got a good idea about all the “bones” or specific 
+facts, then you might check that you really understand the relationship between the facts by looking up the connectors that hold them together. If you’re sure of the facts, but you can’t make out the attitude 
+to the facts, look up some of the adjectives and adverbs since they will often reveal the author’s evaluation of the facts.
+
+Before you click to see a translation, take a guess about what the word means.Once you’ve looked up a word, fit the word into the whole sentence where it appears. Does confirming that word help you figure 
+out the rest of the sentence? If so, move on to the next sentence, and see if you can go further.
+"""
+
+
+viewFourthSection : Html Msg
+viewFourthSection =
+    Markdown.toHtml [] """
+#### Read and re-read. 
+
+As you get more words, re-read the passage and develop a firmer understanding of each sentence and how they add meaning to the whole paragraph. 
+Re-reading parts of the text that you've already figured out will help you learn the vocabulary in the text, and will help you begin to see patterns about which words often are used together 
+(i.e.,  школьные учебники =school textbooks, иметь право = to have the right to) and how words fit together (i.e., that verb takes an object in the dative case, that preposition goes with the genitive case). 
 """
 
 

--- a/web/src/Pages/Guide/Strategies.elm
+++ b/web/src/Pages/Guide/Strategies.elm
@@ -1,4 +1,4 @@
-module Pages.Guide.Progress exposing (..)
+module Pages.Guide.Strategies exposing (..)
 
 import Dict exposing (Dict)
 import Html exposing (..)
@@ -35,12 +35,12 @@ type alias Params =
 
 view : Url Params -> Document Msg
 view { params } =
-    { title = "Guide | Progress"
+    { title = "Guide | Techniques"
     , body =
         [ div [ id "body" ]
             [ div [ id "about" ]
                 [ div [ id "about-box" ]
-                    [ div [ id "title" ] [ text "Progress" ]
+                    [ div [ id "title" ] [ text "Techniques" ]
                     , viewTabs
                     , viewFirstSection
                     , viewFirstSectionImage
@@ -84,7 +84,6 @@ viewTabs =
             ]
         , div
             [ class "guide-tab"
-            , class "selected-guide-tab"
             ]
             [ a
                 [ href (Route.toString Route.Guide__Progress)
@@ -92,12 +91,38 @@ viewTabs =
                 ]
                 [ text "Progress" ]
             ]
-        , div [ class "guide-tab" ]
+        , div [ class "guide-tab" 
+            , class "selected-guide-tab"
+            ]
             [ a
                 [ href (Route.toString Route.Guide__Strategies)
                 , class "guide-link"
                 ]
                 [ text "Strategies" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Comprehension)
+                , class "guide-link"
+                ]
+                [ text "Comprehension" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Context)
+                , class "guide-link"
+                ]
+                [ text "Context" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Priority)
+                , class "guide-link"
+                ]
+                [ text "Priority" ]
             ]
         ]
 
@@ -105,55 +130,28 @@ viewTabs =
 viewFirstSection : Html Msg
 viewFirstSection =
     Markdown.toHtml [ attribute "class" "markdown-link" ] """
-**1\\.**
-**My Words.** In this section, you can access the words that you have saved from when you 
-were reading texts and looking up words. You can download these words either as a PDF 
-(to review visually), or as a plain comma-separated text file, which you can paste in a 
-flashcards program like [Quizlet](https://quizlet.com/), [Anki](https://apps.ankiweb.net/),
-or [Kommit](https://kommit.rosano.ca/). For each word you’ve saved, you’ll get the dictionary 
-form of the word, part of the text’s sentence that includes the word from the text you were 
-reading and an English equivalent appropriate for that context.
 
-**2\\.**
-**My Performance.** 
-This section gives you two tables: the “Completion” table shows you how much you’ve been 
-reading, by proficiency levels, over the current month (today and the previous 30 days), 
-the previous month (31 to 60 days ago), and cumulatively. The “First Time Comprehension” 
-table will show you how many comprehension questions you’ve answered correctly the first 
-time that you tried them, and what % that represents from all the questions you’ve tried 
-at that level.
 """
 
 
 viewFirstSectionImage : Html Msg
 viewFirstSectionImage =
     div [ class "guide-image-container" ]
-        [ img
-            [ class "guide-image"
-            , src "/public/img/tutorial/student/14.png"
-            , alt (viewAltText "13" altTexts)
-            , title (viewAltText "13" altTexts)
-            ]
-            []
+        [
+        -- [ img
+            -- [ class "guide-image"
+            -- , src "/public/img/tutorial/student/14.png"
+            -- , alt (viewAltText "13" altTexts)
+            -- , title (viewAltText "13" altTexts)
+            -- ]
+            -- []
         ]
 
 
 viewSecondSection : Html Msg
 viewSecondSection =
     Markdown.toHtml [] """
-**3\\.**
-This “first time correct” number is a good indicator of how well you will probably read in a 
-testing situation.
 
-
-You can download the “My Performance” tables as a PDF document if you want or need to share 
-your progress with a teacher or an advisor.
-
-
-**4\\.**
-**Contact.**
-These links allow you to report any problems that you encounter when using the site, or to 
-give a general evaluation of the site, its layout and functionality.
 """
 
 
@@ -170,4 +168,4 @@ viewAltText id texts =
 altTexts : Dict String String
 altTexts =
     Dict.fromList
-        [ ( "14", "Performance report indicating first time correct, completed, and in-progress texts over time" ) ]
+        [ ]


### PR DESCRIPTION
Adds tabs to the Student Guide.

Adapted from a Google Site used to demonstrate STAR and more broadly speak on reading comprehension. The `Strategies` tab can be seen at the end of the list of tabs. 

When the `Strategies` tab has been selected three other tabs become available on a row below. As these are cycled through the `Strategies` tab remains styled as a selected tab. This color could be slightly lighter, but currently it is the same color.

Currently working on Responsiveness for mobile site.