### PR TITLE
Updating Student Guide

### DIFF
--- a/web/public/css/ereader-unauth.css
+++ b/web/public/css/ereader-unauth.css
@@ -3,11 +3,11 @@
     font-size: 18px;
     grid-auto-rows: minmax(65px, auto);
     margin-bottom: 0;
-    grid-template-columns: 7% 13% [content] auto 13% 7%;
+    grid-template-columns: 8% auto 8%;
 }
 
 #about-box {
-    grid-column: 3;
+    grid-column: 2;
     display: grid;
     grid-template-columns: auto;
     grid-auto-rows: minmax(50px, auto);
@@ -58,12 +58,12 @@
     max-width: 45%;
 }
 
-
-@media (max-width: 460px) {
+@media (max-width: 880px) {
     #about {
         font-size: 15px;
-        grid-template-columns: auto;
-        margin-left: 15px;
-        margin-right: 15px;
+    }
+    
+    .guide-tabs{
+        grid-template-columns: repeat(auto-fill, 134px);
     }
 }

--- a/web/public/css/ereader.css
+++ b/web/public/css/ereader.css
@@ -87,6 +87,12 @@ body {
   align-items: center;
 }
 
+.correct-answer-guide {
+  border: 1px solid;
+  border-color: #07e200 !important;
+  padding: 7px;
+  margin-top: 10px;
+}
 
 .creator-guide {
   padding: 10px 20px;
@@ -204,24 +210,35 @@ body {
   align-items: center;
 }
 
+.guide-question {
+  border: #00458a solid 0.5px;
+  border-radius: 2px;
+  margin-top: 7px;
+  padding: 7px;
+}
+
+.guide-question-button {
+  width: 5%;
+}
+
 .guide-tab {
   display: inline-block;
   padding: 7px;
-
+  height: 40px;
   border: 1px solid #999999;
-  border-left: none;
 }
 
 .guide-tab > .guide-link {
   color: #000000;
   text-decoration: none;
+  display: flex;
+  height: inherit;
 }
 
 .guide-tabs {
   display: grid;
-  height: 20px;
-  max-width: 450px;
-  grid-template-columns: auto auto auto 1fr;
+  max-width: 745px;
+  grid-template-columns: repeat(auto-fill, 149px);
 }
 
 
@@ -274,6 +291,13 @@ body {
 
 .hint_overlay span.cursor:hover {
   text-decoration: underline;
+}
+
+.incorrect-answer-guide {
+  border-color: #fc3605 !important;
+  border: 1px solid;
+  padding: 7px;
+  margin-top: 10px;
 }
 
 #info-image {
@@ -527,6 +551,13 @@ body {
   align-items: center;
 }
 
+.sample-passage {
+  background: #f4f4f4;
+  border-radius: 2px;
+  padding: 7px;
+  margin: 10px;
+}
+
 .selected-guide-tab {
   color: #ffffff;
   background-color: #0054a6;
@@ -675,6 +706,12 @@ body {
 
     opacity: 1;
     transition: opacity 0.25s, height 0.4s;
+  }
+
+  .guide-tabs {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 134px);
+    max-width: none;
   }
 
   #header {

--- a/web/src/Help/Activities.elm
+++ b/web/src/Help/Activities.elm
@@ -1,0 +1,38 @@
+module Help.Activities exposing (..)
+
+import Dict exposing (Dict)
+
+
+type alias Answer =
+    { answer : String
+    , correct : Bool
+    , selected : Bool
+    }
+
+
+type Activity
+    = Activity (Dict String Question)
+
+
+type Question
+    = Question (Dict String Answer) { showButton : Bool, showSolution : Bool }
+
+
+questions : Activity -> Dict String Question
+questions (Activity qs) =
+    qs
+
+
+answers : Question -> Dict String Answer
+answers (Question ans _) =
+    ans
+
+
+showButton : Question -> Bool
+showButton (Question _ visibilityRecord) =
+    visibilityRecord.showButton
+
+
+showSolution : Question -> Bool
+showSolution (Question _ visibilityRecord) =
+    visibilityRecord.showSolution

--- a/web/src/Pages/Guide/Comprehension.elm
+++ b/web/src/Pages/Guide/Comprehension.elm
@@ -1,0 +1,842 @@
+module Pages.Guide.Comprehension exposing (..)
+
+import Dict exposing (Dict)
+import Help.Activities exposing (..)
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
+import Markdown
+import Shared
+import Spa.Document exposing (Document)
+import Spa.Generated.Route as Route
+import Spa.Page as Page exposing (Page)
+import Spa.Url as Url exposing (Url)
+
+
+page : Page Params Model Msg
+page =
+    Page.application
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        , save = save
+        , load = load
+        }
+
+
+type alias Model =
+    { activities : Dict String Activity }
+
+
+
+-- INIT
+
+
+init : Shared.Model -> Url Params -> ( Model, Cmd Msg )
+init shared { params } =
+    ( { activities = initActivitiesHelper }
+    , Cmd.none
+    )
+
+
+initActivitiesHelper : Dict String Activity
+initActivitiesHelper =
+    Dict.fromList
+        [ ( "Activity1"
+          , Activity
+                (Dict.fromList
+                    [ ( "Question1"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "1" False False )
+                                , ( "Answer2", Answer "2" True False )
+                                , ( "Answer3", Answer "3" False False )
+                                , ( "Answer4", Answer "Can't tell." False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question2"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "Yes" False False )
+                                , ( "Answer2", Answer "No" True False )
+                                , ( "Answer3", Answer "Can't tell." False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question3"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "Small" True False )
+                                , ( "Answer2", Answer "Large" False False )
+                                , ( "Answer3", Answer "Plain" True False )
+                                , ( "Answer4", Answer "Well-equipped" False False )
+                                , ( "Answer5", Answer "Comfortable" False False )
+                                , ( "Answer6", Answer "has sails" False False )
+                                , ( "Answer7", Answer "has oars" True False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question4"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "They're taking a pleasure trip." False False )
+                                , ( "Answer2", Answer "They are fishing." False False )
+                                , ( "Answer3", Answer "They are hauling things across the river." False False )
+                                , ( "Answer4", Answer "They are trying to rescue someone who's drowning." False False )
+                                , ( "Answer5", Answer "Can't tell." True False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question5"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "Cheerful" False False )
+                                , ( "Answer2", Answer "Anxious" True False )
+                                , ( "Answer3", Answer "Bored" False False )
+                                , ( "Answer4", Answer "Can't tell." True False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    ]
+                )
+          )
+        ]
+
+
+
+-- UPDATE
+
+
+type Msg
+    = UpdateAnswer String String String
+    | RevealSolution String String
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        UpdateAnswer activity question answer ->
+            let
+                updatedActivities =
+                    accessActivity model activity
+                        |> accessQuestion question
+                        |> accessAnswer answer
+                        |> updateAnswer
+                        |> updateQuestionShowsButton model activity question answer
+                        |> updateActivity model activity question
+                        |> updateActivities model activity
+            in
+            ( { model | activities = updatedActivities }
+            , Cmd.none
+            )
+
+        RevealSolution activity question ->
+            let
+                updatedActivities =
+                    accessActivity model activity
+                        |> accessQuestion question
+                        |> updateQuestionShowsSolution
+                        |> updateActivity model activity question
+                        |> updateActivities model activity
+            in
+            ( { model | activities = updatedActivities }, Cmd.none )
+
+
+
+-- UPDATE UTILITY
+
+
+accessActivity : Model -> String -> Maybe Activity
+accessActivity model activity =
+    Dict.get activity model.activities
+
+
+accessQuestion : String -> Maybe Activity -> Maybe Question
+accessQuestion questionKey maybeActivity =
+    case maybeActivity of
+        Just ac ->
+            Dict.get questionKey (questions ac)
+
+        Nothing ->
+            Maybe.map identity Nothing
+
+
+accessAnswer : String -> Maybe Question -> Maybe Answer
+accessAnswer answer maybeQuestion =
+    case maybeQuestion of
+        Just q ->
+            Dict.get answer (answers q)
+
+        Nothing ->
+            Just (Answer "" False False)
+
+
+clearQuestion : Maybe Question -> Question
+clearQuestion maybeQuestion =
+    case maybeQuestion of
+        Just q ->
+            Question (Dict.map (\_ an -> { an | selected = False }) (answers q)) { showButton = True, showSolution = False }
+
+        Nothing ->
+            Question (Dict.fromList []) { showButton = False, showSolution = False }
+
+
+updateAnswer : Maybe Answer -> Maybe Answer
+updateAnswer maybeAnswer =
+    case maybeAnswer of
+        Just an ->
+            Just (Answer an.answer an.correct (not an.selected))
+
+        Nothing ->
+            Just (Answer "" False False)
+
+
+updateQuestionShowsButton : Model -> String -> String -> String -> Maybe Answer -> Question
+updateQuestionShowsButton model activityKey questionKey answerKey updatedAnswer =
+    let
+        clearedQuestion =
+            accessActivity model activityKey
+                |> accessQuestion questionKey
+                |> clearQuestion
+    in
+    Question (Dict.update answerKey (\_ -> updatedAnswer) (answers clearedQuestion)) { showButton = True, showSolution = False }
+
+
+updateQuestionShowsSolution : Maybe Question -> Question
+updateQuestionShowsSolution maybeQuestion =
+    case maybeQuestion of
+        Just q ->
+            Question (answers q) { showButton = True, showSolution = True }
+
+        Nothing ->
+            Question (Dict.fromList []) { showButton = False, showSolution = False }
+
+
+updateActivity : Model -> String -> String -> Question -> Activity
+updateActivity model activityKey questionKey updatedQuestion =
+    let
+        maybeActivity =
+            accessActivity model activityKey
+    in
+    case maybeActivity of
+        Just ac ->
+            Activity (Dict.update questionKey (Maybe.map (\_ -> updatedQuestion)) (questions ac))
+
+        Nothing ->
+            Activity (Dict.fromList [])
+
+
+updateActivities : Model -> String -> Activity -> Dict String Activity
+updateActivities model activityKey updatedActivity =
+    Dict.update activityKey (Maybe.map (\_ -> updatedActivity)) model.activities
+
+
+
+-- VIEW
+
+
+type alias Params =
+    ()
+
+
+view : Model -> Document Msg
+view model =
+    { title = "Guide | Comprehension"
+    , body =
+        [ div [ id "body" ]
+            [ div [ id "about" ]
+                [ div [ id "about-box" ]
+                    [ div [ id "title" ] [ text "Comprehension" ]
+                    , viewTabs
+                    , viewFirstSection
+                    , viewSecondSection
+                    , viewThirdSection
+                    , viewFirstQuestion model
+                    , viewSecondQuestion model
+                    , viewThirdQuestion model
+                    , viewFourthQuestion model
+                    , viewFifthQuestion model
+                    ]
+                ]
+            ]
+        ]
+    }
+
+
+viewTabs : Html Msg
+viewTabs =
+    div [ class "guide-tabs" ]
+        [ div
+            [ class "guide-tab"
+            , class "leftmost-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__GettingStarted)
+                , class "guide-link"
+                ]
+                [ text "Getting Started" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__ReadingTexts)
+                , class "guide-link"
+                ]
+                [ text "Reading Texts" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Settings)
+                , class "guide-link"
+                ]
+                [ text "Settings" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Progress)
+                , class "guide-link"
+                ]
+                [ text "Progress" ]
+            ]
+        , div
+            [ class "guide-tab"
+            , class "selected-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Strategies)
+                , class "guide-link"
+                ]
+                [ text "Strategies" ]
+            ]
+        , div
+            [ class "guide-tab"
+            , class "selected-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Comprehension)
+                , class "guide-link"
+                ]
+                [ text "Comprehension" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Context)
+                , class "guide-link"
+                ]
+                [ text "Context" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Priority)
+                , class "guide-link"
+                ]
+                [ text "Priority" ]
+            ]
+        ]
+
+
+viewFirstSection : Html Msg
+viewFirstSection =
+    Markdown.toHtml [ attribute "class" "markdown-link" ] """
+### Focus on Comprehension: Reading through unknown words
+
+Even in your first language there will be texts that you can read and comprehend where you do not know every word in the text. Sometimes, 
+you can figure out the meaning of the unfamiliar word from context; other times, you can look up the unfamiliar word if it seems important; 
+most times, the unfamiliar word may not keep you from understanding the basic meaning of the passage.
+
+Try these reading strategies for yourself on the text below where 30% of the words have been replaced with non-sense words.
+
+#### Pre-reading Work:
+The paragraph below starts a chapter of an English novel published in the 1860s. The title of the chapter is: A Boat on the River 
+
+**Activity 1**. Before reading, stop and brainstorming about what might be in such a chapter. Make hypotheses. Try to visualize the possible 
+scene. What does a 19th century boat on a river look like? How might people be dressed? What might be visible on the banks of the river?
+
+**Activity 2**. After you've completed your brainstorming, go on to read the text below. You won’t know every word, but keep on reading to 
+the end, and make as much sense out of the passage as you can.
+"""
+
+
+viewSecondSection : Html Msg
+viewSecondSection =
+    div [ class "sample-passage" ]
+        [ Html.em [] [ Html.text "A Boat on the River" ]
+        , Html.br [] []
+        , Html.br [] []
+        , Html.text """
+        The gapels in this boat were those of a foslaint man with nabelked amboned hair and a trathmollated face, and a finlact girl of nineteen or twenty, 
+        nabbastly like him to be sorbicable as his fornoy. The girl zarred, pulling a pair of sculls very easily; the man, with the rudder-lines slack in 
+        his dispers, and his dispers loose in his waistband, kept an eager look out. He had no net, galeaft, or line, and he could not be a paplil; his boat 
+        had no exbain for a sitter, no paint, no debilk, no bepult beyond a rusty calben and a lanop of rope, and he could not be a waterman; his boat was too 
+        anem and too divey to take in besder for delivery, and he could not be a river-carrier; there was no paff to what he looked for, sar he looked for 
+        something, with a most nagril and searching profar. The befin, which had turned an hour before, was melucting zopt, and his eyes hasteled every little 
+        furan and gaist in its broad sweep, as the boat made bilp ducasp against it, or drove stern foremost before it, according as he calbained his fornoy by 
+        a calput of his head. She hasteled his face as parnly as he hasteled the river. But, in the astortant of her look there was a touch of bazad or fisd.
+        """
+        ]
+
+
+viewThirdSection : Html Msg
+viewThirdSection =
+    Markdown.toHtml [] """
+### Learning to read through unfamiliar words
+
+How many of the comprehension questions *who? what? when? where? why?* were you able to answer correctly? Did the presence of so many unfamiliar words keep you from forming a general impression of what is going on in this passage? 
+
+Which ones of your hypotheses about the text were accurate? Which ones did you need to abandon? Did trying to visualize what the scene might look like help you in reading the text?
+
+How can you apply this strategy when you are reading a text in Russian?
+
+In the next section of this strategy instruction, you will work on using context to guess the meaning of unfamiliar words.
+
+
+## Comprehension Questions
+
+After reading the passage above, complete these comprehension questions. After making your choice, click the “check answer” tab to see the correct answer and the reasoning behind it.
+"""
+
+
+viewFirstQuestion : Model -> Html Msg
+viewFirstQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity1" "Question1"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity1" "Question1"
+
+        solutionVisible =
+            checkButtonClicked model "Activity1" "Question1"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "How many people are there in the boat?" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity1_question1", id "a1q1first", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer1") ] []
+            , label [ for "a1q1first" ] [ getAnswerText model "Activity1" "Question1" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question1", id "a1q1second", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer2") ] []
+            , label [ for "a1q1second" ] [ getAnswerText model "Activity1" "Question1" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question1", id "a1q1third", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer3") ] []
+            , label [ for "a1q1third" ] [ getAnswerText model "Activity1" "Question1" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question1", id "a1q1fourth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer4") ] []
+            , label [ for "a1q1fourth" ] [ getAnswerText model "Activity1" "Question1" "Answer4" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity1" "Question1") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text "The correct answer is: 2"
+                                , Html.br [] []
+                                , Html.text """There are two people in the boat, a man and a girl. They are mentioned in the first sentence, and then they are referred to only as "he" and "she." """
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewSecondQuestion : Model -> Html Msg
+viewSecondQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity1" "Question2"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity1" "Question2"
+
+        solutionVisible =
+            checkButtonClicked model "Activity1" "Question2"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "Are the people in the boat strangers to each other?" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity1_question2", id "a1q2first", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question2" "Answer1") ] []
+            , label [ for "a1q2first" ] [ getAnswerText model "Activity1" "Question2" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question2", id "a1q2second", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question2" "Answer2") ] []
+            , label [ for "a1q2second" ] [ getAnswerText model "Activity1" "Question2" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question2", id "a1q2third", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question2" "Answer3") ] []
+            , label [ for "a1q2third" ] [ getAnswerText model "Activity1" "Question2" "Answer3" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity1" "Question2") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text "The most likely answer is: No"
+                                , Html.br [] []
+                                , Html.text """Although it's not directly stated that they know each other, we can infer that since the man is able to communicate to the girl 
+                                using his head ("according as he calbained his fornoy by a calput of his head"), and the phrase ("nabbastly like him to be sorbicable as his fornoy") 
+                                probably explains the relationship between them. """
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewThirdQuestion : Model -> Html Msg
+viewThirdQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity1" "Question3"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity1" "Question3"
+
+        solutionVisible =
+            checkButtonClicked model "Activity1" "Question3"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "What kind of boat is it?" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity1_question3", id "a1q3first", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer1") ] []
+            , label [ for "a1q3first" ] [ getAnswerText model "Activity1" "Question3" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question3", id "a1q3second", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer2") ] []
+            , label [ for "a1q3second" ] [ getAnswerText model "Activity1" "Question3" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question3", id "a1q3third", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer3") ] []
+            , label [ for "a1q3third" ] [ getAnswerText model "Activity1" "Question3" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question3", id "a1q3fourth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer4") ] []
+            , label [ for "a1q3fourth" ] [ getAnswerText model "Activity1" "Question3" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question3", id "a1q3fifth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer5") ] []
+            , label [ for "a1q3fifth" ] [ getAnswerText model "Activity1" "Question3" "Answer5" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question3", id "a1q3sixth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer6") ] []
+            , label [ for "a1q3sixth" ] [ getAnswerText model "Activity1" "Question3" "Answer6" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question3", id "a1q3seventh", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer7") ] []
+            , label [ for "a1q3seventh" ] [ getAnswerText model "Activity1" "Question3" "Answer7" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity1" "Question3") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The most likely answers are: "Small", "Plain", and "has oars". """
+                                , Html.br [] []
+                                , Html.text """
+We know that the boat is unfit for commercial purposes "he could not be a waterman...and he could not be a river-carrier" 
+suggests its small size; the list of things that it is missing ("no exbain for a sitter, no paint, no debilk, no bepult 
+beyond a rusty calben and a lanop of rope") suggests that the boat is poorly equipped and plain; and that it's a row boat is suggested in the phrase 
+("The girl zarred, pulling a pair of sculls very easily"). """
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewFourthQuestion : Model -> Html Msg
+viewFourthQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity1" "Question4"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity1" "Question4"
+
+        solutionVisible =
+            checkButtonClicked model "Activity1" "Question4"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "Why are the people out on the river?" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity1_question4", id "a1q4first", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question4" "Answer1") ] []
+            , label [ for "a1q4first" ] [ getAnswerText model "Activity1" "Question4" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question4", id "a1q4second", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question4" "Answer2") ] []
+            , label [ for "a1q4second" ] [ getAnswerText model "Activity1" "Question4" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question4", id "a1q4third", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question4" "Answer3") ] []
+            , label [ for "a1q4third" ] [ getAnswerText model "Activity1" "Question4" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question4", id "a1q4fourth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question4" "Answer4") ] []
+            , label [ for "a1q4fourth" ] [ getAnswerText model "Activity1" "Question4" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question4", id "a1q4fifth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question4" "Answer5") ] []
+            , label [ for "a1q4fifth" ] [ getAnswerText model "Activity1" "Question4" "Answer5" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity1" "Question4") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The best answer here is: Can't tell. """
+                                , Html.br [] []
+                                , Html.text """We can rule out the choices involving fishing or hauling items since the text tells us that the man doesn't have a net or a line that he'd need for fishing, and 
+                                the boat is unfit for the commercial purposes of river transport. A pleasure trip seems unlikely since the boat isn't particularly comfortable or well-appointed. 
+                                A rescue mission also is unlikely since there's no reference to urgency or someone in the water. """
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewFifthQuestion : Model -> Html Msg
+viewFifthQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity1" "Question5"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity1" "Question5"
+
+        solutionVisible =
+            checkButtonClicked model "Activity1" "Question5"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "What is the mood of the people in the boat?" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity1_question5", id "a1q5first", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question5" "Answer1") ] []
+            , label [ for "a1q5first" ] [ getAnswerText model "Activity1" "Question5" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question5", id "a1q5second", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question5" "Answer2") ] []
+            , label [ for "a1q5second" ] [ getAnswerText model "Activity1" "Question5" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question5", id "a1q5third", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question5" "Answer3") ] []
+            , label [ for "a1q5third" ] [ getAnswerText model "Activity1" "Question5" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question5", id "a1q5fourth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question5" "Answer4") ] []
+            , label [ for "a1q5fourth" ] [ getAnswerText model "Activity1" "Question5" "Answer4" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity1" "Question5") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The best answers here are: Anxious or Can't tell. """
+                                , Html.br [] []
+                                , Html.text """
+Since the text mentions the plainness of the boat and the absence of so many features, it seems unlikely that the people in the boat are there for pleasure. For this reason, 
+"Cheerful" seems unlikely way to describe their mood. "Bored" also seems unlikely since the man is described as looking for something ("eager look out" and "what he looked for" 
+and "searching."). The man's mood doesn't seem to be shared by the girl, and so that suggests some conflict between the two, and so the mood might be tense or anxious. """
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+
+-- VIEW UTILITY
+
+
+getAnswerText : Model -> String -> String -> String -> Html Msg
+getAnswerText model activityKey questionKey answerKey =
+    let
+        maybeQuestion =
+            case Dict.get activityKey model.activities of
+                Just qs ->
+                    Dict.get questionKey (questions qs)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        maybeAnswer =
+            case maybeQuestion of
+                Just q ->
+                    Dict.get answerKey (answers q)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        answerText =
+            case maybeAnswer of
+                Just a ->
+                    a.answer
+
+                Nothing ->
+                    ""
+    in
+    Html.text answerText
+
+
+checkAnswerCorrect : Model -> String -> String -> Bool
+checkAnswerCorrect model activityLabel questionLabel =
+    let
+        maybeActivity =
+            Dict.get activityLabel model.activities
+
+        maybeQuestion =
+            case maybeActivity of
+                Just ac ->
+                    Dict.get questionLabel (questions ac)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        answerList =
+            case maybeQuestion of
+                Just q ->
+                    List.map Tuple.second (Dict.toList (answers q))
+
+                Nothing ->
+                    []
+
+        answeredCorrectly =
+            List.any (\v -> v == True) (List.map (\a -> (a.correct == True) && a.selected) answerList)
+    in
+    answeredCorrectly
+
+
+checkAnswerSelected : Model -> String -> String -> Bool
+checkAnswerSelected model activityLabel questionLabel =
+    let
+        maybeActivity =
+            Dict.get activityLabel model.activities
+
+        maybeQuestion =
+            case maybeActivity of
+                Just ac ->
+                    Dict.get questionLabel (questions ac)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        answerList =
+            case maybeQuestion of
+                Just q ->
+                    List.map Tuple.second (Dict.toList (answers q))
+
+                Nothing ->
+                    []
+
+        answerSelected =
+            List.any (\a -> a.selected == True) answerList
+    in
+    answerSelected
+
+
+checkButtonClicked : Model -> String -> String -> Bool
+checkButtonClicked model activityLabel questionLabel =
+    let
+        maybeActivities =
+            Dict.get activityLabel model.activities
+
+        maybeQuestion =
+            case maybeActivities of
+                Just activities ->
+                    Dict.get questionLabel (questions activities)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+    in
+    case maybeQuestion of
+        Just question ->
+            showSolution question
+
+        Nothing ->
+            False
+
+
+
+-- SHARED
+
+
+save : Model -> Shared.Model -> Shared.Model
+save model shared =
+    shared
+
+
+load : Shared.Model -> Model -> ( Model, Cmd Msg )
+load shared model =
+    ( model, Cmd.none )
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none

--- a/web/src/Pages/Guide/Context.elm
+++ b/web/src/Pages/Guide/Context.elm
@@ -1,0 +1,1071 @@
+module Pages.Guide.Context exposing (..)
+
+import Dict exposing (Dict)
+import Help.Activities exposing (..)
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
+import Markdown
+import Shared
+import Spa.Document exposing (Document)
+import Spa.Generated.Route as Route
+import Spa.Page as Page exposing (Page)
+import Spa.Url as Url exposing (Url)
+
+
+page : Page Params Model Msg
+page =
+    Page.application
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        , save = save
+        , load = load
+        }
+
+
+type alias Model =
+    { activities : Dict String Activity }
+
+
+
+-- INIT
+
+
+init : Shared.Model -> Url Params -> ( Model, Cmd Msg )
+init shared { params } =
+    ( { activities = initActivitiesHelper }
+    , Cmd.none
+    )
+
+
+initActivitiesHelper : Dict String Activity
+initActivitiesHelper =
+    Dict.fromList
+        [ ( "Activity1"
+          , Activity
+                (Dict.fromList
+                    [ ( "Question1"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "boxes" False False )
+                                , ( "Answer2", Answer "animals" False False )
+                                , ( "Answer3", Answer "figures" True False )
+                                , ( "Answer4", Answer "fish" False False )
+                                , ( "Answer5", Answer "uniforms" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question2"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "loops" False False )
+                                , ( "Answer2", Answer "hands" True False )
+                                , ( "Answer3", Answer "belts" False False )
+                                , ( "Answer4", Answer "sleeves" False False )
+                                , ( "Answer5", Answer "knees" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question3"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "large" False False )
+                                , ( "Answer2", Answer "grand" False False )
+                                , ( "Answer3", Answer "new" False False )
+                                , ( "Answer4", Answer "small" True False )
+                                , ( "Answer5", Answer "ancient" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question4"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "interest" False False )
+                                , ( "Answer2", Answer "gaze" True False )
+                                , ( "Answer3", Answer "thirst" False False )
+                                , ( "Answer4", Answer "need" False False )
+                                , ( "Answer5", Answer "binoculars" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question5"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "hated" False False )
+                                , ( "Answer2", Answer "loved" False False )
+                                , ( "Answer3", Answer "watched" True False )
+                                , ( "Answer4", Answer "avoided" False False )
+                                , ( "Answer5", Answer "stunned" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    ]
+                )
+          )
+        , ( "Activity2"
+          , Activity
+                (Dict.fromList
+                    [ ( "Question1"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "galeaft" False False )
+                                , ( "Answer2", Answer "exbain" False False )
+                                , ( "Answer3", Answer "debilk" False False )
+                                , ( "Answer4", Answer "bepult" False False )
+                                , ( "Answer5", Answer "paplil" True False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question2"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "zopt" False False )
+                                , ( "Answer2", Answer "befin" True False )
+                                , ( "Answer3", Answer "furan" False False )
+                                , ( "Answer4", Answer "ducasp" False False )
+                                , ( "Answer5", Answer "paff" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    ]
+                )
+          )
+        ]
+
+
+
+-- UPDATE
+
+
+type Msg
+    = UpdateAnswer String String String
+    | RevealSolution String String
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        UpdateAnswer activity question answer ->
+            let
+                updatedActivities =
+                    accessActivity model activity
+                        |> accessQuestion question
+                        |> accessAnswer answer
+                        |> updateAnswer
+                        |> updateQuestionShowsButton model activity question answer
+                        |> updateActivity model activity question
+                        |> updateActivities model activity
+            in
+            ( { model | activities = updatedActivities }
+            , Cmd.none
+            )
+
+        RevealSolution activity question ->
+            let
+                updatedActivities =
+                    accessActivity model activity
+                        |> accessQuestion question
+                        |> updateQuestionShowsSolution
+                        |> updateActivity model activity question
+                        |> updateActivities model activity
+            in
+            ( { model | activities = updatedActivities }, Cmd.none )
+
+
+
+-- UPDATE UTILITY
+
+
+accessActivity : Model -> String -> Maybe Activity
+accessActivity model activity =
+    Dict.get activity model.activities
+
+
+accessQuestion : String -> Maybe Activity -> Maybe Question
+accessQuestion questionKey maybeActivity =
+    case maybeActivity of
+        Just ac ->
+            Dict.get questionKey (questions ac)
+
+        Nothing ->
+            Maybe.map identity Nothing
+
+
+accessAnswer : String -> Maybe Question -> Maybe Answer
+accessAnswer answer maybeQuestion =
+    case maybeQuestion of
+        Just q ->
+            Dict.get answer (answers q)
+
+        Nothing ->
+            Just (Answer "" False False)
+
+
+clearQuestion : Maybe Question -> Question
+clearQuestion maybeQuestion =
+    case maybeQuestion of
+        Just q ->
+            Question (Dict.map (\_ an -> { an | selected = False }) (answers q)) { showButton = True, showSolution = False }
+
+        Nothing ->
+            Question (Dict.fromList []) { showButton = False, showSolution = False }
+
+
+updateAnswer : Maybe Answer -> Maybe Answer
+updateAnswer maybeAnswer =
+    case maybeAnswer of
+        Just an ->
+            Just (Answer an.answer an.correct (not an.selected))
+
+        Nothing ->
+            Just (Answer "" False False)
+
+
+updateQuestionShowsButton : Model -> String -> String -> String -> Maybe Answer -> Question
+updateQuestionShowsButton model activityKey questionKey answerKey updatedAnswer =
+    let
+        clearedQuestion =
+            accessActivity model activityKey
+                |> accessQuestion questionKey
+                |> clearQuestion
+    in
+    Question (Dict.update answerKey (\_ -> updatedAnswer) (answers clearedQuestion)) { showButton = True, showSolution = False }
+
+
+updateQuestionShowsSolution : Maybe Question -> Question
+updateQuestionShowsSolution maybeQuestion =
+    case maybeQuestion of
+        Just q ->
+            Question (answers q) { showButton = True, showSolution = True }
+
+        Nothing ->
+            Question (Dict.fromList []) { showButton = False, showSolution = False }
+
+
+updateActivity : Model -> String -> String -> Question -> Activity
+updateActivity model activityKey questionKey updatedQuestion =
+    let
+        maybeActivity =
+            accessActivity model activityKey
+    in
+    case maybeActivity of
+        Just ac ->
+            Activity (Dict.update questionKey (Maybe.map (\_ -> updatedQuestion)) (questions ac))
+
+        Nothing ->
+            Activity (Dict.fromList [])
+
+
+updateActivities : Model -> String -> Activity -> Dict String Activity
+updateActivities model activityKey updatedActivity =
+    Dict.update activityKey (Maybe.map (\_ -> updatedActivity)) model.activities
+
+
+
+-- VIEW
+
+
+type alias Params =
+    ()
+
+
+view : Model -> Document Msg
+view model =
+    { title = "Guide | Context"
+    , body =
+        [ div [ id "body" ]
+            [ div [ id "about" ]
+                [ div [ id "about-box" ]
+                    [ div [ id "title" ] [ text "Context" ]
+                    , viewTabs
+                    , viewFirstSection
+                    , viewSecondSection
+                    , viewInstructionsFirstActivity
+                    , viewFirstQuestion model
+                    , viewSecondQuestion model
+                    , viewThirdQuestion model
+                    , viewFourthQuestion model
+                    , viewFifthQuestion model
+                    , viewThirdSection
+                    , viewFourthSection
+                    , viewInstructionsSecondActivity
+                    , viewSixthQuestion model
+                    , viewSeventhQuestion model
+                    , viewFifthSection
+                    ]
+                ]
+            ]
+        ]
+    }
+
+
+viewTabs : Html Msg
+viewTabs =
+    div [ class "guide-tabs" ]
+        [ div
+            [ class "guide-tab"
+            , class "leftmost-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__GettingStarted)
+                , class "guide-link"
+                ]
+                [ text "Getting Started" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__ReadingTexts)
+                , class "guide-link"
+                ]
+                [ text "Reading Texts" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Settings)
+                , class "guide-link"
+                ]
+                [ text "Settings" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Progress)
+                , class "guide-link"
+                ]
+                [ text "Progress" ]
+            ]
+        , div
+            [ class "guide-tab"
+            , class "selected-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Strategies)
+                , class "guide-link"
+                ]
+                [ text "Strategies" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Comprehension)
+                , class "guide-link"
+                ]
+                [ text "Comprehension" ]
+            ]
+        , div
+            [ class "guide-tab"
+            , class "selected-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Context)
+                , class "guide-link"
+                ]
+                [ text "Context" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Priority)
+                , class "guide-link"
+                ]
+                [ text "Priority" ]
+            ]
+        ]
+
+
+viewFirstSection : Html Msg
+viewFirstSection =
+    Markdown.toHtml [ attribute "class" "markdown-link" ] """
+### Using context to guess unknown words
+
+While you may not be able to guess the meaning of every unfamiliar word from context, you should be able to narrow the possible range of meanings of specific words.  
+Use context and these questions to help you narrow down the possible meaning of key words. 
+1. If the unknown word seems to be a noun, does it refer to a person? To a place? To a thing? To a concept? Does it seem to be a synonym for something already mentioned in the text?
+2. If it’s an adjective, what word does it modify? Does it seem to suggest a positive or a negative quality? Does it refer to time? Or place? 
+3. If it’s a verb, who seems to be the doer of the action? Is there a direct object of the action? Does it suggest motion (into/to/towards) a person or place? Does it suggest 
+communication (to someone or with someone)? Is it present/future tense? Or past?
+"""
+
+
+viewSecondSection : Html Msg
+viewSecondSection =
+    div [ class "sample-passage" ]
+        [ Html.em [] [ Html.text "A Boat on the River" ]
+        , Html.br [] []
+        , Html.br [] []
+        , Html.text "The "
+        , Html.strong [] [ Html.text "gapels" ]
+        , Html.text """ in this boat were those of a foslaint man with nabelked amboned hair and a trathmollated face, and a finlact girl of nineteen or twenty, 
+        nabbastly like him to be sorbicable as his fornoy. The girl zarred, pulling a pair of sculls very easily; the man, with the rudder-lines slack in 
+        his """
+        , Html.strong [] [ Html.text "dispers" ]
+        , Html.text " and his "
+        , Html.strong [] [ Html.text "dispers" ]
+        , Html.text """ loose in his waistband, kept an eager look out. He had no net, galeaft, or line, and he could not be a paplil; his boat 
+        had no exbain for a sitter, no paint, no debilk, no bepult beyond a rusty calben and a lanop of rope, and he could not be a waterman; his boat was too """
+        , Html.strong [] [ Html.text "anem" ]
+        , Html.text " and too "
+        , Html.strong [] [ Html.text "divey" ]
+        , Html.text """ to take in besder for delivery, and he could not be a river-carrier; there was no paff to what he looked for, sar he looked for 
+        something, with a most nagril and searching """
+        , Html.strong [] [ Html.text "profar" ]
+        , Html.text ". The befin, which had turned an hour before, was melucting zopt, and his eyes "
+        , Html.strong [] [ Html.text "hasteled" ]
+        , Html.text """ every little furan and gaist in its broad sweep, as the boat made bilp ducasp against it, or drove stern foremost before it, according as he calbained his fornoy by 
+        a calput of his head. She """
+        , Html.strong [] [ Html.text "hasteled" ]
+        , Html.text " his face as parnly as he "
+        , Html.strong [] [ Html.text "hasteled" ]
+        , Html.text " the river. But, in the astortant of her look there was a touch of bazad or fisd."
+        ]
+
+
+viewInstructionsFirstActivity : Html Msg
+viewInstructionsFirstActivity =
+    div []
+        [ Html.br [] []
+        , Html.strong [] [ Html.text "Instructions" ]
+        , Html.br [] []
+        , Html.br [] []
+        , Html.text """Using context clues from the text above, try to guess the meaning of these nonsense words from the set of words provided. 
+                                To help you find the words in the text, they have been put in bold-face. Be sure to re-read the sentence or section of the text before making your guess."""
+        ]
+
+
+viewFirstQuestion : Model -> Html Msg
+viewFirstQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity1" "Question1"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity1" "Question1"
+
+        solutionVisible =
+            checkButtonClicked model "Activity1" "Question1"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "Gapels" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity1_question1", id "a1q1first", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer1") ] []
+            , label [ for "a1q1first" ] [ getAnswerText model "Activity1" "Question1" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question1", id "a1q1second", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer2") ] []
+            , label [ for "a1q1second" ] [ getAnswerText model "Activity1" "Question1" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question1", id "a1q1third", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer3") ] []
+            , label [ for "a1q1third" ] [ getAnswerText model "Activity1" "Question1" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question1", id "a1q1fourth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer4") ] []
+            , label [ for "a1q1fourth" ] [ getAnswerText model "Activity1" "Question1" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question1", id "a1q1fifth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer5") ] []
+            , label [ for "a1q1fifth" ] [ getAnswerText model "Activity1" "Question1" "Answer5" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity1" "Question1") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The correct answer is "figures" """
+                                , Html.br [] []
+                                , Html.text """Gapels has to be some kind of collective term for the man and the girl in the boat. Now re-read that sentence again and see if 
+                                you can guess any other words that are in the immediate context."""
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewSecondQuestion : Model -> Html Msg
+viewSecondQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity1" "Question2"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity1" "Question2"
+
+        solutionVisible =
+            checkButtonClicked model "Activity1" "Question2"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "Dispers" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity1_question2", id "a1q2first", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question2" "Answer1") ] []
+            , label [ for "a1q2first" ] [ getAnswerText model "Activity1" "Question2" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question2", id "a1q2second", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question2" "Answer2") ] []
+            , label [ for "a1q2second" ] [ getAnswerText model "Activity1" "Question2" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question2", id "a1q2third", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question2" "Answer3") ] []
+            , label [ for "a1q2third" ] [ getAnswerText model "Activity1" "Question2" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question2", id "a1q2fourth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question2" "Answer4") ] []
+            , label [ for "a1q2fourth" ] [ getAnswerText model "Activity1" "Question2" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question2", id "a1q2fifth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question2" "Answer5") ] []
+            , label [ for "a1q2fifth" ] [ getAnswerText model "Activity1" "Question2" "Answer5" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity1" "Question2") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The correct answer is "hands" """
+                                , Html.br [] []
+                                , Html.text """Dispers have to be some part of the man (e.g., hands, fingers, fists) that can both hold a slack line, and also fit in his waistband."""
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewThirdQuestion : Model -> Html Msg
+viewThirdQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity1" "Question3"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity1" "Question3"
+
+        solutionVisible =
+            checkButtonClicked model "Activity1" "Question3"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "Anem/divey" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity1_question3", id "a1q3first", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer1") ] []
+            , label [ for "a1q3first" ] [ getAnswerText model "Activity1" "Question3" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question3", id "a1q3second", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer2") ] []
+            , label [ for "a1q3second" ] [ getAnswerText model "Activity1" "Question3" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question3", id "a1q3third", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer3") ] []
+            , label [ for "a1q3third" ] [ getAnswerText model "Activity1" "Question3" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question3", id "a1q3fourth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer4") ] []
+            , label [ for "a1q3fourth" ] [ getAnswerText model "Activity1" "Question3" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question3", id "a1q3fifth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question3" "Answer5") ] []
+            , label [ for "a1q3fifth" ] [ getAnswerText model "Activity1" "Question3" "Answer5" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity1" "Question3") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The correct answer is: "small" """
+                                , Html.br [] []
+                                , Html.text """The boat here is defined by what it can't do, and so anem/divey must be synonyms for an undesirable characteristic. "Ancient" 
+                                might be possible, although there's nothing that would keep an old boat from being well equipped."""
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewFourthQuestion : Model -> Html Msg
+viewFourthQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity1" "Question4"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity1" "Question4"
+
+        solutionVisible =
+            checkButtonClicked model "Activity1" "Question4"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "profar" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity1_question4", id "a1q4first", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question4" "Answer1") ] []
+            , label [ for "a1q4first" ] [ getAnswerText model "Activity1" "Question4" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question4", id "a1q4second", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question4" "Answer2") ] []
+            , label [ for "a1q4second" ] [ getAnswerText model "Activity1" "Question4" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question4", id "a1q4third", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question4" "Answer3") ] []
+            , label [ for "a1q4third" ] [ getAnswerText model "Activity1" "Question4" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question4", id "a1q4fourth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question4" "Answer4") ] []
+            , label [ for "a1q4fourth" ] [ getAnswerText model "Activity1" "Question4" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question4", id "a1q4fifth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question4" "Answer5") ] []
+            , label [ for "a1q4fifth" ] [ getAnswerText model "Activity1" "Question4" "Answer5" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity1" "Question4") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The best answer here is: "gaze" """
+                                , Html.br [] []
+                                , Html.text """
+""binoculars" can't work because the unknown word is modified by the article "a" ("he looked...with a most... profar") and that rules out the plural binoculars. "Thirst" seems 
+unlikely since it would create a mixed metaphor (one can drink with intense thirst, but looking pairs better with gaze). "Interest", "gaze", and "need" are all possible, but 
+"gaze" fits best with the verb "looked." """
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewFifthQuestion : Model -> Html Msg
+viewFifthQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity1" "Question5"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity1" "Question5"
+
+        solutionVisible =
+            checkButtonClicked model "Activity1" "Question5"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "hasteled" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity1_question5", id "a1q5first", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question5" "Answer1") ] []
+            , label [ for "a1q5first" ] [ getAnswerText model "Activity1" "Question5" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question5", id "a1q5second", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question5" "Answer2") ] []
+            , label [ for "a1q5second" ] [ getAnswerText model "Activity1" "Question5" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question5", id "a1q5third", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question5" "Answer3") ] []
+            , label [ for "a1q5third" ] [ getAnswerText model "Activity1" "Question5" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question5", id "a1q5fourth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question5" "Answer4") ] []
+            , label [ for "a1q5fourth" ] [ getAnswerText model "Activity1" "Question5" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question5", id "a1q5fifth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question5" "Answer5") ] []
+            , label [ for "a1q5fifth" ] [ getAnswerText model "Activity1" "Question5" "Answer5" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity1" "Question5") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The best answer here is: "watched" """
+                                , Html.br [] []
+                                , Html.text """It can't be "hated" or "avoided" since the man is so eager to look at the river. It could possibly be "loved", but "watched" would fit better with the subject "his eyes." """
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewThirdSection : Html Msg
+viewThirdSection =
+    Markdown.toHtml [] """
+#### Learning to read through unfamiliar words
+
+How many of the non-sense words were you able to guess correctly? What contextual clues helped you the most?  How might you apply some of those same contextual clues when you try to read in Russian?
+
+
+### Other Guessing Strategies
+Another way to approach guessing the meaning of unfamiliar words in a text is to think about what words are likely to appear in the text. Knowing the title "A boat on the river" of this text, 
+you could imagine that the text might contain the words "fisherman" and "tide," and indeed those words are in the original text.  Can you figure out which non-sense words are standing in for them? 
+"""
+
+
+viewFourthSection : Html Msg
+viewFourthSection =
+    div [ class "sample-passage" ]
+        [ Html.em [] [ Html.text "A Boat on the River" ]
+        , Html.br [] []
+        , Html.br [] []
+        , Html.text """
+        The gapels in this boat were those of a foslaint man with nabelked amboned hair and a trathmollated face, and a finlact girl of nineteen or twenty, 
+        nabbastly like him to be sorbicable as his fornoy. The girl zarred, pulling a pair of sculls very easily; the man, with the rudder-lines slack in 
+        his dispers, and his dispers loose in his waistband, kept an eager look out. He had no net, """
+        , Html.strong [] [ Html.text "galeaft" ]
+        , Html.text ", or line, and he could not be a "
+        , Html.strong [] [ Html.text "paplil" ]
+        , Html.text "; his boat had no "
+        , Html.strong [] [ Html.text "exbain" ]
+        , Html.text " for a sitter, no paint, no "
+        , Html.strong [] [ Html.text "debilk" ]
+        , Html.text ", no "
+        , Html.strong [] [ Html.text "bepult" ]
+        , Html.text """ beyond a rusty calben and a lanop of rope, and he could not be a waterman; his boat was too 
+        anem and too divey to take in besder for delivery, and he could not be a river-carrier; there was no """
+        , Html.strong [] [ Html.text "paff" ]
+        , Html.text " to what he looked for, sar he looked for something, with a most nagril and searching profar. The "
+        , Html.strong [] [ Html.text "befin" ]
+        , Html.text ", which had turned an hour before, was melucting "
+        , Html.strong [] [ Html.text "zopt" ]
+        , Html.text ", and his eyes hasteled every little "
+        , Html.strong [] [ Html.text "furan" ]
+        , Html.text " and gaist in its broad sweep, as the boat made bilp "
+        , Html.strong [] [ Html.text "ducasp" ]
+        , Html.text """ against it, or drove stern foremost before it, according as he calbained his fornoy by 
+        a calput of his head. She hasteled his face as parnly as he hasteled the river. But, in the astortant of her look there was a touch of bazad or fisd."""
+        ]
+
+
+viewInstructionsSecondActivity : Html Msg
+viewInstructionsSecondActivity =
+    div []
+        [ Html.br [] []
+        , Html.strong [] [ Html.text "Instructions" ]
+        , Html.br [] []
+        , Html.br [] []
+        , Html.text """Since this paragraph deals with a boat on a river, it should be no surprise that it contains the words fisherman and tide. Go back and re-read the text. Which non-sense words are standing in for them?"""
+        ]
+
+
+viewSixthQuestion : Model -> Html Msg
+viewSixthQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity2" "Question1"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity2" "Question1"
+
+        solutionVisible =
+            checkButtonClicked model "Activity2" "Question1"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "fisherman" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity2_question1", id "a2q1first", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question1" "Answer1") ] []
+            , label [ for "a2q1first" ] [ getAnswerText model "Activity2" "Question1" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question1", id "a2q1second", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question1" "Answer2") ] []
+            , label [ for "a2q1second" ] [ getAnswerText model "Activity2" "Question1" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question1", id "a2q1third", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question1" "Answer3") ] []
+            , label [ for "a2q1third" ] [ getAnswerText model "Activity2" "Question1" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question1", id "a2q1fourth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question1" "Answer4") ] []
+            , label [ for "a2q1fourth" ] [ getAnswerText model "Activity2" "Question1" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question1", id "a2q1fifth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question1" "Answer5") ] []
+            , label [ for "a2q1fifth" ] [ getAnswerText model "Activity2" "Question1" "Answer5" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity2" "Question1") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The correct answer is: "paplil" """
+                                , Html.br [] []
+                                , Html.text """Since the man in the boat is lacking the some of the tools ("He had no net, galeaft, or line") for fishing, we can imagine that "he could not be a paplil / fisherman." """
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewSeventhQuestion : Model -> Html Msg
+viewSeventhQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity2" "Question2"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity2" "Question2"
+
+        solutionVisible =
+            checkButtonClicked model "Activity2" "Question2"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "Tide" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity2_question2", id "a2q2first", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question2" "Answer1") ] []
+            , label [ for "a2q2first" ] [ getAnswerText model "Activity2" "Question2" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question2", id "a2q2second", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question2" "Answer2") ] []
+            , label [ for "a2q2second" ] [ getAnswerText model "Activity2" "Question2" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question2", id "a2q2third", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question2" "Answer3") ] []
+            , label [ for "a2q2third" ] [ getAnswerText model "Activity2" "Question2" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question2", id "a2q2fourth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question2" "Answer4") ] []
+            , label [ for "a2q2fourth" ] [ getAnswerText model "Activity2" "Question2" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question2", id "a2q2fifth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question2" "Answer5") ] []
+            , label [ for "a2q2fifth" ] [ getAnswerText model "Activity2" "Question2" "Answer5" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity2" "Question2") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The correct answer is: "befin" """
+                                , Html.br [] []
+                                , Html.text """Befin is standing in for the noun "tide." We can guess this since the relative clause "which had turned an hour before" could well 
+                                describe the tide. "furan" is unlikely since "little" usually doesn't describe tides in English; similarly "ducasp" doesn't fit since a boat can't 
+                                make a tide. Similarly, "paff" seems unlikely, since the construction would suggest a word like "hint," or "reason." """
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewFifthSection : Html Msg
+viewFifthSection =
+    Markdown.toHtml [] """
+### Continuing from a guess
+
+Guessing from background knowledge is a risky strategy, especially if you don't know a large number of words in the text.   Be sure to look up the word after guessing to confirm your hypothesis.
+
+You may be able to enhance your ability to guess from background knowledge if you can combine that strategy with some word recognition strategies. For example, in this text, if you knew that **pap** 
+meant "**fish**," and the suffix **lin** often signified the doer of an action, then you'd have stronger justification to guess that **paplin** means "**fisherman**." Such word formation clues can be powerful 
+tools in guessing the meaning of unknown words.
+
+In the next section of this strategy instruction, you will work on deciding how to prioritize which unfamiliar words you would look up in a dictionary.
+"""
+
+
+
+-- VIEW UTILITY
+
+
+getAnswerText : Model -> String -> String -> String -> Html Msg
+getAnswerText model activityKey questionKey answerKey =
+    let
+        maybeQuestion =
+            case Dict.get activityKey model.activities of
+                Just qs ->
+                    Dict.get questionKey (questions qs)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        maybeAnswer =
+            case maybeQuestion of
+                Just q ->
+                    Dict.get answerKey (answers q)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        answerText =
+            case maybeAnswer of
+                Just a ->
+                    a.answer
+
+                Nothing ->
+                    ""
+    in
+    Html.text answerText
+
+
+checkAnswerCorrect : Model -> String -> String -> Bool
+checkAnswerCorrect model activityLabel questionLabel =
+    let
+        maybeActivity =
+            Dict.get activityLabel model.activities
+
+        maybeQuestion =
+            case maybeActivity of
+                Just ac ->
+                    Dict.get questionLabel (questions ac)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        answerList =
+            case maybeQuestion of
+                Just q ->
+                    List.map Tuple.second (Dict.toList (answers q))
+
+                Nothing ->
+                    []
+
+        answeredCorrectly =
+            List.any (\v -> v == True) (List.map (\a -> (a.correct == True) && a.selected) answerList)
+    in
+    answeredCorrectly
+
+
+checkAnswerSelected : Model -> String -> String -> Bool
+checkAnswerSelected model activityLabel questionLabel =
+    let
+        maybeActivity =
+            Dict.get activityLabel model.activities
+
+        maybeQuestion =
+            case maybeActivity of
+                Just ac ->
+                    Dict.get questionLabel (questions ac)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        answerList =
+            case maybeQuestion of
+                Just q ->
+                    List.map Tuple.second (Dict.toList (answers q))
+
+                Nothing ->
+                    []
+
+        answerSelected =
+            List.any (\a -> a.selected == True) answerList
+    in
+    answerSelected
+
+
+checkButtonClicked : Model -> String -> String -> Bool
+checkButtonClicked model activityLabel questionLabel =
+    let
+        maybeActivities =
+            Dict.get activityLabel model.activities
+
+        maybeQuestion =
+            case maybeActivities of
+                Just activities ->
+                    Dict.get questionLabel (questions activities)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+    in
+    case maybeQuestion of
+        Just question ->
+            showSolution question
+
+        Nothing ->
+            False
+
+
+
+-- SHARED
+
+
+save : Model -> Shared.Model -> Shared.Model
+save model shared =
+    shared
+
+
+load : Shared.Model -> Model -> ( Model, Cmd Msg )
+load shared model =
+    ( model, Cmd.none )
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none

--- a/web/src/Pages/Guide/GettingStarted.elm
+++ b/web/src/Pages/Guide/GettingStarted.elm
@@ -262,6 +262,13 @@ viewTabs =
                 ]
                 [ text "Progress" ]
             ]
+        , div [ class "guide-tab" ]
+            [ a
+                [ href (Route.toString Route.Guide__Strategies)
+                , class "guide-link"
+                ]
+                [ text "Strategies" ]
+            ]
         ]
 
 

--- a/web/src/Pages/Guide/Priority.elm
+++ b/web/src/Pages/Guide/Priority.elm
@@ -1,0 +1,1165 @@
+module Pages.Guide.Priority exposing (..)
+
+import Dict exposing (Dict)
+import Help.Activities exposing (..)
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
+import Markdown
+import Session exposing (Session)
+import Shared
+import Spa.Document exposing (Document)
+import Spa.Generated.Route as Route
+import Spa.Page as Page exposing (Page)
+import Spa.Url as Url exposing (Url)
+
+
+page : Page Params Model Msg
+page =
+    Page.application
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        , save = save
+        , load = load
+        }
+
+
+type alias Model =
+    { activities : Dict String Activity }
+
+
+
+-- INIT
+
+
+init : Shared.Model -> Url Params -> ( Model, Cmd Msg )
+init shared { params } =
+    ( { activities = initActivitiesHelper }
+    , Cmd.none
+    )
+
+
+initActivitiesHelper : Dict String Activity
+initActivitiesHelper =
+    Dict.fromList
+        [ ( "Activity1"
+          , Activity
+                (Dict.fromList
+                    [ ( "Question1"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "exbain" False False )
+                                , ( "Answer2", Answer "hasteled" True False )
+                                , ( "Answer3", Answer "fornoy" True False )
+                                , ( "Answer4", Answer "calput" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    ]
+                )
+          )
+        , ( "Activity2"
+          , Activity
+                (Dict.fromList
+                    [ ( "Question1"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "noun" False False )
+                                , ( "Answer2", Answer "verb" False False )
+                                , ( "Answer3", Answer "adjective" True False )
+                                , ( "Answer4", Answer "adverb" False False )
+                                , ( "Answer5", Answer "conjunction" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question2"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "noun" False False )
+                                , ( "Answer2", Answer "verb" True False )
+                                , ( "Answer3", Answer "adjective" False False )
+                                , ( "Answer4", Answer "adverb" False False )
+                                , ( "Answer5", Answer "conjunction" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question3"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "noun" True False )
+                                , ( "Answer2", Answer "verb" False False )
+                                , ( "Answer3", Answer "adjective" False False )
+                                , ( "Answer4", Answer "adverb" False False )
+                                , ( "Answer5", Answer "conjunction" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question4"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "noun" False False )
+                                , ( "Answer2", Answer "verb" False False )
+                                , ( "Answer3", Answer "adjective" True False )
+                                , ( "Answer4", Answer "adverb" False False )
+                                , ( "Answer5", Answer "conjunction" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question5"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "noun" False False )
+                                , ( "Answer2", Answer "verb" False False )
+                                , ( "Answer3", Answer "adjective" False False )
+                                , ( "Answer4", Answer "adverb" False False )
+                                , ( "Answer5", Answer "conjunction" True False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    , ( "Question6"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "noun" False False )
+                                , ( "Answer2", Answer "verb" False False )
+                                , ( "Answer3", Answer "adjective" False False )
+                                , ( "Answer4", Answer "adverb" True False )
+                                , ( "Answer5", Answer "conjunction" False False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    ]
+                )
+          )
+        , ( "Activity3"
+          , Activity
+                (Dict.fromList
+                    [ ( "Question1"
+                      , Question
+                            (Dict.fromList
+                                [ ( "Answer1", Answer "foslaint" False False )
+                                , ( "Answer2", Answer "fornoy" True False )
+                                , ( "Answer3", Answer "divey" False False )
+                                , ( "Answer4", Answer "calbained" True False )
+                                , ( "Answer5", Answer "bazad" True False )
+                                , ( "Answer6", Answer "fisd" True False )
+                                ]
+                            )
+                            { showButton = False, showSolution = False }
+                      )
+                    ]
+                )
+          )
+        ]
+
+
+
+-- UPDATE
+
+
+type Msg
+    = UpdateAnswer String String String
+    | RevealSolution String String
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        UpdateAnswer activity question answer ->
+            let
+                updatedActivities =
+                    accessActivity model activity
+                        |> accessQuestion question
+                        |> accessAnswer answer
+                        |> updateAnswer
+                        |> updateQuestionShowsButton model activity question answer
+                        |> updateActivity model activity question
+                        |> updateActivities model activity
+            in
+            ( { model | activities = updatedActivities }
+            , Cmd.none
+            )
+
+        RevealSolution activity question ->
+            let
+                updatedActivities =
+                    accessActivity model activity
+                        |> accessQuestion question
+                        |> updateQuestionShowsSolution
+                        |> updateActivity model activity question
+                        |> updateActivities model activity
+            in
+            ( { model | activities = updatedActivities }, Cmd.none )
+
+
+
+-- UPDATE UTILITY
+
+
+accessActivity : Model -> String -> Maybe Activity
+accessActivity model activity =
+    Dict.get activity model.activities
+
+
+accessQuestion : String -> Maybe Activity -> Maybe Question
+accessQuestion questionKey maybeActivity =
+    case maybeActivity of
+        Just ac ->
+            Dict.get questionKey (questions ac)
+
+        Nothing ->
+            Maybe.map identity Nothing
+
+
+accessAnswer : String -> Maybe Question -> Maybe Answer
+accessAnswer answer maybeQuestion =
+    case maybeQuestion of
+        Just q ->
+            Dict.get answer (answers q)
+
+        Nothing ->
+            Just (Answer "" False False)
+
+
+clearQuestion : Maybe Question -> Question
+clearQuestion maybeQuestion =
+    case maybeQuestion of
+        Just q ->
+            Question (Dict.map (\_ an -> { an | selected = False }) (answers q)) { showButton = True, showSolution = False }
+
+        Nothing ->
+            Question (Dict.fromList []) { showButton = False, showSolution = False }
+
+
+updateAnswer : Maybe Answer -> Maybe Answer
+updateAnswer maybeAnswer =
+    case maybeAnswer of
+        Just an ->
+            Just (Answer an.answer an.correct (not an.selected))
+
+        Nothing ->
+            Just (Answer "" False False)
+
+
+updateQuestionShowsButton : Model -> String -> String -> String -> Maybe Answer -> Question
+updateQuestionShowsButton model activityKey questionKey answerKey updatedAnswer =
+    let
+        clearedQuestion =
+            accessActivity model activityKey
+                |> accessQuestion questionKey
+                |> clearQuestion
+    in
+    Question (Dict.update answerKey (\_ -> updatedAnswer) (answers clearedQuestion)) { showButton = True, showSolution = False }
+
+
+updateQuestionShowsSolution : Maybe Question -> Question
+updateQuestionShowsSolution maybeQuestion =
+    case maybeQuestion of
+        Just q ->
+            Question (answers q) { showButton = True, showSolution = True }
+
+        Nothing ->
+            Question (Dict.fromList []) { showButton = False, showSolution = False }
+
+
+updateActivity : Model -> String -> String -> Question -> Activity
+updateActivity model activityKey questionKey updatedQuestion =
+    let
+        maybeActivity =
+            accessActivity model activityKey
+    in
+    case maybeActivity of
+        Just ac ->
+            Activity (Dict.update questionKey (Maybe.map (\_ -> updatedQuestion)) (questions ac))
+
+        Nothing ->
+            Activity (Dict.fromList [])
+
+
+updateActivities : Model -> String -> Activity -> Dict String Activity
+updateActivities model activityKey updatedActivity =
+    Dict.update activityKey (Maybe.map (\_ -> updatedActivity)) model.activities
+
+
+
+-- VIEW
+
+
+type alias Params =
+    ()
+
+
+view : Model -> Document Msg
+view model =
+    { title = "Guide | Priority"
+    , body =
+        [ div [ id "body" ]
+            [ div [ id "about" ]
+                [ div [ id "about-box" ]
+                    [ div [ id "title" ] [ text "Priority" ]
+                    , viewTabs
+                    , viewFirstSection
+                    , viewSecondSection
+                    , viewFirstQuestion model
+                    , viewThirdSection
+                    , viewFourthSection
+                    , viewSecondQuestion model
+                    , viewThirdQuestion model
+                    , viewFourthQuestion model
+                    , viewFifthQuestion model
+                    , viewSixthQuestion model
+                    , viewSeventhQuestion model
+                    , viewFifthSection
+                    , viewSixthSection
+                    , viewEigthQuestion model
+                    , viewSeventhSection
+                    ]
+                ]
+            ]
+        ]
+    }
+
+
+viewTabs : Html Msg
+viewTabs =
+    div [ class "guide-tabs" ]
+        [ div
+            [ class "guide-tab"
+            , class "leftmost-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__GettingStarted)
+                , class "guide-link"
+                ]
+                [ text "Getting Started" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__ReadingTexts)
+                , class "guide-link"
+                ]
+                [ text "Reading Texts" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Settings)
+                , class "guide-link"
+                ]
+                [ text "Settings" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Progress)
+                , class "guide-link"
+                ]
+                [ text "Progress" ]
+            ]
+        , div
+            [ class "guide-tab"
+            , class "selected-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Strategies)
+                , class "guide-link"
+                ]
+                [ text "Strategies" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Comprehension)
+                , class "guide-link"
+                ]
+                [ text "Comprehension" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Context)
+                , class "guide-link"
+                ]
+                [ text "Context" ]
+            ]
+        , div
+            [ class "guide-tab"
+            , class "selected-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Priority)
+                , class "guide-link"
+                ]
+                [ text "Priority" ]
+            ]
+        ]
+
+
+viewFirstSection : Html Msg
+viewFirstSection =
+    Markdown.toHtml [ attribute "class" "markdown-link" ] """
+### Prioritizing words
+
+It is usually not practical to try to look up every word that you don’t know in a text. It can take far too much time, and the process of looking 
+may distract you from trying to get any meaning out of what you do understand. So, you need to develop a sense of what words to prioritize for looking up. 
+
+
+1. **Notice the frequency of unfamiliar words**
+The first thing to prioritize are unknown words that appear multiple times in a text or passage. Understanding repeated words will help you stretch your understanding of the text.
+"""
+
+
+viewSecondSection : Html Msg
+viewSecondSection =
+    div [ class "sample-passage" ]
+        [ Html.em [] [ Html.text "A Boat on the River" ]
+        , Html.br [] []
+        , Html.br [] []
+        , Html.text """
+        The gapels in this boat were those of a foslaint man with nabelked amboned hair and a trathmollated face, and a finlact girl of nineteen or twenty, 
+        nabbastly like him to be sorbicable as his """
+        , Html.strong [] [ Html.text "fornoy" ]
+        , Html.text """. The girl zarred, pulling a pair of sculls very easily; the man, with the rudder-lines slack in 
+        his dispers, and his dispers loose in his waistband, kept an eager look out. He had no net, galeaft, or line, and he could not be a paplil; his boat 
+        had no """
+        , Html.strong [] [ Html.text "exbain" ]
+        , Html.text """ for a sitter, no paint, no debilk, no bepult beyond a rusty calben and a lanop of rope, and he could not be a waterman; his boat was too 
+        anem and too divey to take in besder for delivery, and he could not be a river-carrier; there was no paff to what he looked for, sar he looked for 
+        something, with a most nagril and searching profar. The befin, which had turned an hour before, was melucting zopt, and his eyes """
+        , Html.strong [] [ Html.text "hasteled" ]
+        , Html.text " every little furan and gaist in its broad sweep, as the boat made bilp ducasp against it, or drove stern foremost before it, according as he calbained his "
+        , Html.strong [] [ Html.text "fornoy" ]
+        , Html.text " by a "
+        , Html.strong [] [ Html.text "calput" ]
+        , Html.text " of his head. She "
+        , Html.strong [] [ Html.text "hasteled" ]
+        , Html.text " his face as parnly as he "
+        , Html.strong [] [ Html.text "hasteled" ]
+        , Html.text " the river. But, in the astortant of her look there was a touch of bazad or fisd."
+        ]
+
+
+viewFirstQuestion : Model -> Html Msg
+viewFirstQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity1" "Question1"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity1" "Question1"
+
+        solutionVisible =
+            checkButtonClicked model "Activity1" "Question1"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "Based on frequency alone, which of these four words should you definitely look up?" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity1_question1", id "a1q1first", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer1") ] []
+            , label [ for "a1q1first" ] [ getAnswerText model "Activity1" "Question1" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question1", id "a1q1second", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer2") ] []
+            , label [ for "a1q1second" ] [ getAnswerText model "Activity1" "Question1" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question1", id "a1q1third", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer3") ] []
+            , label [ for "a1q1third" ] [ getAnswerText model "Activity1" "Question1" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity1_question1", id "a1q1fourth", class "guide-question-button", onClick (UpdateAnswer "Activity1" "Question1" "Answer4") ] []
+            , label [ for "a1q1fourth" ] [ getAnswerText model "Activity1" "Question1" "Answer4" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity1" "Question1") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text "Hasteled -- should be a high priority since it occurs three times in the last five lines"
+                                , Html.br [] []
+                                , Html.text "Fornoy -- should also be a priority, since it occurs twice in two different places in the text"
+                                , Html.br [] []
+                                , Html.text """Exbain -- should be a low priority. It occurs only once, and in the context it’s clear that it has to mean something 
+                                like "bench, seat, or cushion." Unless the word is absolutely key to a comprehension question, having the sense that it is 
+                                something in the range of "bench, seat, cushion" is probably sufficient."""
+                                , Html.br [] []
+                                , Html.text """Calput -- should be a low priority. It occurs only once, and in the context it’s clear that it has to be something 
+                                like "position, tilt, twist, bend" of his head."""
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewThirdSection : Html Msg
+viewThirdSection =
+    Markdown.toHtml [] """
+### Prioritize words to look up strategically
+What next to prioritize will depend on what your motivation for reading is. 
+
+If you’re trying to follow the basic plot of a story, then look up nouns and verbs, so you know the answers to the 
+questions: where? when? who? what is happening? 
+
+If you’re trying to understand a character, then look up adjectives and phrases that are applied to that character. 
+
+If you are trying to follow motivations of characters, then looking up words in the clause that starts with the word “because….” might be most helpful. 
+
+If you are reading a text for class, the comprehension questions your teacher has assigned can help you prioritize what parts of the text you need to focus on.
+
+#### Unfamiliar words and their part of speech
+Part of prioritizing what words to look up is recognizing or having a strong sense as to the part of speech of the unfamiliar word. Using the grammar of the surrounding text, you can often 
+tell an unfamiliar word’s part of speech. The nonsense words in this text also all use regular English grammatical endings, so those can help you as well. Be sure to determine the part of 
+speech based on how the word is used in the sentence and not just on its grammatical ending.
+"""
+
+
+viewFourthSection : Html Msg
+viewFourthSection =
+    div [ class "sample-passage" ]
+        [ Html.em [] [ Html.text "A Boat on the River" ]
+        , Html.br [] []
+        , Html.br [] []
+        , Html.text "The gapels in this boat were those of a foslaint man with nabelked amboned hair and a "
+        , Html.strong [] [ Html.text "trathmollated" ]
+        , Html.text " face, and a finlact girl of nineteen or twenty, nabbastly like him to be sorbicable as his fornoy. The girl "
+        , Html.strong [] [ Html.text "zarred" ]
+        , Html.text """, pulling a pair of sculls very easily; the man, with the rudder-lines slack in his dispers, and his dispers loose in his waistband, 
+        kept an eager look out. He had no net, galeaft, or line, and he could not be a """
+        , Html.strong [] [ Html.text "paplil" ]
+        , Html.text """; his boat had no exbain for a sitter, no paint, no debilk, no bepult beyond a rusty calben and a lanop of rope, and he could not be a waterman; his boat was too 
+        anem and too divey to take in besder for delivery, and he could not be a river-carrier; there was no paff to what he looked for, """
+        , Html.strong [] [ Html.text "sar" ]
+        , Html.text " he looked for something, with a most "
+        , Html.strong [] [ Html.text "nagril" ]
+        , Html.text """ and searching profar. The befin, which had turned an hour before, was melucting zopt, and his eyes hasteled every little 
+        furan and gaist in its broad sweep, as the boat made bilp ducasp against it, or drove stern foremost before it, according as he calbained his fornoy by 
+        a calput of his head. She hasteled his face as """
+        , Html.strong [] [ Html.text "parnly" ]
+        , Html.text " as he hasteled the river. But, in the astortant of her look there was a touch of bazad or fisd."
+        ]
+
+
+viewSecondQuestion : Model -> Html Msg
+viewSecondQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity2" "Question1"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity2" "Question1"
+
+        solutionVisible =
+            checkButtonClicked model "Activity2" "Question1"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "trathmollated" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity2_question1", id "a2q1first", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question1" "Answer1") ] []
+            , label [ for "a2q1first" ] [ getAnswerText model "Activity2" "Question1" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question1", id "a2q1second", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question1" "Answer2") ] []
+            , label [ for "a2q1second" ] [ getAnswerText model "Activity2" "Question1" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question1", id "a2q1third", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question1" "Answer3") ] []
+            , label [ for "a2q1third" ] [ getAnswerText model "Activity2" "Question1" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question1", id "a2q1fourth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question1" "Answer4") ] []
+            , label [ for "a2q1fourth" ] [ getAnswerText model "Activity2" "Question1" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question1", id "a2q1fifth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question1" "Answer5") ] []
+            , label [ for "a2q1fifth" ] [ getAnswerText model "Activity2" "Question1" "Answer5" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity2" "Question1") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text "The correct answer is \"adjective\". It describes the noun \"face.\""
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewThirdQuestion : Model -> Html Msg
+viewThirdQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity2" "Question2"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity2" "Question2"
+
+        solutionVisible =
+            checkButtonClicked model "Activity2" "Question2"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "zarred" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity2_question2", id "a2q2first", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question2" "Answer1") ] []
+            , label [ for "a2q2first" ] [ getAnswerText model "Activity2" "Question2" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question2", id "a2q2second", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question2" "Answer2") ] []
+            , label [ for "a2q2second" ] [ getAnswerText model "Activity2" "Question2" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question2", id "a2q2third", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question2" "Answer3") ] []
+            , label [ for "a2q2third" ] [ getAnswerText model "Activity2" "Question2" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question2", id "a2q2fourth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question2" "Answer4") ] []
+            , label [ for "a2q2fourth" ] [ getAnswerText model "Activity2" "Question2" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question2", id "a2q2fifth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question2" "Answer5") ] []
+            , label [ for "a2q2fifth" ] [ getAnswerText model "Activity2" "Question2" "Answer5" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity2" "Question2") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text "The correct answer is \"verb.\" It follows the subject \"the girl\" and makes a complete thought, so it is most likely a verb. It also has the past tense ending (-ed) on it."
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewFourthQuestion : Model -> Html Msg
+viewFourthQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity2" "Question3"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity2" "Question3"
+
+        solutionVisible =
+            checkButtonClicked model "Activity2" "Question3"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "paplil" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity2_question3", id "a2q3first", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question3" "Answer1") ] []
+            , label [ for "a2q3first" ] [ getAnswerText model "Activity2" "Question3" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question3", id "a2q3second", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question3" "Answer2") ] []
+            , label [ for "a2q3second" ] [ getAnswerText model "Activity2" "Question3" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question3", id "a2q3third", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question3" "Answer3") ] []
+            , label [ for "a2q3third" ] [ getAnswerText model "Activity2" "Question3" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question3", id "a2q3fourth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question3" "Answer4") ] []
+            , label [ for "a2q3fourth" ] [ getAnswerText model "Activity2" "Question3" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question3", id "a2q3fifth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question3" "Answer5") ] []
+            , label [ for "a2q3fifth" ] [ getAnswerText model "Activity2" "Question3" "Answer5" ]
+            ]
+        , div [ class "guide-button" ]
+            [ if answerButtonVisible then
+                div []
+                    [ button [ onClick (RevealSolution "Activity2" "Question3") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text "The correct answer is \"noun.\" The word is preceded by the indefinite article \"a\" which strongly suggests a noun."
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewFifthQuestion : Model -> Html Msg
+viewFifthQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity2" "Question4"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity2" "Question4"
+
+        solutionVisible =
+            checkButtonClicked model "Activity2" "Question4"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "nagril" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity2_question4", id "a2q4first", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question4" "Answer1") ] []
+            , label [ for "a2q4first" ] [ getAnswerText model "Activity2" "Question4" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question4", id "a2q4second", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question4" "Answer2") ] []
+            , label [ for "a2q4second" ] [ getAnswerText model "Activity2" "Question4" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question4", id "a2q4third", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question4" "Answer3") ] []
+            , label [ for "a2q4third" ] [ getAnswerText model "Activity2" "Question4" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question4", id "a2q4fourth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question4" "Answer4") ] []
+            , label [ for "a2q4fourth" ] [ getAnswerText model "Activity2" "Question4" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question5", id "a2q4fifth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question4" "Answer5") ] []
+            , label [ for "a2q4fifth" ] [ getAnswerText model "Activity2" "Question4" "Answer5" ]
+            ]
+        , div [ class "guide-button" ]
+            [ if answerButtonVisible then
+                div []
+                    [ button [ onClick (RevealSolution "Activity2" "Question4") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text "The correct answer is \"adjective.\" It is used in an adjective phrase following \"a most...\" and it is also in parallel construction to \"searching\" and so it is being used as some kind of modifier to the noun profar."
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewSixthQuestion : Model -> Html Msg
+viewSixthQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity2" "Question5"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity2" "Question5"
+
+        solutionVisible =
+            checkButtonClicked model "Activity2" "Question5"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "sar" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity2_question5", id "a2q5first", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question5" "Answer1") ] []
+            , label [ for "a2q5first" ] [ getAnswerText model "Activity2" "Question5" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question5", id "a2q5second", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question5" "Answer2") ] []
+            , label [ for "a2q5second" ] [ getAnswerText model "Activity2" "Question5" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question5", id "a2q5third", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question5" "Answer3") ] []
+            , label [ for "a2q5third" ] [ getAnswerText model "Activity2" "Question5" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question5", id "a2q5fourth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question5" "Answer4") ] []
+            , label [ for "a2q5fourth" ] [ getAnswerText model "Activity2" "Question5" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question6", id "a2q5fifth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question5" "Answer5") ] []
+            , label [ for "a2q5fifth" ] [ getAnswerText model "Activity2" "Question5" "Answer5" ]
+            ]
+        , div [ class "guide-button" ]
+            [ if answerButtonVisible then
+                div []
+                    [ button [ onClick (RevealSolution "Activity2" "Question5") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The best answer here is "conjunction" since it connects two clauses "there was no..." and "he looked for something," it must be a conjunction, possibly "though" or "but." """
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewSeventhQuestion : Model -> Html Msg
+viewSeventhQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity2" "Question6"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity2" "Question6"
+
+        solutionVisible =
+            checkButtonClicked model "Activity2" "Question6"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "parnly" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity2_question6", id "a2q6first", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question6" "Answer1") ] []
+            , label [ for "a2q6first" ] [ getAnswerText model "Activity2" "Question6" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question6", id "a2q6second", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question6" "Answer2") ] []
+            , label [ for "a2q6second" ] [ getAnswerText model "Activity2" "Question6" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question6", id "a2q6third", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question6" "Answer3") ] []
+            , label [ for "a2q6third" ] [ getAnswerText model "Activity2" "Question6" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question6", id "a2q6fourth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question6" "Answer4") ] []
+            , label [ for "a2q6fourth" ] [ getAnswerText model "Activity2" "Question6" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity2_question6", id "a2q6fifth", class "guide-question-button", onClick (UpdateAnswer "Activity2" "Question6" "Answer5") ] []
+            , label [ for "a2q6fifth" ] [ getAnswerText model "Activity2" "Question6" "Answer5" ]
+            ]
+        , div []
+            [ if answerButtonVisible then
+                div [ class "guide-button" ]
+                    [ button [ onClick (RevealSolution "Activity2" "Question6") ] [ Html.text "Check answer" ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """The best answer here is "adverb." It must be an adjective or adverb to be used in the phrase "as X as," and the "-ly" suffix suggests an adverb."""
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewFifthSection : Html Msg
+viewFifthSection =
+    Markdown.toHtml [] """
+### Unfamiliar words and their importance to your tasks
+
+If you are reading a text for class, the comprehension questions your teacher has assigned can help you prioritize what parts of the text you need to focus on. For example, your teacher 
+included a question that asked about the emotional relationship between the man and the girl in the boat. You will need to locate the part of the text that contains that information, and to 
+prioritize those descriptive words that will help you understand that relationship.
+"""
+
+
+viewSixthSection : Html Msg
+viewSixthSection =
+    div [ class "sample-passage" ]
+        [ Html.em [] [ Html.text "A Boat on the River" ]
+        , Html.br [] []
+        , Html.br [] []
+        , Html.text "The gapels in this boat were those of a "
+        , Html.strong [] [ Html.text "foslaint" ]
+        , Html.text " man with nabelked amboned hair and a trathmollated face, and a finlact girl of nineteen or twenty, nabbastly like him to be sorbicable as his "
+        , Html.strong [] [ Html.text "fornoy" ]
+        , Html.text """. The girl zarred, pulling a pair of sculls very easily; the man, with the rudder-lines slack in 
+        his dispers, and his dispers loose in his waistband, kept an eager look out. He had no net, galeaft, or line, and he could not be a paplil; his boat 
+        had no exbain for a sitter, no paint, no debilk, no bepult beyond a rusty calben and a lanop of rope, and he could not be a waterman; his boat was too 
+        anem and too """
+        , Html.strong [] [ Html.text "divey" ]
+        , Html.text """ to take in besder for delivery, and he could not be a river-carrier; there was no paff to what he looked for, sar he looked for 
+        something, with a most nagril and searching profar. The befin, which had turned an hour before, was melucting zopt, and his eyes hasteled every little 
+        furan and gaist in its broad sweep, as the boat made bilp ducasp against it, or drove stern foremost before it, according as he """
+        , Html.strong [] [ Html.text "calbained" ]
+        , Html.text " his "
+        , Html.strong [] [ Html.text "fornoy" ]
+        , Html.text " by a calput of his head. She hasteled his face as parnly as he hasteled the river. But, in the astortant of her look there was a touch of "
+        , Html.strong [] [ Html.text "bazad" ]
+        , Html.text " or "
+        , Html.strong [] [ Html.text "fisd" ]
+        , Html.text "."
+        ]
+
+
+viewEigthQuestion : Model -> Html Msg
+viewEigthQuestion model =
+    let
+        answerButtonVisible =
+            checkAnswerSelected model "Activity3" "Question1"
+
+        answerCorrect =
+            checkAnswerCorrect model "Activity3" "Question1"
+
+        solutionVisible =
+            checkButtonClicked model "Activity3" "Question1"
+    in
+    div [ class "guide-question" ]
+        [ Html.div [] [ text "Go back to the text, and locate the place there the author seems to describe the emotions of the characters. Which of these words would be the most important to look up?" ]
+        , Html.form []
+            [ input [ type_ "radio", name "activity3_question1", id "a3q1first", class "guide-question-button", onClick (UpdateAnswer "Activity3" "Question1" "Answer1") ] []
+            , label [ for "a3q1first" ] [ getAnswerText model "Activity3" "Question1" "Answer1" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity3_question1", id "a3q1second", class "guide-question-button", onClick (UpdateAnswer "Activity3" "Question1" "Answer2") ] []
+            , label [ for "a3q1second" ] [ getAnswerText model "Activity3" "Question1" "Answer2" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity3_question1", id "a3q1third", class "guide-question-button", onClick (UpdateAnswer "Activity3" "Question1" "Answer3") ] []
+            , label [ for "a3q1third" ] [ getAnswerText model "Activity3" "Question1" "Answer3" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity3_question1", id "a3q1fourth", class "guide-question-button", onClick (UpdateAnswer "Activity3" "Question1" "Answer4") ] []
+            , label [ for "a3q1fourth" ] [ getAnswerText model "Activity3" "Question1" "Answer4" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity3_question1", id "a3q1fifth", class "guide-question-button", onClick (UpdateAnswer "Activity3" "Question1" "Answer5") ] []
+            , label [ for "a3q1fifth" ] [ getAnswerText model "Activity3" "Question1" "Answer5" ]
+            , Html.br [] []
+            , input [ type_ "radio", name "activity3_question1", id "a3q1sixth", class "guide-question-button", onClick (UpdateAnswer "Activity3" "Question1" "Answer6") ] []
+            , label [ for "a3q1sixth" ] [ getAnswerText model "Activity3" "Question1" "Answer6" ]
+            ]
+        , div [ class "guide-button" ]
+            [ if answerButtonVisible then
+                div []
+                    [ div [ class "guide-button" ] [ button [ onClick (RevealSolution "Activity3" "Question1") ] [ Html.text "Check answer" ] ]
+                    , div []
+                        [ if solutionVisible then
+                            (if answerCorrect then
+                                div [ class "correct-answer-guide" ]
+
+                             else
+                                div [ class "incorrect-answer-guide" ]
+                            )
+                                [ Html.text """Choices "bazad" and "fisd" would be high priority in determining the emotional charge of this scene, since they both describe the girl's look at the man.
+                                Choices "fornoy" and "calbained" are medium priority. Knowing the meaning of "fornoy" might help to clarify the bond/relationship between the man and the girl.
+                                Since "calbained" is an action that the man does with his head, it might reveal how the man communicates with the girl.
+                                The choice "foslaint" would be lower priority, since it relates primarily to the man in the boat, and "foslaint" is likely to be a word of physical description for the man.
+                                The choice "divey" would be lowest priority, since it describes the boat, and is unlikely to give a direct indication of the emotional relationship between the man and the girl."""
+                                ]
+
+                          else
+                            div [] []
+                        ]
+                    ]
+
+              else
+                div [] []
+            ]
+        ]
+
+
+viewSeventhSection : Html Msg
+viewSeventhSection =
+    Markdown.toHtml [] """
+#### When looking up words
+Once you’ve prioritized a word for look up, be sure you make a guess about its English equivalent before you actually look it up. If your guess is right (or a very close synonym to the right answer), 
+then you are probably understanding the passage well.  If your guess is very far from the right answer, be sure to re-read the passage to understand how that changes your sense of what the passage is 
+about. If your guess is very far from the answer you find, check to make certain that the word doesn't have other meanings that might fight the context. There aren't an enormous number of homonyms in 
+Russian, but many Russian words can be used in different senses or contexts. Be sure that you've got the right sense for your context.
+
+#### Homonyms
+Homonyms to look out for:
+
+есть -- can be an infinitive "to eat," and it can be the third person of the verb быть meaning "there is/there are." 
+
+стали -- can be the past tense of стать = to become, begin OR the genitive/dative/prepositional of the noun сталь = steel
+
+Words that are similar, but have different stress
+
+за́мок - (noun) castle
+
+замо́к - (noun) lock
+
+мука́ - (noun) flour
+
+му́ка - (noun) torment
+"""
+
+
+
+-- VIEW UTILITY
+
+
+getAnswerText : Model -> String -> String -> String -> Html Msg
+getAnswerText model activityKey questionKey answerKey =
+    let
+        maybeQuestion =
+            case Dict.get activityKey model.activities of
+                Just qs ->
+                    Dict.get questionKey (questions qs)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        maybeAnswer =
+            case maybeQuestion of
+                Just q ->
+                    Dict.get answerKey (answers q)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        answerText =
+            case maybeAnswer of
+                Just a ->
+                    a.answer
+
+                Nothing ->
+                    ""
+    in
+    Html.text answerText
+
+
+checkAnswerCorrect : Model -> String -> String -> Bool
+checkAnswerCorrect model activityLabel questionLabel =
+    let
+        maybeActivity =
+            Dict.get activityLabel model.activities
+
+        maybeQuestion =
+            case maybeActivity of
+                Just ac ->
+                    Dict.get questionLabel (questions ac)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        answerList =
+            case maybeQuestion of
+                Just q ->
+                    List.map Tuple.second (Dict.toList (answers q))
+
+                Nothing ->
+                    []
+
+        answeredCorrectly =
+            List.any (\v -> v == True) (List.map (\a -> (a.correct == True) && a.selected) answerList)
+    in
+    answeredCorrectly
+
+
+checkAnswerSelected : Model -> String -> String -> Bool
+checkAnswerSelected model activityLabel questionLabel =
+    let
+        maybeActivity =
+            Dict.get activityLabel model.activities
+
+        maybeQuestion =
+            case maybeActivity of
+                Just ac ->
+                    Dict.get questionLabel (questions ac)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+
+        answerList =
+            case maybeQuestion of
+                Just q ->
+                    List.map Tuple.second (Dict.toList (answers q))
+
+                Nothing ->
+                    []
+
+        answerSelected =
+            List.any (\a -> a.selected == True) answerList
+    in
+    answerSelected
+
+
+checkButtonClicked : Model -> String -> String -> Bool
+checkButtonClicked model activityLabel questionLabel =
+    let
+        maybeActivities =
+            Dict.get activityLabel model.activities
+
+        maybeQuestion =
+            case maybeActivities of
+                Just activities ->
+                    Dict.get questionLabel (questions activities)
+
+                Nothing ->
+                    Maybe.map identity Nothing
+    in
+    case maybeQuestion of
+        Just question ->
+            showSolution question
+
+        Nothing ->
+            False
+
+
+
+-- SHARED
+
+
+save : Model -> Shared.Model -> Shared.Model
+save model shared =
+    shared
+
+
+load : Shared.Model -> Model -> ( Model, Cmd Msg )
+load shared model =
+    ( model, Cmd.none )
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none

--- a/web/src/Pages/Guide/Progress.elm
+++ b/web/src/Pages/Guide/Progress.elm
@@ -92,6 +92,13 @@ viewTabs =
                 ]
                 [ text "Progress" ]
             ]
+        , div [ class "guide-tab" ]
+            [ a
+                [ href (Route.toString Route.Guide__Strategies)
+                , class "guide-link"
+                ]
+                [ text "Strategies" ]
+            ]
         ]
 
 

--- a/web/src/Pages/Guide/ReadingTexts.elm
+++ b/web/src/Pages/Guide/ReadingTexts.elm
@@ -98,6 +98,13 @@ viewTabs =
                 ]
                 [ text "Progress" ]
             ]
+        , div [ class "guide-tab" ]
+            [ a
+                [ href (Route.toString Route.Guide__Strategies)
+                , class "guide-link"
+                ]
+                [ text "Strategies" ]
+            ]
         ]
 
 

--- a/web/src/Pages/Guide/Settings.elm
+++ b/web/src/Pages/Guide/Settings.elm
@@ -90,6 +90,13 @@ viewTabs =
                 ]
                 [ text "Progress" ]
             ]
+        , div [ class "guide-tab" ]
+            [ a
+                [ href (Route.toString Route.Guide__Strategies)
+                , class "guide-link"
+                ]
+                [ text "Strategies" ]
+            ]
         ]
 
 

--- a/web/src/Pages/Guide/Strategies.elm
+++ b/web/src/Pages/Guide/Strategies.elm
@@ -1,0 +1,204 @@
+module Pages.Guide.Strategies exposing (..)
+
+import Dict exposing (Dict)
+import Html exposing (..)
+import Html.Attributes exposing (alt, attribute, class, href, id, src, style, title)
+import Markdown
+import Spa.Document exposing (Document)
+import Spa.Generated.Route as Route
+import Spa.Page as Page exposing (Page)
+import Spa.Url as Url exposing (Url)
+
+
+page : Page Params Model Msg
+page =
+    Page.static
+        { view = view
+        }
+
+
+type alias Model =
+    Url Params
+
+
+type alias Msg =
+    Never
+
+
+
+-- VIEW
+
+
+type alias Params =
+    ()
+
+
+view : Url Params -> Document Msg
+view { params } =
+    { title = "Guide | Strategies"
+    , body =
+        [ div [ id "body" ]
+            [ div [ id "about" ]
+                [ div [ id "about-box" ]
+                    [ div [ id "title" ] [ text "Strategies" ]
+                    , viewTabs
+                    , viewFirstSection
+                    , viewSecondSection
+                    , viewThirdSection
+                    , viewFourthSection
+                    ]
+                ]
+            ]
+        ]
+    }
+
+
+viewTabs : Html Msg
+viewTabs =
+    div [ class "guide-tabs" ]
+        [ div
+            [ class "guide-tab"
+            , class "leftmost-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__GettingStarted)
+                , class "guide-link"
+                ]
+                [ text "Getting Started" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__ReadingTexts)
+                , class "guide-link"
+                ]
+                [ text "Reading Texts" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Settings)
+                , class "guide-link"
+                ]
+                [ text "Settings" ]
+            ]
+        , div
+            [ class "guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Progress)
+                , class "guide-link"
+                ]
+                [ text "Progress" ]
+            ]
+        , div [ class "guide-tab" 
+            , class "selected-guide-tab"
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Strategies)
+                , class "guide-link"
+                ]
+                [ text "Strategies" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Comprehension)
+                , class "guide-link"
+                ]
+                [ text "Comprehension" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Context)
+                , class "guide-link"
+                ]
+                [ text "Context" ]
+            ]
+        , div [ class "guide-tab" 
+            ]
+            [ a
+                [ href (Route.toString Route.Guide__Priority)
+                , class "guide-link"
+                ]
+                [ text "Priority" ]
+            ]
+        ]
+
+
+viewFirstSection : Html Msg
+viewFirstSection =
+    Markdown.toHtml [ attribute "class" "markdown-link" ] """
+### How to approach a text
+
+#### Preview and get ready to read.
+If you know the general topic of the text (from the teacher, or the title, or an illustration), take a minute to formulate some ideas that you think are likely to be referenced in a text on that topic.
+
+Then approach the text to see if any of your initial assumptions are referenced in it. It’s also useful when you realize that your initial assumptions are NOT mentioned in the text. Keep an open mind 
+as you read the text for the first time.
+
+Take stock of your first reading and how it lined up with your assumptions. 
+"""
+
+
+viewSecondSection : Html Msg
+viewSecondSection =
+    Markdown.toHtml [] """
+#### Reading for deeper comprehension.
+
+Now read the text (sentence, paragraph) again. This time around, try to get as much as possible out of the text without drawing on your assumptions.
+
+When you’ve gotten to the end of this reading, try to summarize for yourself the main points by seeing how many questions like these you can answer: What happened? Who did it? When? Where? Why? How?
+
+Don’t worry if you can’t answer all those questions on the first deep reading. Go back and read again. Confirm your answers to the main points that you did get. Add details to those points or find the connections between them.
+If you’ve been having trouble reading to the end of the text (or paragraph or sentence), keep on reading even if you may lose the thread of what’s happening for a while.
+
+Now summarize the fuller picture you’ve gotten of the text (or sentence or paragraph).
+"""
+
+
+viewThirdSection : Html Msg
+viewThirdSection =
+    Markdown.toHtml [] """
+#### Confirming details and prioritizing words to look up.
+
+
+After reading through a text twice or three times, you probably have a good idea of what words you need to check to make sure your hypotheses about the text are correct.
+
+Prioritize the words that you look up by picking key nouns or verbs first. They will give you more of the bones or the skeleton of the sentence. If you’ve got a good idea about all the “bones” or specific 
+facts, then you might check whether you really understand the relationship between the facts by looking up the connectors that hold them together. If you’re sure of the facts, but you can’t make out the 
+writer's attitude to the facts, look up some of the adjectives and adverbs since they will often reveal the author’s evaluation of the facts.
+
+Before you click to see a translation, take a guess about what the word means.Once you’ve looked up a word, fit the word into the whole sentence where it appears. Does confirming that word help you figure 
+out the rest of the sentence? If so, move on to the next sentence, and see if you can go further.
+"""
+
+
+viewFourthSection : Html Msg
+viewFourthSection =
+    Markdown.toHtml [] """
+#### Read and re-read. 
+
+As you get more words, re-read the passage and develop a firmer understanding of each sentence and how they add meaning to the whole paragraph. 
+Re-reading parts of the text that you've already figured out will help you learn the vocabulary in the text, and will help you begin to see patterns about which words often are used together 
+(i.e.,  школьные учебники =school textbooks, иметь право = to have the right to) and how words fit together (i.e., that verb takes an object in the dative case, that preposition goes with the genitive case). 
+"""
+
+
+viewAltText : String -> Dict String String -> String
+viewAltText id texts =
+    case Dict.get id texts of
+        Just text ->
+            text
+
+        Nothing ->
+            ""
+
+
+altTexts : Dict String String
+altTexts =
+    Dict.fromList
+        [ ]


### PR DESCRIPTION
Due to a diverging branch, there was a need to fork off master and copy all of the files into a single commit. The branch is named as such because the static page Recognition.elm needed to be deleted. Not to worry, they're mostly new files and some small additions to CSS. Devel seems to have gone out of sync at release 2.2.0

This commit brings in new student guide pages and makes some minor
styling adjustments. There are three subpages under the Strategies tab, each multiple choice questions. The contents of the pages have been combed through, but the functionality should still be confirmed. This could be tested is by sampling the multiple choice questions and trying each of the tabs at the top of the guide. The dev server is currently hosting the branch feature/guide-rewrite-no-recog so mobile testing could be done there aside from using devtools.

